### PR TITLE
Develop to main MyCase view + Fees Closed workflow + worksheet dropdowns

### DIFF
--- a/drizzle/0010_fees_closed_and_approved_by_options.sql
+++ b/drizzle/0010_fees_closed_and_approved_by_options.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "approved_by_options" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" varchar(100) NOT NULL,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"sort_order" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "approved_by_options_name_unique" UNIQUE("name")
+);
+--> statement-breakpoint
+ALTER TABLE "fee_records" ADD COLUMN "is_closed" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "fee_records" ADD COLUMN "closed_at" timestamp with time zone;--> statement-breakpoint
+CREATE INDEX "idx_fee_records_is_closed" ON "fee_records" USING btree ("is_closed");

--- a/drizzle/0011_dropdown_options_and_seed.sql
+++ b/drizzle/0011_dropdown_options_and_seed.sql
@@ -1,0 +1,27 @@
+CREATE TABLE "dropdown_options" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"category" varchar(50) NOT NULL,
+	"name" varchar(150) NOT NULL,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"sort_order" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_dropdown_options_category_name" ON "dropdown_options" USING btree ("category","name");--> statement-breakpoint
+CREATE INDEX "idx_dropdown_options_category" ON "dropdown_options" USING btree ("category");--> statement-breakpoint
+-- Carry over anything already added to the standalone approved_by_options table.
+INSERT INTO "dropdown_options" ("category","name","is_active","sort_order","created_at","updated_at")
+SELECT 'approved_by', "name", "is_active", "sort_order", "created_at", "updated_at"
+FROM "approved_by_options"
+ON CONFLICT ("category","name") DO NOTHING;--> statement-breakpoint
+-- Seed initial options extracted from the master worksheet's dropdowns.
+INSERT INTO "dropdown_options" ("category","name","sort_order") VALUES
+('assigned_to','Aaron',1),('assigned_to','Alex',2),('assigned_to','Amanda',3),('assigned_to','Annie',4),('assigned_to','April',5),('assigned_to','Arvin',6),('assigned_to','Aura',7),('assigned_to','Aurora',8),('assigned_to','Benedict',9),('assigned_to','Bree',10),('assigned_to','Charlie',11),('assigned_to','Clariz',12),('assigned_to','Cora',13),('assigned_to','DeAnne',14),('assigned_to','Ferdie',15),('assigned_to','Georgia',16),('assigned_to','Hunter',17),('assigned_to','Ivan',18),('assigned_to','Jace',19),('assigned_to','Jane',20),('assigned_to','Jean',21),('assigned_to','Josh',22),('assigned_to','Krissa',23),('assigned_to','Lila',24),('assigned_to','Lori',25),('assigned_to','Lovely',26),('assigned_to','Malcolm',27),('assigned_to','Marcus',28),('assigned_to','Miles',29),('assigned_to','Molly',30),('assigned_to','Nelia',31),('assigned_to','Nerry',32),('assigned_to','Royce',33),('assigned_to','Shane',34),('assigned_to','Shelby',35),('assigned_to','Steph',36),('assigned_to','Tyler',37),
+('case_level','INITIAL',1),('case_level','RECON',2),('case_level','HEARING',3),('case_level','AC',4),('case_level','FEE PETITION',5),
+('claim_type','T2',1),('claim_type','T16',2),('claim_type','CONC',3),('claim_type','DWB',4),('claim_type','DAC',5),('claim_type','AUX',6),
+('win_sheet_status','Started',1),('win_sheet_status','Finished',2),
+('fees_confirmation','Paid In Full',1),('fees_confirmation','Partial Payment',2),('fees_confirmation','Pending (full/partial)',3),('fees_confirmation','No Fees Due',4),('fees_confirmation','Overpaid',5),
+('case_status','Ready for Review',1),('case_status','For follow-up',2),('case_status','FEE O/PMPT XVI',3),('case_status','O/PMPT II & XVI',4),('case_status','O/PAID USER $120',5),('case_status','NEED AUX FEE',6),('case_status','FIX YOUR WIN SHEET',7),('case_status','FEE',8),('case_status','FEE PD BUT O/PD',9),
+('approved_by','DeAnne',1),('approved_by','Reviewing',2),('approved_by','Lori',3),('approved_by','Georgia',4)
+ON CONFLICT ("category","name") DO NOTHING;

--- a/drizzle/0012_loosen_enum_columns_to_varchar.sql
+++ b/drizzle/0012_loosen_enum_columns_to_varchar.sql
@@ -1,0 +1,8 @@
+-- Postgres requires an explicit USING expression to cast existing enum
+-- values to text. Drop the default first, then re-set it after the
+-- type change.
+ALTER TABLE "fee_records" ALTER COLUMN "win_sheet_status" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "fee_records" ALTER COLUMN "win_sheet_status" SET DATA TYPE varchar(50) USING "win_sheet_status"::text;--> statement-breakpoint
+ALTER TABLE "fee_records" ALTER COLUMN "win_sheet_status" SET DEFAULT 'not_started';--> statement-breakpoint
+ALTER TABLE "cases" ALTER COLUMN "claim_type_label" SET DATA TYPE varchar(50) USING "claim_type_label"::text;--> statement-breakpoint
+ALTER TABLE "cases" ALTER COLUMN "level_won" SET DATA TYPE varchar(50) USING "level_won"::text;

--- a/drizzle/meta/0010_snapshot.json
+++ b/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,2533 @@
+{
+  "id": "0e87df12-8e97-4b1a-9877-c93d5a24ca73",
+  "prevId": "75d32514-bd89-4af9-81a1-866af3f9809d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_log": {
+      "name": "activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_record_id": {
+          "name": "fee_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_activity_log_case_id": {
+          "name": "idx_activity_log_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_log_created_at": {
+          "name": "idx_activity_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_log_case_id_cases_client_id_fk": {
+          "name": "activity_log_case_id_cases_client_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_log_fee_record_id_fee_records_id_fk": {
+          "name": "activity_log_fee_record_id_fee_records_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "fee_records",
+          "columnsFrom": [
+            "fee_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_settings": {
+      "name": "app_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approved_by_options": {
+      "name": "approved_by_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "approved_by_options_name_unique": {
+          "name": "approved_by_options_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cases": {
+      "name": "cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dob": {
+          "name": "dob",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last4_ssn": {
+          "name": "last4_ssn",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_type": {
+          "name": "claim_type",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "claim_type_label": {
+          "name": "claim_type_label",
+          "type": "claim_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level_won": {
+          "name": "level_won",
+          "type": "level_won_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "t2_decision": {
+          "name": "t2_decision",
+          "type": "decision_outcome_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'unknown'"
+        },
+        "t16_decision": {
+          "name": "t16_decision",
+          "type": "decision_outcome_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'unknown'"
+        },
+        "application_date": {
+          "name": "application_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alleged_onset_date": {
+          "name": "alleged_onset_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_date": {
+          "name": "approval_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_date": {
+          "name": "closure_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_held_date": {
+          "name": "hearing_held_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_scheduled_date": {
+          "name": "hearing_scheduled_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_scheduled_datetime": {
+          "name": "hearing_scheduled_datetime",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_timezone": {
+          "name": "hearing_timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "office_with_jurisdiction": {
+          "name": "office_with_jurisdiction",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alj_first_name": {
+          "name": "alj_first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alj_last_name": {
+          "name": "alj_last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimant_location": {
+          "name": "claimant_location",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representative_location": {
+          "name": "representative_location",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_expert": {
+          "name": "medical_expert",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vocational_expert": {
+          "name": "vocational_expert",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_file_link": {
+          "name": "all_file_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exhibits_file_link": {
+          "name": "exhibits_file_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_file_updated_at": {
+          "name": "all_file_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exhibits_file_updated_at": {
+          "name": "exhibits_file_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_ssn": {
+          "name": "full_ssn",
+          "type": "varchar(11)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_diagnosis": {
+          "name": "primary_diagnosis",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_diagnosis_code": {
+          "name": "primary_diagnosis_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secondary_diagnosis": {
+          "name": "secondary_diagnosis",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secondary_diagnosis_code": {
+          "name": "secondary_diagnosis_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allegations": {
+          "name": "allegations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blind_dli": {
+          "name": "blind_dli",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firm_name": {
+          "name": "firm_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firm_ein": {
+          "name": "firm_ein",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_office": {
+          "name": "hearing_office",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representatives": {
+          "name": "representatives",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_history": {
+          "name": "decision_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_type": {
+          "name": "report_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expedited_case": {
+          "name": "expedited_case",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_of_case": {
+          "name": "status_of_case",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_date": {
+          "name": "status_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_date": {
+          "name": "request_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_date": {
+          "name": "receipt_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_date_assigned": {
+          "name": "first_date_assigned",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_fqr_starts": {
+          "name": "date_fqr_starts",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_insured": {
+          "name": "last_insured",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_created_at": {
+          "name": "source_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_updated_at": {
+          "name": "source_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ere_session_date": {
+          "name": "last_ere_session_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status_report_date": {
+          "name": "last_status_report_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documents_last_added_at": {
+          "name": "documents_last_added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invalid_ssn": {
+          "name": "invalid_ssn",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ssn_encrypted": {
+          "name": "ssn_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_link": {
+          "name": "case_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_pulled_at": {
+          "name": "last_pulled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_cases_client_id": {
+          "name": "idx_cases_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_external_id": {
+          "name": "idx_cases_external_id",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_claim_type_label": {
+          "name": "idx_cases_claim_type_label",
+          "columns": [
+            {
+              "expression": "claim_type_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_approval_date": {
+          "name": "idx_cases_approval_date",
+          "columns": [
+            {
+              "expression": "approval_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_last_name": {
+          "name": "idx_cases_last_name",
+          "columns": [
+            {
+              "expression": "last_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cases_client_id_unique": {
+          "name": "cases_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chronicle_documents": {
+      "name": "chronicle_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mycase_client_id": {
+          "name": "mycase_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chronicle_client_id": {
+          "name": "chronicle_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chronicle_document_id": {
+          "name": "chronicle_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_name": {
+          "name": "document_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_category": {
+          "name": "document_category",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_document": {
+          "name": "raw_document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chronicle_documents_case_id": {
+          "name": "idx_chronicle_documents_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chronicle_documents_case_id_cases_client_id_fk": {
+          "name": "chronicle_documents_case_id_cases_client_id_fk",
+          "tableFrom": "chronicle_documents",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chronicle_documents_case_id_chronicle_document_id_unique": {
+          "name": "chronicle_documents_case_id_chronicle_document_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id",
+            "chronicle_document_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_metrics": {
+      "name": "daily_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_date": {
+          "name": "metric_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ssa_calls": {
+          "name": "ssa_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "client_calls_ib": {
+          "name": "client_calls_ib",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "client_calls_ob": {
+          "name": "client_calls_ob",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_metrics_agent": {
+          "name": "idx_daily_metrics_agent",
+          "columns": [
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_metrics_date": {
+          "name": "idx_daily_metrics_date",
+          "columns": [
+            {
+              "expression": "metric_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_metrics_agent_name_team_members_name_fk": {
+          "name": "daily_metrics_agent_name_team_members_name_fk",
+          "tableFrom": "daily_metrics",
+          "tableTo": "team_members",
+          "columnsFrom": [
+            "agent_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_cap_history": {
+      "name": "fee_cap_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cap_amount": {
+          "name": "cap_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fee_cap_history_effective_date_unique": {
+          "name": "fee_cap_history_effective_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "effective_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_petitions": {
+      "name": "fee_petitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "noa": {
+          "name": "noa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "time_delineation": {
+          "name": "time_delineation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "fee_petition_doc": {
+          "name": "fee_petition_doc",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ltr_to_clmt": {
+          "name": "ltr_to_clmt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ltr_to_clmt_with_signature": {
+          "name": "ltr_to_clmt_with_signature",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ltr_to_alj": {
+          "name": "ltr_to_alj",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "fax_conf_fee_pet": {
+          "name": "fax_conf_fee_pet",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "update_note": {
+          "name": "update_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fee_petitions_case_id": {
+          "name": "idx_fee_petitions_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fee_petitions_case_id_cases_client_id_fk": {
+          "name": "fee_petitions_case_id_cases_client_id_fk",
+          "tableFrom": "fee_petitions",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fee_petitions_case_id_unique": {
+          "name": "fee_petitions_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_records": {
+      "name": "fee_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "win_sheet_status": {
+          "name": "win_sheet_status",
+          "type": "win_sheet_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'not_started'"
+        },
+        "win_sheet_link": {
+          "name": "win_sheet_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_status": {
+          "name": "case_status",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fees_confirmation": {
+          "name": "fees_confirmation",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_assigned_to_agent": {
+          "name": "date_assigned_to_agent",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "t16_retro": {
+          "name": "t16_retro",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_fee_due": {
+          "name": "t16_fee_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_fee_received": {
+          "name": "t16_fee_received",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_pending": {
+          "name": "t16_pending",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_fee_received_date": {
+          "name": "t16_fee_received_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "t2_retro": {
+          "name": "t2_retro",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_fee_due": {
+          "name": "t2_fee_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_fee_received": {
+          "name": "t2_fee_received",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_pending": {
+          "name": "t2_pending",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_fee_received_date": {
+          "name": "t2_fee_received_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aux_retro": {
+          "name": "aux_retro",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_fee_due": {
+          "name": "aux_fee_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_fee_received": {
+          "name": "aux_fee_received",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_pending": {
+          "name": "aux_pending",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_fee_received_date": {
+          "name": "aux_fee_received_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_retro_due": {
+          "name": "total_retro_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "total_fees_expected": {
+          "name": "total_fees_expected",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "total_fees_paid": {
+          "name": "total_fees_paid",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "pif_ready_to_close": {
+          "name": "pif_ready_to_close",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_closed": {
+          "name": "is_closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_method": {
+          "name": "fee_method",
+          "type": "fee_method_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'fee_agreement'"
+        },
+        "applicable_fee_cap": {
+          "name": "applicable_fee_cap",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'9200'"
+        },
+        "fee_cap_applied": {
+          "name": "fee_cap_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "fee_computed": {
+          "name": "fee_computed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "fee_computed_at": {
+          "name": "fee_computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "sync_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'not_synced'"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mycase_record_id": {
+          "name": "mycase_record_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fee_records_case_id": {
+          "name": "idx_fee_records_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_assigned_to": {
+          "name": "idx_fee_records_assigned_to",
+          "columns": [
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_win_sheet_status": {
+          "name": "idx_fee_records_win_sheet_status",
+          "columns": [
+            {
+              "expression": "win_sheet_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_sync_status": {
+          "name": "idx_fee_records_sync_status",
+          "columns": [
+            {
+              "expression": "sync_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_pif": {
+          "name": "idx_fee_records_pif",
+          "columns": [
+            {
+              "expression": "pif_ready_to_close",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_is_closed": {
+          "name": "idx_fee_records_is_closed",
+          "columns": [
+            {
+              "expression": "is_closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fee_records_case_id_cases_client_id_fk": {
+          "name": "fee_records_case_id_cases_client_id_fk",
+          "tableFrom": "fee_records",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fee_records_case_id_unique": {
+          "name": "fee_records_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mycase_notice_documents": {
+      "name": "mycase_notice_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mycase_client_id": {
+          "name": "mycase_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mycase_document_id": {
+          "name": "mycase_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_name": {
+          "name": "document_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_pattern": {
+          "name": "matched_pattern",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_document": {
+          "name": "raw_document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mycase_notice_documents_case_id": {
+          "name": "idx_mycase_notice_documents_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mycase_notice_documents_case_id_cases_client_id_fk": {
+          "name": "mycase_notice_documents_case_id_cases_client_id_fk",
+          "tableFrom": "mycase_notice_documents",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mycase_notice_documents_case_id_mycase_document_id_unique": {
+          "name": "mycase_notice_documents_case_id_mycase_document_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id",
+            "mycase_document_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "notification_severity_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notifications_type": {
+          "name": "idx_notifications_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_is_read": {
+          "name": "idx_notifications_is_read",
+          "columns": [
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_created_at": {
+          "name": "idx_notifications_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_agent": {
+          "name": "idx_notifications_agent",
+          "columns": [
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_case_id_cases_client_id_fk": {
+          "name": "notifications_case_id_cases_client_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.overpaid_cases": {
+      "name": "overpaid_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "op_ltr_received": {
+          "name": "op_ltr_received",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checks_cleared": {
+          "name": "checks_cleared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "update_note": {
+          "name": "update_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_overpaid_cases_case_id": {
+          "name": "idx_overpaid_cases_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "overpaid_cases_case_id_cases_client_id_fk": {
+          "name": "overpaid_cases_case_id_cases_client_id_fk",
+          "tableFrom": "overpaid_cases",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "overpaid_cases_case_id_unique": {
+          "name": "overpaid_cases_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pull_logs": {
+      "name": "pull_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_records_pulled": {
+          "name": "total_records_pulled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "new_cases": {
+          "name": "new_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_cases": {
+          "name": "updated_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "errors": {
+          "name": "errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_at": {
+          "name": "triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_logs": {
+      "name": "sync_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cases": {
+          "name": "total_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "case_ids": {
+          "name": "case_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_at": {
+          "name": "triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_sync_logs_triggered_at": {
+          "name": "idx_sync_logs_triggered_at",
+          "columns": [
+            {
+              "expression": "triggered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'collections_specialist'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_members_name_unique": {
+          "name": "team_members_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_details": {
+      "name": "user_details",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chronicle_id": {
+          "name": "chronicle_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line_1": {
+          "name": "address_line_1",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line_2": {
+          "name": "address_line_2",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip_code": {
+          "name": "zip_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cell_phone": {
+          "name": "cell_phone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssn": {
+          "name": "ssn",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssn_last4": {
+          "name": "ssn_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age_at_approval": {
+          "name": "age_at_approval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "place_of_birth": {
+          "name": "place_of_birth",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mothers_first_name_and_maiden_name": {
+          "name": "mothers_first_name_and_maiden_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fathers_first_and_last_name": {
+          "name": "fathers_first_and_last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_details_case_id": {
+          "name": "idx_user_details_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_details_case_id_cases_client_id_fk": {
+          "name": "user_details_case_id_cases_client_id_fk",
+          "tableFrom": "user_details",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_details_case_id_unique": {
+          "name": "user_details_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        },
+        "user_details_chronicle_id_unique": {
+          "name": "user_details_chronicle_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chronicle_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.claim_type_enum": {
+      "name": "claim_type_enum",
+      "schema": "public",
+      "values": [
+        "T2",
+        "T16",
+        "T2_T16"
+      ]
+    },
+    "public.decision_outcome_enum": {
+      "name": "decision_outcome_enum",
+      "schema": "public",
+      "values": [
+        "fully_favorable",
+        "partially_favorable",
+        "unfavorable",
+        "dismissed",
+        "remand",
+        "unknown"
+      ]
+    },
+    "public.fee_method_enum": {
+      "name": "fee_method_enum",
+      "schema": "public",
+      "values": [
+        "fee_agreement",
+        "fee_petition"
+      ]
+    },
+    "public.level_won_enum": {
+      "name": "level_won_enum",
+      "schema": "public",
+      "values": [
+        "INITIAL",
+        "RECON",
+        "HEARING",
+        "AC",
+        "FEDERAL_COURT",
+        "FEE_PETITION"
+      ]
+    },
+    "public.notification_severity_enum": {
+      "name": "notification_severity_enum",
+      "schema": "public",
+      "values": [
+        "info",
+        "warning",
+        "critical"
+      ]
+    },
+    "public.notification_type_enum": {
+      "name": "notification_type_enum",
+      "schema": "public",
+      "values": [
+        "case_aging",
+        "fee_payment",
+        "call_target_missed",
+        "case_assigned"
+      ]
+    },
+    "public.sync_status_enum": {
+      "name": "sync_status_enum",
+      "schema": "public",
+      "values": [
+        "not_synced",
+        "syncing",
+        "synced",
+        "error"
+      ]
+    },
+    "public.user_role_enum": {
+      "name": "user_role_enum",
+      "schema": "public",
+      "values": [
+        "admin",
+        "member",
+        "system_admin"
+      ]
+    },
+    "public.win_sheet_status_enum": {
+      "name": "win_sheet_status_enum",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "started",
+        "in_progress",
+        "pending_payment",
+        "partially_paid",
+        "paid_in_full",
+        "closed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,2629 @@
+{
+  "id": "d70e8f55-a108-4b4c-a49f-e33b2019c950",
+  "prevId": "0e87df12-8e97-4b1a-9877-c93d5a24ca73",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_log": {
+      "name": "activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_record_id": {
+          "name": "fee_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_activity_log_case_id": {
+          "name": "idx_activity_log_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_log_created_at": {
+          "name": "idx_activity_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_log_case_id_cases_client_id_fk": {
+          "name": "activity_log_case_id_cases_client_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_log_fee_record_id_fee_records_id_fk": {
+          "name": "activity_log_fee_record_id_fee_records_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "fee_records",
+          "columnsFrom": [
+            "fee_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_settings": {
+      "name": "app_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approved_by_options": {
+      "name": "approved_by_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "approved_by_options_name_unique": {
+          "name": "approved_by_options_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cases": {
+      "name": "cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dob": {
+          "name": "dob",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last4_ssn": {
+          "name": "last4_ssn",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_type": {
+          "name": "claim_type",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "claim_type_label": {
+          "name": "claim_type_label",
+          "type": "claim_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level_won": {
+          "name": "level_won",
+          "type": "level_won_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "t2_decision": {
+          "name": "t2_decision",
+          "type": "decision_outcome_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'unknown'"
+        },
+        "t16_decision": {
+          "name": "t16_decision",
+          "type": "decision_outcome_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'unknown'"
+        },
+        "application_date": {
+          "name": "application_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alleged_onset_date": {
+          "name": "alleged_onset_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_date": {
+          "name": "approval_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_date": {
+          "name": "closure_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_held_date": {
+          "name": "hearing_held_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_scheduled_date": {
+          "name": "hearing_scheduled_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_scheduled_datetime": {
+          "name": "hearing_scheduled_datetime",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_timezone": {
+          "name": "hearing_timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "office_with_jurisdiction": {
+          "name": "office_with_jurisdiction",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alj_first_name": {
+          "name": "alj_first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alj_last_name": {
+          "name": "alj_last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimant_location": {
+          "name": "claimant_location",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representative_location": {
+          "name": "representative_location",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_expert": {
+          "name": "medical_expert",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vocational_expert": {
+          "name": "vocational_expert",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_file_link": {
+          "name": "all_file_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exhibits_file_link": {
+          "name": "exhibits_file_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_file_updated_at": {
+          "name": "all_file_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exhibits_file_updated_at": {
+          "name": "exhibits_file_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_ssn": {
+          "name": "full_ssn",
+          "type": "varchar(11)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_diagnosis": {
+          "name": "primary_diagnosis",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_diagnosis_code": {
+          "name": "primary_diagnosis_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secondary_diagnosis": {
+          "name": "secondary_diagnosis",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secondary_diagnosis_code": {
+          "name": "secondary_diagnosis_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allegations": {
+          "name": "allegations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blind_dli": {
+          "name": "blind_dli",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firm_name": {
+          "name": "firm_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firm_ein": {
+          "name": "firm_ein",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_office": {
+          "name": "hearing_office",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representatives": {
+          "name": "representatives",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_history": {
+          "name": "decision_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_type": {
+          "name": "report_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expedited_case": {
+          "name": "expedited_case",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_of_case": {
+          "name": "status_of_case",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_date": {
+          "name": "status_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_date": {
+          "name": "request_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_date": {
+          "name": "receipt_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_date_assigned": {
+          "name": "first_date_assigned",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_fqr_starts": {
+          "name": "date_fqr_starts",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_insured": {
+          "name": "last_insured",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_created_at": {
+          "name": "source_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_updated_at": {
+          "name": "source_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ere_session_date": {
+          "name": "last_ere_session_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status_report_date": {
+          "name": "last_status_report_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documents_last_added_at": {
+          "name": "documents_last_added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invalid_ssn": {
+          "name": "invalid_ssn",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ssn_encrypted": {
+          "name": "ssn_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_link": {
+          "name": "case_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_pulled_at": {
+          "name": "last_pulled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_cases_client_id": {
+          "name": "idx_cases_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_external_id": {
+          "name": "idx_cases_external_id",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_claim_type_label": {
+          "name": "idx_cases_claim_type_label",
+          "columns": [
+            {
+              "expression": "claim_type_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_approval_date": {
+          "name": "idx_cases_approval_date",
+          "columns": [
+            {
+              "expression": "approval_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_last_name": {
+          "name": "idx_cases_last_name",
+          "columns": [
+            {
+              "expression": "last_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cases_client_id_unique": {
+          "name": "cases_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chronicle_documents": {
+      "name": "chronicle_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mycase_client_id": {
+          "name": "mycase_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chronicle_client_id": {
+          "name": "chronicle_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chronicle_document_id": {
+          "name": "chronicle_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_name": {
+          "name": "document_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_category": {
+          "name": "document_category",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_document": {
+          "name": "raw_document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chronicle_documents_case_id": {
+          "name": "idx_chronicle_documents_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chronicle_documents_case_id_cases_client_id_fk": {
+          "name": "chronicle_documents_case_id_cases_client_id_fk",
+          "tableFrom": "chronicle_documents",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chronicle_documents_case_id_chronicle_document_id_unique": {
+          "name": "chronicle_documents_case_id_chronicle_document_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id",
+            "chronicle_document_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_metrics": {
+      "name": "daily_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_date": {
+          "name": "metric_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ssa_calls": {
+          "name": "ssa_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "client_calls_ib": {
+          "name": "client_calls_ib",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "client_calls_ob": {
+          "name": "client_calls_ob",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_metrics_agent": {
+          "name": "idx_daily_metrics_agent",
+          "columns": [
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_metrics_date": {
+          "name": "idx_daily_metrics_date",
+          "columns": [
+            {
+              "expression": "metric_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_metrics_agent_name_team_members_name_fk": {
+          "name": "daily_metrics_agent_name_team_members_name_fk",
+          "tableFrom": "daily_metrics",
+          "tableTo": "team_members",
+          "columnsFrom": [
+            "agent_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dropdown_options": {
+      "name": "dropdown_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(150)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_dropdown_options_category_name": {
+          "name": "uq_dropdown_options_category_name",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dropdown_options_category": {
+          "name": "idx_dropdown_options_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_cap_history": {
+      "name": "fee_cap_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cap_amount": {
+          "name": "cap_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fee_cap_history_effective_date_unique": {
+          "name": "fee_cap_history_effective_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "effective_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_petitions": {
+      "name": "fee_petitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "noa": {
+          "name": "noa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "time_delineation": {
+          "name": "time_delineation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "fee_petition_doc": {
+          "name": "fee_petition_doc",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ltr_to_clmt": {
+          "name": "ltr_to_clmt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ltr_to_clmt_with_signature": {
+          "name": "ltr_to_clmt_with_signature",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ltr_to_alj": {
+          "name": "ltr_to_alj",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "fax_conf_fee_pet": {
+          "name": "fax_conf_fee_pet",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "update_note": {
+          "name": "update_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fee_petitions_case_id": {
+          "name": "idx_fee_petitions_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fee_petitions_case_id_cases_client_id_fk": {
+          "name": "fee_petitions_case_id_cases_client_id_fk",
+          "tableFrom": "fee_petitions",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fee_petitions_case_id_unique": {
+          "name": "fee_petitions_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_records": {
+      "name": "fee_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "win_sheet_status": {
+          "name": "win_sheet_status",
+          "type": "win_sheet_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'not_started'"
+        },
+        "win_sheet_link": {
+          "name": "win_sheet_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_status": {
+          "name": "case_status",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fees_confirmation": {
+          "name": "fees_confirmation",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_assigned_to_agent": {
+          "name": "date_assigned_to_agent",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "t16_retro": {
+          "name": "t16_retro",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_fee_due": {
+          "name": "t16_fee_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_fee_received": {
+          "name": "t16_fee_received",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_pending": {
+          "name": "t16_pending",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_fee_received_date": {
+          "name": "t16_fee_received_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "t2_retro": {
+          "name": "t2_retro",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_fee_due": {
+          "name": "t2_fee_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_fee_received": {
+          "name": "t2_fee_received",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_pending": {
+          "name": "t2_pending",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_fee_received_date": {
+          "name": "t2_fee_received_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aux_retro": {
+          "name": "aux_retro",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_fee_due": {
+          "name": "aux_fee_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_fee_received": {
+          "name": "aux_fee_received",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_pending": {
+          "name": "aux_pending",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_fee_received_date": {
+          "name": "aux_fee_received_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_retro_due": {
+          "name": "total_retro_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "total_fees_expected": {
+          "name": "total_fees_expected",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "total_fees_paid": {
+          "name": "total_fees_paid",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "pif_ready_to_close": {
+          "name": "pif_ready_to_close",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_closed": {
+          "name": "is_closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_method": {
+          "name": "fee_method",
+          "type": "fee_method_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'fee_agreement'"
+        },
+        "applicable_fee_cap": {
+          "name": "applicable_fee_cap",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'9200'"
+        },
+        "fee_cap_applied": {
+          "name": "fee_cap_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "fee_computed": {
+          "name": "fee_computed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "fee_computed_at": {
+          "name": "fee_computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "sync_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'not_synced'"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mycase_record_id": {
+          "name": "mycase_record_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fee_records_case_id": {
+          "name": "idx_fee_records_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_assigned_to": {
+          "name": "idx_fee_records_assigned_to",
+          "columns": [
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_win_sheet_status": {
+          "name": "idx_fee_records_win_sheet_status",
+          "columns": [
+            {
+              "expression": "win_sheet_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_sync_status": {
+          "name": "idx_fee_records_sync_status",
+          "columns": [
+            {
+              "expression": "sync_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_pif": {
+          "name": "idx_fee_records_pif",
+          "columns": [
+            {
+              "expression": "pif_ready_to_close",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_is_closed": {
+          "name": "idx_fee_records_is_closed",
+          "columns": [
+            {
+              "expression": "is_closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fee_records_case_id_cases_client_id_fk": {
+          "name": "fee_records_case_id_cases_client_id_fk",
+          "tableFrom": "fee_records",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fee_records_case_id_unique": {
+          "name": "fee_records_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mycase_notice_documents": {
+      "name": "mycase_notice_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mycase_client_id": {
+          "name": "mycase_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mycase_document_id": {
+          "name": "mycase_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_name": {
+          "name": "document_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_pattern": {
+          "name": "matched_pattern",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_document": {
+          "name": "raw_document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mycase_notice_documents_case_id": {
+          "name": "idx_mycase_notice_documents_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mycase_notice_documents_case_id_cases_client_id_fk": {
+          "name": "mycase_notice_documents_case_id_cases_client_id_fk",
+          "tableFrom": "mycase_notice_documents",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mycase_notice_documents_case_id_mycase_document_id_unique": {
+          "name": "mycase_notice_documents_case_id_mycase_document_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id",
+            "mycase_document_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "notification_severity_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notifications_type": {
+          "name": "idx_notifications_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_is_read": {
+          "name": "idx_notifications_is_read",
+          "columns": [
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_created_at": {
+          "name": "idx_notifications_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_agent": {
+          "name": "idx_notifications_agent",
+          "columns": [
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_case_id_cases_client_id_fk": {
+          "name": "notifications_case_id_cases_client_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.overpaid_cases": {
+      "name": "overpaid_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "op_ltr_received": {
+          "name": "op_ltr_received",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checks_cleared": {
+          "name": "checks_cleared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "update_note": {
+          "name": "update_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_overpaid_cases_case_id": {
+          "name": "idx_overpaid_cases_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "overpaid_cases_case_id_cases_client_id_fk": {
+          "name": "overpaid_cases_case_id_cases_client_id_fk",
+          "tableFrom": "overpaid_cases",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "overpaid_cases_case_id_unique": {
+          "name": "overpaid_cases_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pull_logs": {
+      "name": "pull_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_records_pulled": {
+          "name": "total_records_pulled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "new_cases": {
+          "name": "new_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_cases": {
+          "name": "updated_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "errors": {
+          "name": "errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_at": {
+          "name": "triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_logs": {
+      "name": "sync_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cases": {
+          "name": "total_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "case_ids": {
+          "name": "case_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_at": {
+          "name": "triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_sync_logs_triggered_at": {
+          "name": "idx_sync_logs_triggered_at",
+          "columns": [
+            {
+              "expression": "triggered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'collections_specialist'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_members_name_unique": {
+          "name": "team_members_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_details": {
+      "name": "user_details",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chronicle_id": {
+          "name": "chronicle_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line_1": {
+          "name": "address_line_1",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line_2": {
+          "name": "address_line_2",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip_code": {
+          "name": "zip_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cell_phone": {
+          "name": "cell_phone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssn": {
+          "name": "ssn",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssn_last4": {
+          "name": "ssn_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age_at_approval": {
+          "name": "age_at_approval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "place_of_birth": {
+          "name": "place_of_birth",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mothers_first_name_and_maiden_name": {
+          "name": "mothers_first_name_and_maiden_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fathers_first_and_last_name": {
+          "name": "fathers_first_and_last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_details_case_id": {
+          "name": "idx_user_details_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_details_case_id_cases_client_id_fk": {
+          "name": "user_details_case_id_cases_client_id_fk",
+          "tableFrom": "user_details",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_details_case_id_unique": {
+          "name": "user_details_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        },
+        "user_details_chronicle_id_unique": {
+          "name": "user_details_chronicle_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chronicle_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.claim_type_enum": {
+      "name": "claim_type_enum",
+      "schema": "public",
+      "values": [
+        "T2",
+        "T16",
+        "T2_T16"
+      ]
+    },
+    "public.decision_outcome_enum": {
+      "name": "decision_outcome_enum",
+      "schema": "public",
+      "values": [
+        "fully_favorable",
+        "partially_favorable",
+        "unfavorable",
+        "dismissed",
+        "remand",
+        "unknown"
+      ]
+    },
+    "public.fee_method_enum": {
+      "name": "fee_method_enum",
+      "schema": "public",
+      "values": [
+        "fee_agreement",
+        "fee_petition"
+      ]
+    },
+    "public.level_won_enum": {
+      "name": "level_won_enum",
+      "schema": "public",
+      "values": [
+        "INITIAL",
+        "RECON",
+        "HEARING",
+        "AC",
+        "FEDERAL_COURT",
+        "FEE_PETITION"
+      ]
+    },
+    "public.notification_severity_enum": {
+      "name": "notification_severity_enum",
+      "schema": "public",
+      "values": [
+        "info",
+        "warning",
+        "critical"
+      ]
+    },
+    "public.notification_type_enum": {
+      "name": "notification_type_enum",
+      "schema": "public",
+      "values": [
+        "case_aging",
+        "fee_payment",
+        "call_target_missed",
+        "case_assigned"
+      ]
+    },
+    "public.sync_status_enum": {
+      "name": "sync_status_enum",
+      "schema": "public",
+      "values": [
+        "not_synced",
+        "syncing",
+        "synced",
+        "error"
+      ]
+    },
+    "public.user_role_enum": {
+      "name": "user_role_enum",
+      "schema": "public",
+      "values": [
+        "admin",
+        "member",
+        "system_admin"
+      ]
+    },
+    "public.win_sheet_status_enum": {
+      "name": "win_sheet_status_enum",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "started",
+        "in_progress",
+        "pending_payment",
+        "partially_paid",
+        "paid_in_full",
+        "closed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,2626 @@
+{
+  "id": "ad4783ce-1264-4fec-bcc3-ed119a5bf292",
+  "prevId": "d70e8f55-a108-4b4c-a49f-e33b2019c950",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_log": {
+      "name": "activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_record_id": {
+          "name": "fee_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_activity_log_case_id": {
+          "name": "idx_activity_log_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_log_created_at": {
+          "name": "idx_activity_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_log_case_id_cases_client_id_fk": {
+          "name": "activity_log_case_id_cases_client_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_log_fee_record_id_fee_records_id_fk": {
+          "name": "activity_log_fee_record_id_fee_records_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "fee_records",
+          "columnsFrom": [
+            "fee_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_settings": {
+      "name": "app_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approved_by_options": {
+      "name": "approved_by_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "approved_by_options_name_unique": {
+          "name": "approved_by_options_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cases": {
+      "name": "cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dob": {
+          "name": "dob",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last4_ssn": {
+          "name": "last4_ssn",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_type": {
+          "name": "claim_type",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "claim_type_label": {
+          "name": "claim_type_label",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level_won": {
+          "name": "level_won",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "t2_decision": {
+          "name": "t2_decision",
+          "type": "decision_outcome_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'unknown'"
+        },
+        "t16_decision": {
+          "name": "t16_decision",
+          "type": "decision_outcome_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'unknown'"
+        },
+        "application_date": {
+          "name": "application_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alleged_onset_date": {
+          "name": "alleged_onset_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_date": {
+          "name": "approval_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_date": {
+          "name": "closure_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_held_date": {
+          "name": "hearing_held_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_scheduled_date": {
+          "name": "hearing_scheduled_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_scheduled_datetime": {
+          "name": "hearing_scheduled_datetime",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_timezone": {
+          "name": "hearing_timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "office_with_jurisdiction": {
+          "name": "office_with_jurisdiction",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alj_first_name": {
+          "name": "alj_first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alj_last_name": {
+          "name": "alj_last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimant_location": {
+          "name": "claimant_location",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representative_location": {
+          "name": "representative_location",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_expert": {
+          "name": "medical_expert",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vocational_expert": {
+          "name": "vocational_expert",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_file_link": {
+          "name": "all_file_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exhibits_file_link": {
+          "name": "exhibits_file_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_file_updated_at": {
+          "name": "all_file_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exhibits_file_updated_at": {
+          "name": "exhibits_file_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_ssn": {
+          "name": "full_ssn",
+          "type": "varchar(11)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_diagnosis": {
+          "name": "primary_diagnosis",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_diagnosis_code": {
+          "name": "primary_diagnosis_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secondary_diagnosis": {
+          "name": "secondary_diagnosis",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secondary_diagnosis_code": {
+          "name": "secondary_diagnosis_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allegations": {
+          "name": "allegations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blind_dli": {
+          "name": "blind_dli",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firm_name": {
+          "name": "firm_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firm_ein": {
+          "name": "firm_ein",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_office": {
+          "name": "hearing_office",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representatives": {
+          "name": "representatives",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_history": {
+          "name": "decision_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_type": {
+          "name": "report_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expedited_case": {
+          "name": "expedited_case",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_of_case": {
+          "name": "status_of_case",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_date": {
+          "name": "status_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_date": {
+          "name": "request_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_date": {
+          "name": "receipt_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_date_assigned": {
+          "name": "first_date_assigned",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_fqr_starts": {
+          "name": "date_fqr_starts",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_insured": {
+          "name": "last_insured",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_created_at": {
+          "name": "source_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_updated_at": {
+          "name": "source_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ere_session_date": {
+          "name": "last_ere_session_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status_report_date": {
+          "name": "last_status_report_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documents_last_added_at": {
+          "name": "documents_last_added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invalid_ssn": {
+          "name": "invalid_ssn",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ssn_encrypted": {
+          "name": "ssn_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_link": {
+          "name": "case_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_pulled_at": {
+          "name": "last_pulled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_cases_client_id": {
+          "name": "idx_cases_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_external_id": {
+          "name": "idx_cases_external_id",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_claim_type_label": {
+          "name": "idx_cases_claim_type_label",
+          "columns": [
+            {
+              "expression": "claim_type_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_approval_date": {
+          "name": "idx_cases_approval_date",
+          "columns": [
+            {
+              "expression": "approval_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_last_name": {
+          "name": "idx_cases_last_name",
+          "columns": [
+            {
+              "expression": "last_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cases_client_id_unique": {
+          "name": "cases_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chronicle_documents": {
+      "name": "chronicle_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mycase_client_id": {
+          "name": "mycase_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chronicle_client_id": {
+          "name": "chronicle_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chronicle_document_id": {
+          "name": "chronicle_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_name": {
+          "name": "document_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_category": {
+          "name": "document_category",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_document": {
+          "name": "raw_document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chronicle_documents_case_id": {
+          "name": "idx_chronicle_documents_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chronicle_documents_case_id_cases_client_id_fk": {
+          "name": "chronicle_documents_case_id_cases_client_id_fk",
+          "tableFrom": "chronicle_documents",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chronicle_documents_case_id_chronicle_document_id_unique": {
+          "name": "chronicle_documents_case_id_chronicle_document_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id",
+            "chronicle_document_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_metrics": {
+      "name": "daily_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_date": {
+          "name": "metric_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ssa_calls": {
+          "name": "ssa_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "client_calls_ib": {
+          "name": "client_calls_ib",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "client_calls_ob": {
+          "name": "client_calls_ob",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_metrics_agent": {
+          "name": "idx_daily_metrics_agent",
+          "columns": [
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_metrics_date": {
+          "name": "idx_daily_metrics_date",
+          "columns": [
+            {
+              "expression": "metric_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_metrics_agent_name_team_members_name_fk": {
+          "name": "daily_metrics_agent_name_team_members_name_fk",
+          "tableFrom": "daily_metrics",
+          "tableTo": "team_members",
+          "columnsFrom": [
+            "agent_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dropdown_options": {
+      "name": "dropdown_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(150)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_dropdown_options_category_name": {
+          "name": "uq_dropdown_options_category_name",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dropdown_options_category": {
+          "name": "idx_dropdown_options_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_cap_history": {
+      "name": "fee_cap_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cap_amount": {
+          "name": "cap_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fee_cap_history_effective_date_unique": {
+          "name": "fee_cap_history_effective_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "effective_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_petitions": {
+      "name": "fee_petitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "noa": {
+          "name": "noa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "time_delineation": {
+          "name": "time_delineation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "fee_petition_doc": {
+          "name": "fee_petition_doc",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ltr_to_clmt": {
+          "name": "ltr_to_clmt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ltr_to_clmt_with_signature": {
+          "name": "ltr_to_clmt_with_signature",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ltr_to_alj": {
+          "name": "ltr_to_alj",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "fax_conf_fee_pet": {
+          "name": "fax_conf_fee_pet",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "update_note": {
+          "name": "update_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fee_petitions_case_id": {
+          "name": "idx_fee_petitions_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fee_petitions_case_id_cases_client_id_fk": {
+          "name": "fee_petitions_case_id_cases_client_id_fk",
+          "tableFrom": "fee_petitions",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fee_petitions_case_id_unique": {
+          "name": "fee_petitions_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_records": {
+      "name": "fee_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "win_sheet_status": {
+          "name": "win_sheet_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'not_started'"
+        },
+        "win_sheet_link": {
+          "name": "win_sheet_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_status": {
+          "name": "case_status",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fees_confirmation": {
+          "name": "fees_confirmation",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_assigned_to_agent": {
+          "name": "date_assigned_to_agent",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "t16_retro": {
+          "name": "t16_retro",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_fee_due": {
+          "name": "t16_fee_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_fee_received": {
+          "name": "t16_fee_received",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_pending": {
+          "name": "t16_pending",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_fee_received_date": {
+          "name": "t16_fee_received_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "t2_retro": {
+          "name": "t2_retro",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_fee_due": {
+          "name": "t2_fee_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_fee_received": {
+          "name": "t2_fee_received",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_pending": {
+          "name": "t2_pending",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_fee_received_date": {
+          "name": "t2_fee_received_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aux_retro": {
+          "name": "aux_retro",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_fee_due": {
+          "name": "aux_fee_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_fee_received": {
+          "name": "aux_fee_received",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_pending": {
+          "name": "aux_pending",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_fee_received_date": {
+          "name": "aux_fee_received_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_retro_due": {
+          "name": "total_retro_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "total_fees_expected": {
+          "name": "total_fees_expected",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "total_fees_paid": {
+          "name": "total_fees_paid",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "pif_ready_to_close": {
+          "name": "pif_ready_to_close",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_closed": {
+          "name": "is_closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_method": {
+          "name": "fee_method",
+          "type": "fee_method_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'fee_agreement'"
+        },
+        "applicable_fee_cap": {
+          "name": "applicable_fee_cap",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'9200'"
+        },
+        "fee_cap_applied": {
+          "name": "fee_cap_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "fee_computed": {
+          "name": "fee_computed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "fee_computed_at": {
+          "name": "fee_computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "sync_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'not_synced'"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mycase_record_id": {
+          "name": "mycase_record_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fee_records_case_id": {
+          "name": "idx_fee_records_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_assigned_to": {
+          "name": "idx_fee_records_assigned_to",
+          "columns": [
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_win_sheet_status": {
+          "name": "idx_fee_records_win_sheet_status",
+          "columns": [
+            {
+              "expression": "win_sheet_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_sync_status": {
+          "name": "idx_fee_records_sync_status",
+          "columns": [
+            {
+              "expression": "sync_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_pif": {
+          "name": "idx_fee_records_pif",
+          "columns": [
+            {
+              "expression": "pif_ready_to_close",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_is_closed": {
+          "name": "idx_fee_records_is_closed",
+          "columns": [
+            {
+              "expression": "is_closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fee_records_case_id_cases_client_id_fk": {
+          "name": "fee_records_case_id_cases_client_id_fk",
+          "tableFrom": "fee_records",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fee_records_case_id_unique": {
+          "name": "fee_records_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mycase_notice_documents": {
+      "name": "mycase_notice_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mycase_client_id": {
+          "name": "mycase_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mycase_document_id": {
+          "name": "mycase_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_name": {
+          "name": "document_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_pattern": {
+          "name": "matched_pattern",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_document": {
+          "name": "raw_document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mycase_notice_documents_case_id": {
+          "name": "idx_mycase_notice_documents_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mycase_notice_documents_case_id_cases_client_id_fk": {
+          "name": "mycase_notice_documents_case_id_cases_client_id_fk",
+          "tableFrom": "mycase_notice_documents",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mycase_notice_documents_case_id_mycase_document_id_unique": {
+          "name": "mycase_notice_documents_case_id_mycase_document_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id",
+            "mycase_document_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "notification_severity_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notifications_type": {
+          "name": "idx_notifications_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_is_read": {
+          "name": "idx_notifications_is_read",
+          "columns": [
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_created_at": {
+          "name": "idx_notifications_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_agent": {
+          "name": "idx_notifications_agent",
+          "columns": [
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_case_id_cases_client_id_fk": {
+          "name": "notifications_case_id_cases_client_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.overpaid_cases": {
+      "name": "overpaid_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "op_ltr_received": {
+          "name": "op_ltr_received",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checks_cleared": {
+          "name": "checks_cleared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "update_note": {
+          "name": "update_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_overpaid_cases_case_id": {
+          "name": "idx_overpaid_cases_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "overpaid_cases_case_id_cases_client_id_fk": {
+          "name": "overpaid_cases_case_id_cases_client_id_fk",
+          "tableFrom": "overpaid_cases",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "overpaid_cases_case_id_unique": {
+          "name": "overpaid_cases_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pull_logs": {
+      "name": "pull_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_records_pulled": {
+          "name": "total_records_pulled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "new_cases": {
+          "name": "new_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_cases": {
+          "name": "updated_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "errors": {
+          "name": "errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_at": {
+          "name": "triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_logs": {
+      "name": "sync_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cases": {
+          "name": "total_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "case_ids": {
+          "name": "case_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_at": {
+          "name": "triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_sync_logs_triggered_at": {
+          "name": "idx_sync_logs_triggered_at",
+          "columns": [
+            {
+              "expression": "triggered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'collections_specialist'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_members_name_unique": {
+          "name": "team_members_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_details": {
+      "name": "user_details",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chronicle_id": {
+          "name": "chronicle_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line_1": {
+          "name": "address_line_1",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line_2": {
+          "name": "address_line_2",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip_code": {
+          "name": "zip_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cell_phone": {
+          "name": "cell_phone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssn": {
+          "name": "ssn",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssn_last4": {
+          "name": "ssn_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age_at_approval": {
+          "name": "age_at_approval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "place_of_birth": {
+          "name": "place_of_birth",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mothers_first_name_and_maiden_name": {
+          "name": "mothers_first_name_and_maiden_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fathers_first_and_last_name": {
+          "name": "fathers_first_and_last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_details_case_id": {
+          "name": "idx_user_details_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_details_case_id_cases_client_id_fk": {
+          "name": "user_details_case_id_cases_client_id_fk",
+          "tableFrom": "user_details",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_details_case_id_unique": {
+          "name": "user_details_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        },
+        "user_details_chronicle_id_unique": {
+          "name": "user_details_chronicle_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chronicle_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.claim_type_enum": {
+      "name": "claim_type_enum",
+      "schema": "public",
+      "values": [
+        "T2",
+        "T16",
+        "T2_T16"
+      ]
+    },
+    "public.decision_outcome_enum": {
+      "name": "decision_outcome_enum",
+      "schema": "public",
+      "values": [
+        "fully_favorable",
+        "partially_favorable",
+        "unfavorable",
+        "dismissed",
+        "remand",
+        "unknown"
+      ]
+    },
+    "public.fee_method_enum": {
+      "name": "fee_method_enum",
+      "schema": "public",
+      "values": [
+        "fee_agreement",
+        "fee_petition"
+      ]
+    },
+    "public.level_won_enum": {
+      "name": "level_won_enum",
+      "schema": "public",
+      "values": [
+        "INITIAL",
+        "RECON",
+        "HEARING",
+        "AC",
+        "FEDERAL_COURT",
+        "FEE_PETITION"
+      ]
+    },
+    "public.notification_severity_enum": {
+      "name": "notification_severity_enum",
+      "schema": "public",
+      "values": [
+        "info",
+        "warning",
+        "critical"
+      ]
+    },
+    "public.notification_type_enum": {
+      "name": "notification_type_enum",
+      "schema": "public",
+      "values": [
+        "case_aging",
+        "fee_payment",
+        "call_target_missed",
+        "case_assigned"
+      ]
+    },
+    "public.sync_status_enum": {
+      "name": "sync_status_enum",
+      "schema": "public",
+      "values": [
+        "not_synced",
+        "syncing",
+        "synced",
+        "error"
+      ]
+    },
+    "public.user_role_enum": {
+      "name": "user_role_enum",
+      "schema": "public",
+      "values": [
+        "admin",
+        "member",
+        "system_admin"
+      ]
+    },
+    "public.win_sheet_status_enum": {
+      "name": "win_sheet_status_enum",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "started",
+        "in_progress",
+        "pending_payment",
+        "partially_paid",
+        "paid_in_full",
+        "closed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,27 @@
       "when": 1779381004085,
       "tag": "0009_add_auth_users_table",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1779811696949,
+      "tag": "0010_fees_closed_and_approved_by_options",
+      "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1779822270477,
+      "tag": "0011_dropdown_options_and_seed",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1779830266321,
+      "tag": "0012_loosen_enum_columns_to_varchar",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/preflight-migrate.mjs
+++ b/scripts/preflight-migrate.mjs
@@ -1,0 +1,51 @@
+// Read-only pre-flight check before running `npm run db:migrate` against
+// prod. Lists every migration already applied (in drizzle.__drizzle_migrations)
+// and every migration on disk (drizzle/meta/_journal.json), so you can
+// confirm the diff matches your expectations before mutating prod.
+//
+// Run with:  node --env-file=.env.local scripts/preflight-migrate.mjs
+
+import { readFile } from "node:fs/promises";
+import postgres from "postgres";
+
+const url = process.env.DATABASE_URL;
+if (!url) {
+  console.error("DATABASE_URL not set (did you load .env.local?)");
+  process.exit(1);
+}
+
+// Quick masked print so you can confirm you're pointed at prod.
+const masked = url.replace(/:\/\/([^:]+):([^@]+)@/, "://$1:****@");
+console.log(`DB:  ${masked}\n`);
+
+const sql = postgres(url, { max: 1, prepare: false });
+
+try {
+  // Migrations on disk
+  const journal = JSON.parse(
+    await readFile(new URL("../drizzle/meta/_journal.json", import.meta.url)),
+  );
+  const journalTags = journal.entries.map((e) => e.tag);
+
+  // Migrations applied in this DB
+  const rows = await sql`
+    SELECT id, hash, created_at
+    FROM drizzle.__drizzle_migrations
+    ORDER BY created_at ASC
+  `;
+
+  console.log(`Applied in DB:        ${rows.length}`);
+  console.log(`On disk (journal):    ${journalTags.length}`);
+  console.log(`Pending:              ${journalTags.length - rows.length}\n`);
+
+  console.log("Journal tags (in order):");
+  for (let i = 0; i < journalTags.length; i++) {
+    const status = i < rows.length ? "✓ applied" : "→ PENDING";
+    console.log(`  [${i.toString().padStart(2, "0")}] ${status}  ${journalTags[i]}`);
+  }
+} catch (err) {
+  console.error("\nPre-flight failed:", err.message);
+  process.exit(1);
+} finally {
+  await sql.end({ timeout: 1 });
+}

--- a/src/app/(dashboard)/fees-closed/page.tsx
+++ b/src/app/(dashboard)/fees-closed/page.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useTheme } from "next-themes";
+import { RefreshCw, AlertCircle, CheckCircle2 } from "lucide-react";
+import { FeeRecordsTable } from "@/components/cases/FeeRecordsTable";
+import { useDateRange } from "@/lib/date-range-context";
+import { themeClasses } from "@/lib/theme-classes";
+import type { CaseRow } from "@/types";
+
+export default function FeesClosedPage() {
+  const { resolvedTheme } = useTheme();
+  const dark = resolvedTheme === "dark";
+  const t = themeClasses(dark);
+  const { dateRange } = useDateRange();
+
+  const [cases, setCases] = useState<CaseRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchClosed = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/cases?isClosed=true&limit=500");
+      if (!res.ok) throw new Error(`Failed to load (${res.status})`);
+      const json = await res.json();
+      setCases(json.data || []);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchClosed();
+  }, [fetchClosed]);
+
+  const sectionCard = `rounded-xl border ${t.card}`;
+
+  if (error) {
+    return (
+      <div
+        className={`rounded-xl border p-4 flex items-center gap-3 ${dark ? "bg-red-900/20 border-red-800 text-red-400" : "bg-red-50 border-red-200 text-red-700"}`}
+      >
+        <AlertCircle className="h-4 w-4 shrink-0" />
+        <span className="text-sm">Failed to load closed fees: {error}</span>
+        <button
+          onClick={fetchClosed}
+          className="ml-auto text-xs font-medium underline"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <RefreshCw className={`h-6 w-6 animate-spin ${t.textMuted}`} />
+        <span className={`ml-3 text-sm ${t.textSub}`}>
+          Loading closed fees...
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className={`${sectionCard} p-4 md:p-5`}>
+        <div className="flex items-center gap-3">
+          <div
+            className={`w-10 h-10 rounded-lg flex items-center justify-center ${dark ? "bg-emerald-900/40" : "bg-emerald-50"}`}
+          >
+            <CheckCircle2
+              aria-hidden="true"
+              className={`h-5 w-5 ${dark ? "text-emerald-400" : "text-emerald-600"}`}
+            />
+          </div>
+          <div>
+            <h3 className={`text-sm font-bold ${t.text}`}>Fees Closed</h3>
+            <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
+              Cases acknowledged and marked closed from the dashboard
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <FeeRecordsTable
+        cases={cases}
+        dateRange={dateRange}
+        mode="closed"
+        onImported={fetchClosed}
+      />
+    </div>
+  );
+}

--- a/src/app/(dashboard)/mycase/page.tsx
+++ b/src/app/(dashboard)/mycase/page.tsx
@@ -1,0 +1,56 @@
+import { myCaseDb } from "@/lib/db/mycase";
+import { MyCaseCases, type MyCaseRow } from "@/components/mycase/MyCaseCases";
+
+// Reads cookies via the auth layout → always dynamic.
+export const dynamic = "force-dynamic";
+
+export const metadata = {
+  title: "MyCase · SSA Fee Collections",
+};
+
+// Filter values verified by introspecting the MyCase mirror DB:
+//  - case_stage is stored uppercase: "10 FULLY FAVORABLE ALJ HRG DECISION"
+//  - practice_area is "SOCIAL SECURITY " (uppercase + trailing space) — matched via TRIM/UPPER
+//  - office_id 381685 = Hogan Smith (708 of 725 of this app's cases map to it; none to other offices)
+const CASE_STAGE = "10 FULLY FAVORABLE ALJ HRG DECISION";
+const HOGAN_SMITH_OFFICE_ID = 381685;
+
+export default async function MyCasePage() {
+  let cases: MyCaseRow[] = [];
+  let error: string | null = null;
+
+  try {
+    const rows = await myCaseDb`
+      SELECT id::text                  AS id,
+             name,
+             case_number,
+             status,
+             opened_date::text         AS opened_date,
+             closed_date::text         AS closed_date,
+             outstanding_balance::text AS outstanding_balance,
+             updated_at::text          AS updated_at
+      FROM cases
+      WHERE case_stage = ${CASE_STAGE}
+        AND TRIM(UPPER(practice_area)) = 'SOCIAL SECURITY'
+        AND office_id = ${HOGAN_SMITH_OFFICE_ID}
+      ORDER BY opened_date DESC NULLS LAST
+    `;
+
+    cases = rows.map((r) => ({
+      id: Number(r.id),
+      name: r.name ?? "—",
+      caseNumber: r.case_number ?? null,
+      status: r.status ?? null,
+      openedDate: r.opened_date ?? null,
+      closedDate: r.closed_date ?? null,
+      outstandingBalance:
+        r.outstanding_balance != null ? Number(r.outstanding_balance) : null,
+      updatedAt: r.updated_at ?? null,
+    }));
+  } catch (err) {
+    console.error("MyCase page query error:", err);
+    error = "Could not load cases from the MyCase database.";
+  }
+
+  return <MyCaseCases cases={cases} error={error} />;
+}

--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -11,8 +11,17 @@ import { themeClasses } from "@/lib/theme-classes";
 import { RefreshCw, AlertCircle } from "lucide-react";
 
 export default function OverviewPage() {
-  const { cases, summary, monthlyData, loading, casesLoading, error, refresh } =
-    useDashboard();
+  const {
+    cases,
+    summary,
+    monthlyData,
+    approvedByOptions,
+    dropdownOptions,
+    loading,
+    casesLoading,
+    error,
+    refresh,
+  } = useDashboard();
   const { dateRange } = useDateRange();
   const { resolvedTheme } = useTheme();
   const dark = resolvedTheme === "dark";
@@ -65,6 +74,8 @@ export default function OverviewPage() {
           cases={cases}
           dateRange={dateRange}
           onImported={refresh}
+          approvedByOptions={approvedByOptions}
+          dropdownOptions={dropdownOptions}
         />
       )}
     </>

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -27,8 +27,10 @@ import {
   Loader2,
   // ExternalLink,
   CircleDot,
+  ListChecks,
 } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
+import { DropdownOptionsManager } from "@/components/settings/DropdownOptionsManager";
 
 // ============================================================================
 // Types
@@ -61,7 +63,12 @@ interface ConnectionStatus {
   message: string;
 }
 
-type TabKey = "fees" | "integrations" | "targets" | "notifications";
+type TabKey =
+  | "fees"
+  | "dropdowns"
+  | "integrations"
+  | "targets"
+  | "notifications";
 
 const TAB_META: Record<
   TabKey,
@@ -71,6 +78,11 @@ const TAB_META: Record<
     label: "Fee Configuration",
     icon: DollarSign,
     desc: "Fee cap history and computation defaults",
+  },
+  dropdowns: {
+    label: "Dropdown Options",
+    icon: ListChecks,
+    desc: "Manage the values that populate worksheet dropdowns",
   },
   integrations: {
     label: "Integrations",
@@ -85,7 +97,13 @@ const TAB_META: Record<
   },
 };
 
-const TABS: TabKey[] = ["fees", "integrations", "targets", "notifications"];
+const TABS: TabKey[] = [
+  "fees",
+  "dropdowns",
+  "integrations",
+  "targets",
+  "notifications",
+];
 
 const STATUS_STYLE: Record<
   ConnectionStatus["status"],
@@ -304,7 +322,7 @@ export default function SettingsPage() {
               </p>
             </div>
           </div>
-          {activeTab !== "integrations" && (
+          {activeTab !== "integrations" && activeTab !== "dropdowns" && (
             <button
               onClick={handleSave}
               disabled={saving}
@@ -577,6 +595,13 @@ export default function SettingsPage() {
                   </div>
                 )}
               </div>
+            </div>
+          )}
+
+          {/* ── DROPDOWN OPTIONS TAB ── */}
+          {activeTab === "dropdowns" && (
+            <div className="space-y-4">
+              <DropdownOptionsManager />
             </div>
           )}
 

--- a/src/app/api/cases/[id]/route.ts
+++ b/src/app/api/cases/[id]/route.ts
@@ -82,6 +82,10 @@ export const GET = async (
         totalFeesPaid: feeRecords.totalFeesPaid,
         pifReadyToClose: feeRecords.pifReadyToClose,
         approvedBy: feeRecords.approvedBy,
+        feesConfirmation: feeRecords.feesConfirmation,
+        caseStatus: feeRecords.caseStatus,
+        isClosed: feeRecords.isClosed,
+        closedAt: feeRecords.closedAt,
         feeMethod: feeRecords.feeMethod,
         applicableFeeCap: feeRecords.applicableFeeCap,
         feeCapApplied: feeRecords.feeCapApplied,
@@ -216,6 +220,10 @@ export const GET = async (
             ? "NO"
             : null,
       approvedBy: row.approvedBy,
+      feesConfirmation: row.feesConfirmation ?? null,
+      caseStatus: row.caseStatus ?? null,
+      isClosed: row.isClosed ?? false,
+      closedAt: row.closedAt ? row.closedAt.toISOString() : null,
       feeMethod: row.feeMethod,
       applicableFeeCap: Number(row.applicableFeeCap) || 9200,
       feeCapApplied: row.feeCapApplied,
@@ -342,8 +350,11 @@ export const PATCH = async (
         totalFeesPaid: "total_fees_paid",
         pifReadyToClose: "pif_ready_to_close",
         approvedBy: "approved_by",
+        feesConfirmation: "fees_confirmation",
+        caseStatus: "case_status",
         feeMethod: "fee_method",
         feeComputed: "fee_computed",
+        isClosed: "is_closed",
       };
 
       const updates = Object.entries(feeFields)
@@ -355,6 +366,14 @@ export const PATCH = async (
           if (typeof v === "number") return `${col} = ${v}`;
           return `${col} = '${String(v).replace(/'/g, "''")}'`;
         });
+
+      // When isClosed flips, also stamp/clear closed_at so the fees-closed
+      // page can show "closed on …" without the client having to track time.
+      if (feeFields.isClosed === true) {
+        updates.push("closed_at = NOW()");
+      } else if (feeFields.isClosed === false) {
+        updates.push("closed_at = NULL");
+      }
 
       if (updates.length > 0) {
         await db.execute(

--- a/src/app/api/cases/route.ts
+++ b/src/app/api/cases/route.ts
@@ -10,22 +10,28 @@ export const GET = async (req: NextRequest) => {
     const search = searchParams.get("search");
     const status = searchParams.get("status");
     const assigned = searchParams.get("assigned");
+    // isClosed: "true" → closed only, "false" → active only, anything else
+    // (incl. absent) → no filter (preserves search/back-compat behavior).
+    const isClosedParam = searchParams.get("isClosed");
     const page = parseInt(searchParams.get("page") || "1");
     const limit = parseInt(searchParams.get("limit") || "50");
     const offset = (page - 1) * limit;
+
+    // Shared WHERE for the count and main queries.
+    const whereClause = sql`TRUE
+      ${search ? sql`AND (${ilike(cases.firstName, `%${search}%`)} OR ${ilike(cases.lastName, `%${search}%`)} OR ${ilike(cases.externalId, `%${search}%`)})` : sql``}
+      ${status ? sql`AND ${feeRecords.winSheetStatus} = ${status}` : sql``}
+      ${assigned ? sql`AND ${eq(feeRecords.assignedTo, assigned)}` : sql``}
+      ${isClosedParam === "true" ? sql`AND COALESCE(${feeRecords.isClosed}, false) = true` : sql``}
+      ${isClosedParam === "false" ? sql`AND COALESCE(${feeRecords.isClosed}, false) = false` : sql``}
+    `;
 
     // Total count (respecting filters, ignoring pagination)
     const countQuery = db
       .select({ count: sql<number>`COUNT(*)::int` })
       .from(cases)
       .leftJoin(feeRecords, eq(feeRecords.caseId, cases.clientId))
-      .where(
-        sql`TRUE
-          ${search ? sql`AND (${ilike(cases.firstName, `%${search}%`)} OR ${ilike(cases.lastName, `%${search}%`)} OR ${ilike(cases.externalId, `%${search}%`)})` : sql``}
-          ${status ? sql`AND ${feeRecords.winSheetStatus} = ${status}` : sql``}
-          ${assigned ? sql`AND ${eq(feeRecords.assignedTo, assigned)}` : sql``}
-        `,
-      );
+      .where(whereClause);
 
     // Base query: cases joined with fee_records
     const rowsQuery = db
@@ -67,17 +73,15 @@ export const GET = async (req: NextRequest) => {
         applicableFeeCap: feeRecords.applicableFeeCap,
         syncStatus: feeRecords.syncStatus,
         feeRecordUpdatedAt: feeRecords.updatedAt,
+        isClosed: feeRecords.isClosed,
+        closedAt: feeRecords.closedAt,
+        approvedBy: feeRecords.approvedBy,
+        feesConfirmation: feeRecords.feesConfirmation,
+        caseStatus: feeRecords.caseStatus,
       })
       .from(cases)
       .leftJoin(feeRecords, eq(feeRecords.caseId, cases.clientId))
-      .where(
-        // Apply filters
-        sql`TRUE
-          ${search ? sql`AND (${ilike(cases.firstName, `%${search}%`)} OR ${ilike(cases.lastName, `%${search}%`)} OR ${ilike(cases.externalId, `%${search}%`)})` : sql``}
-          ${status ? sql`AND ${feeRecords.winSheetStatus} = ${status}` : sql``}
-          ${assigned ? sql`AND ${eq(feeRecords.assignedTo, assigned)}` : sql``}
-        `,
-      )
+      .where(whereClause)
       .orderBy(desc(cases.approvalDate))
       .limit(limit)
       .offset(offset);
@@ -179,7 +183,11 @@ export const GET = async (req: NextRequest) => {
 
         // Workflow
         pif,
-        approvedBy: null,
+        approvedBy: r.approvedBy ?? null,
+        feesConfirmation: r.feesConfirmation ?? null,
+        caseStatus: r.caseStatus ?? null,
+        isClosed: r.isClosed ?? false,
+        closedAt: r.closedAt ? r.closedAt.toISOString() : null,
         update: activityMap.get(r.clientId) || "—",
         sync: r.syncStatus || "not_synced",
 

--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -6,7 +6,7 @@ import { eq, sql, count } from "drizzle-orm";
 // GET /api/dashboard — Summary stats + monthly collections data
 export const GET = async () => {
   try {
-    // Summary stats from the view (or computed here)
+    // Summary stats (active rows only — closed cases live on /fees-closed)
     const [stats] = await db
       .select({
         totalCases: count(),
@@ -26,7 +26,8 @@ export const GET = async () => {
         totalPaid: sql<number>`COALESCE(SUM(${feeRecords.totalFeesPaid}::numeric), 0)`,
       })
       .from(cases)
-      .leftJoin(feeRecords, eq(feeRecords.caseId, cases.clientId));
+      .leftJoin(feeRecords, eq(feeRecords.caseId, cases.clientId))
+      .where(sql`COALESCE(${feeRecords.isClosed}, false) = false`);
 
     const expected = Number(stats.totalExpected);
     const paid = Number(stats.totalPaid);

--- a/src/app/api/fee-petitions/route.ts
+++ b/src/app/api/fee-petitions/route.ts
@@ -75,7 +75,10 @@ export const GET = async (req: NextRequest) => {
     const touchedClause = touched === "none" ? sql`AND ${feePetitions.updatedAt} IS NULL` : sql``;
     const missingClause = getMissingClause(missing);
 
-    const whereClause = sql`${cases.levelWon} = 'FEE_PETITION'
+    // Accept both the legacy enum value and the worksheet-direct label
+    // saved via the dashboard dropdown (column C in the master sheet uses
+    // "FEE PETITION" with a space).
+    const whereClause = sql`${cases.levelWon} IN ('FEE_PETITION', 'FEE PETITION')
       ${searchClause}
       ${statusClause}
       ${touchedClause}

--- a/src/app/api/mycase/cases/[id]/documents/route.ts
+++ b/src/app/api/mycase/cases/[id]/documents/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { fetchCaseDocuments } from "@/lib/mycase-proxy";
+
+const resolveParams = async (context: {
+  params: { id: string } | Promise<{ id: string }>;
+}) => {
+  const p =
+    context.params instanceof Promise ? await context.params : context.params;
+  return parseInt(p.id);
+};
+
+// GET /api/mycase/cases/[id]/documents
+// Returns the MyCase documents for the given case id (via the n8n proxy).
+export const GET = async (
+  _req: NextRequest,
+  context: { params: { id: string } | Promise<{ id: string }> },
+) => {
+  try {
+    const caseId = await resolveParams(context);
+    if (!Number.isFinite(caseId)) {
+      return NextResponse.json({ error: "Invalid case ID" }, { status: 400 });
+    }
+    const data = await fetchCaseDocuments(caseId);
+    return NextResponse.json({ data });
+  } catch (err) {
+    console.error("GET /api/mycase/cases/[id]/documents error:", err);
+    return NextResponse.json(
+      { error: (err as Error).message },
+      { status: 500 },
+    );
+  }
+};

--- a/src/app/api/mycase/documents/[id]/file/route.ts
+++ b/src/app/api/mycase/documents/[id]/file/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from "next/server";
+import { fetchDocumentDownloadUrl } from "@/lib/mycase-proxy";
+
+// Filename-extension → MIME, used to coerce a previewable Content-Type when
+// MyCase/S3 hands back a generic one. Types not listed here just download.
+const EXT_MIME: Record<string, string> = {
+  pdf: "application/pdf",
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  bmp: "image/bmp",
+  tif: "image/tiff",
+  tiff: "image/tiff",
+  txt: "text/plain",
+};
+
+const resolveParams = async (context: {
+  params: { id: string } | Promise<{ id: string }>;
+}) => {
+  const p =
+    context.params instanceof Promise ? await context.params : context.params;
+  return parseInt(p.id);
+};
+
+// GET /api/mycase/documents/[id]/file
+// Resolves the document's temporary MyCase (S3) URL via n8n, fetches the file
+// server-side, and re-serves it with `Content-Disposition: inline` so the
+// browser previews it (PDFs/images) instead of downloading. MyCase's signed URL
+// forces `attachment` and we can't change that on the URL itself (it's part of
+// the signature), so we override the disposition here.
+export const GET = async (
+  _req: NextRequest,
+  context: { params: { id: string } | Promise<{ id: string }> },
+) => {
+  try {
+    const documentId = await resolveParams(context);
+    if (!Number.isFinite(documentId)) {
+      return NextResponse.json(
+        { error: "Invalid document ID" },
+        { status: 400 },
+      );
+    }
+
+    const signedUrl = await fetchDocumentDownloadUrl(documentId);
+
+    const fileRes = await fetch(signedUrl, { cache: "no-store" });
+    if (!fileRes.ok || !fileRes.body) {
+      return NextResponse.json(
+        { error: `Could not fetch file from MyCase (${fileRes.status})` },
+        { status: 502 },
+      );
+    }
+
+    // Browsers decide preview-vs-download largely from Content-Type. MyCase's
+    // S3 objects are often served as a generic type, which forces a download
+    // even with `inline`. Infer the real MIME from the filename in the signed
+    // URL and prefer that over the generic upstream type.
+    const fileName = decodeURIComponent(
+      new URL(signedUrl).pathname.split("/").pop() || "",
+    );
+    const ext = fileName.split(".").pop()?.toLowerCase() ?? "";
+    const inferredType = EXT_MIME[ext];
+    const upstreamType = fileRes.headers.get("content-type");
+    const isGeneric =
+      !upstreamType ||
+      upstreamType.includes("octet-stream") ||
+      upstreamType === "binary/octet-stream";
+
+    const headers = new Headers();
+    headers.set(
+      "Content-Type",
+      (isGeneric ? inferredType : upstreamType) ??
+        upstreamType ??
+        "application/octet-stream",
+    );
+    const contentLength = fileRes.headers.get("content-length");
+    if (contentLength) headers.set("Content-Length", contentLength);
+    // Inline so supported types (PDF, images) preview in the browser.
+    headers.set(
+      "Content-Disposition",
+      `inline${fileName ? `; filename="${fileName.replace(/"/g, "")}"` : ""}`,
+    );
+    headers.set("Cache-Control", "private, no-store");
+
+    return new NextResponse(fileRes.body, { status: 200, headers });
+  } catch (err) {
+    console.error("GET /api/mycase/documents/[id]/file error:", err);
+    return NextResponse.json(
+      { error: (err as Error).message },
+      { status: 500 },
+    );
+  }
+};

--- a/src/app/api/settings/dropdown-options/[id]/route.ts
+++ b/src/app/api/settings/dropdown-options/[id]/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { dropdownOptions } from "@/lib/db/schema";
+
+const resolveId = async (context: {
+  params: { id: string } | Promise<{ id: string }>;
+}) => {
+  const p =
+    context.params instanceof Promise ? await context.params : context.params;
+  return parseInt(p.id);
+};
+
+type UpdatePatch = {
+  name?: string;
+  isActive?: boolean;
+  sortOrder?: number;
+  updatedAt: Date;
+};
+
+// PATCH /api/settings/dropdown-options/[id] — rename, toggle active, reorder.
+// Category is intentionally immutable; create a new row in the right category
+// instead of moving an existing one.
+export const PATCH = async (
+  req: NextRequest,
+  context: { params: { id: string } | Promise<{ id: string }> },
+) => {
+  try {
+    const id = await resolveId(context);
+    if (!Number.isFinite(id)) {
+      return NextResponse.json({ error: "Invalid id" }, { status: 400 });
+    }
+
+    const body = await req.json().catch(() => ({}));
+    const updates: UpdatePatch = { updatedAt: new Date() };
+
+    if (typeof body?.name === "string") {
+      const name = body.name.trim();
+      if (!name || name.length > 150) {
+        return NextResponse.json({ error: "Invalid name" }, { status: 400 });
+      }
+      updates.name = name;
+    }
+    if (typeof body?.isActive === "boolean") updates.isActive = body.isActive;
+    if (typeof body?.sortOrder === "number") updates.sortOrder = body.sortOrder;
+
+    // Only `updatedAt` was set → nothing real to change.
+    if (Object.keys(updates).length === 1) {
+      return NextResponse.json(
+        { error: "No fields to update" },
+        { status: 400 },
+      );
+    }
+
+    const [row] = await db
+      .update(dropdownOptions)
+      .set(updates)
+      .where(eq(dropdownOptions.id, id))
+      .returning();
+    if (!row) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    return NextResponse.json({ data: row });
+  } catch (error) {
+    // 23505 = postgres unique_violation (duplicate category+name).
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      (error as { code: string }).code === "23505"
+    ) {
+      return NextResponse.json(
+        { error: "An option with that name already exists in this category" },
+        { status: 409 },
+      );
+    }
+    console.error("PATCH /api/settings/dropdown-options/[id] error:", error);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+};
+
+// DELETE /api/settings/dropdown-options/[id]
+export const DELETE = async (
+  _req: NextRequest,
+  context: { params: { id: string } | Promise<{ id: string }> },
+) => {
+  try {
+    const id = await resolveId(context);
+    if (!Number.isFinite(id)) {
+      return NextResponse.json({ error: "Invalid id" }, { status: 400 });
+    }
+    await db.delete(dropdownOptions).where(eq(dropdownOptions.id, id));
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error("DELETE /api/settings/dropdown-options/[id] error:", error);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+};

--- a/src/app/api/settings/dropdown-options/route.ts
+++ b/src/app/api/settings/dropdown-options/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from "next/server";
+import { and, eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { dropdownOptions } from "@/lib/db/schema";
+import { isDropdownCategory } from "@/lib/dropdown-categories";
+
+// GET /api/settings/dropdown-options?category=<key>
+// Returns rows ordered by (sortOrder, name). When no category is provided,
+// returns every row across all categories (used by admins for export / debug).
+export const GET = async (req: NextRequest) => {
+  try {
+    const url = new URL(req.url);
+    const category = url.searchParams.get("category");
+
+    if (category && !isDropdownCategory(category)) {
+      return NextResponse.json({ error: "Invalid category" }, { status: 400 });
+    }
+
+    const rows = await (category
+      ? db
+          .select()
+          .from(dropdownOptions)
+          .where(eq(dropdownOptions.category, category))
+          .orderBy(dropdownOptions.sortOrder, dropdownOptions.name)
+      : db
+          .select()
+          .from(dropdownOptions)
+          .orderBy(
+            dropdownOptions.category,
+            dropdownOptions.sortOrder,
+            dropdownOptions.name,
+          ));
+
+    return NextResponse.json({ data: rows });
+  } catch (error) {
+    console.error("GET /api/settings/dropdown-options error:", error);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+};
+
+// POST /api/settings/dropdown-options — create a new option within a category.
+export const POST = async (req: NextRequest) => {
+  try {
+    const body = await req.json().catch(() => ({}));
+    const category = String(body?.category ?? "").trim();
+    const name = String(body?.name ?? "").trim();
+
+    if (!isDropdownCategory(category)) {
+      return NextResponse.json({ error: "Invalid category" }, { status: 400 });
+    }
+    if (!name) {
+      return NextResponse.json({ error: "Name is required" }, { status: 400 });
+    }
+    if (name.length > 150) {
+      return NextResponse.json(
+        { error: "Name too long (max 150)" },
+        { status: 400 },
+      );
+    }
+
+    const existing = await db
+      .select({ id: dropdownOptions.id })
+      .from(dropdownOptions)
+      .where(
+        and(
+          eq(dropdownOptions.category, category),
+          eq(dropdownOptions.name, name),
+        ),
+      )
+      .limit(1);
+    if (existing.length > 0) {
+      return NextResponse.json(
+        { error: "An option with that name already exists in this category" },
+        { status: 409 },
+      );
+    }
+
+    const [row] = await db
+      .insert(dropdownOptions)
+      .values({ category, name })
+      .returning();
+    return NextResponse.json({ data: row });
+  } catch (error) {
+    console.error("POST /api/settings/dropdown-options error:", error);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+};

--- a/src/components/cases/AcknowledgeAndCloseDialog.tsx
+++ b/src/components/cases/AcknowledgeAndCloseDialog.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2, AlertCircle, CheckCircle2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface AcknowledgeAndCloseDialogProps {
+  open: boolean;
+  caseId: number | null;
+  caseName: string;
+  // The fee_records field whose value triggered this confirmation (e.g.
+  // "feesConfirmation"). The value gets saved either way; "Yes" additionally
+  // flips isClosed.
+  triggerField: string;
+  triggerValue: string;
+  // Display label used in the dialog copy + activity log entry.
+  triggerLabel: string;
+  onClose: () => void; // dismiss without saving (revert the dropdown)
+  onAcknowledged: () => void; // after a successful save (parent refreshes)
+}
+
+/**
+ * Confirmation prompt shown after a dashboard cell change that may close
+ * the case (e.g. Fees Confirmation = "Paid In Full"). Saves the value
+ * either way; "Yes" additionally marks the case closed (moving it to
+ * /fees-closed). Cancel saves nothing.
+ */
+export function AcknowledgeAndCloseDialog({
+  open,
+  caseId,
+  caseName,
+  triggerField,
+  triggerValue,
+  triggerLabel,
+  onClose,
+  onAcknowledged,
+}: AcknowledgeAndCloseDialogProps) {
+  const [submitting, setSubmitting] = useState<"close" | "keep" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async (markClosed: boolean) => {
+    if (caseId == null || submitting) return;
+    setSubmitting(markClosed ? "close" : "keep");
+    setError(null);
+    try {
+      const baseFields: Record<string, string | boolean> = {
+        [triggerField]: triggerValue,
+      };
+      if (markClosed) baseFields.isClosed = true;
+      const res = await fetch(`/api/cases/${caseId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          feeFields: baseFields,
+          logMessage: markClosed
+            ? `${triggerLabel} set to "${triggerValue}"; marked closed and moved to Fees Closed.`
+            : `${triggerLabel} set to "${triggerValue}".`,
+        }),
+      });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        throw new Error(j.error || `Save failed (${res.status})`);
+      }
+      onAcknowledged();
+      onClose();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setSubmitting(null);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        if (!v && submitting === null) onClose();
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Mark case as closed?</DialogTitle>
+          <DialogDescription>
+            <span className="font-semibold">{caseName}</span> will have{" "}
+            <span className="font-semibold">{triggerLabel}</span> set to{" "}
+            <span className="font-semibold">{triggerValue}</span>. Has this case
+            already been closed? If so, it moves to Fees Closed and leaves the
+            dashboard.
+          </DialogDescription>
+        </DialogHeader>
+
+        {error && (
+          <p
+            role="alert"
+            className="flex items-center gap-2 text-sm text-destructive"
+          >
+            <AlertCircle className="h-4 w-4 shrink-0" />
+            {error}
+          </p>
+        )}
+
+        <DialogFooter className="mt-2 gap-2 sm:gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onClose}
+            disabled={submitting !== null}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => submit(false)}
+            disabled={submitting !== null}
+          >
+            {submitting === "keep" && (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            )}
+            No, keep on dashboard
+          </Button>
+          <Button
+            type="button"
+            onClick={() => submit(true)}
+            disabled={submitting !== null}
+          >
+            {submitting === "close" ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <CheckCircle2 className="h-4 w-4" />
+            )}
+            Yes, mark closed
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/cases/CaseDetailSheet.tsx
+++ b/src/components/cases/CaseDetailSheet.tsx
@@ -25,6 +25,7 @@ import {
   SheetDescription,
 } from "@/components/ui/sheet";
 import { themeClasses } from "@/lib/theme-classes";
+import { MyCaseDocumentsDialog } from "@/components/cases/MyCaseDocumentsDialog";
 import {
   fmtFull,
   fmtDate,
@@ -156,6 +157,7 @@ export default function CaseDetailSheet({
   const [data, setData] = useState<CaseDetailData | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [docsOpen, setDocsOpen] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
 
   const fetchCase = useCallback(async () => {
@@ -199,6 +201,7 @@ export default function CaseDetailSheet({
   const sectionCls = `p-4 border-b ${t.borderLight}`;
 
   return (
+    <>
     <Sheet open={isOpen} onOpenChange={(open) => !open && onClose()}>
       <SheetContent
         side="right"
@@ -275,6 +278,13 @@ export default function CaseDetailSheet({
                   >
                     MyCase <ExternalLink aria-hidden="true" className="h-3 w-3" />
                   </a>
+                  <button
+                    type="button"
+                    onClick={() => setDocsOpen(true)}
+                    className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-[10px] font-bold uppercase transition-colors ${dark ? "bg-emerald-900/30 text-emerald-400 hover:bg-emerald-900/50" : "bg-emerald-50 text-emerald-600 hover:bg-emerald-100"}`}
+                  >
+                    Documents <FileText aria-hidden="true" className="h-3 w-3" />
+                  </button>
                   {data.userDetails?.chronicleId != null && (
                     <a
                       href={`https://app.chroniclelegal.com/dashboard/clients/${data.userDetails.chronicleId}`}
@@ -441,5 +451,14 @@ export default function CaseDetailSheet({
         ) : null}
       </SheetContent>
     </Sheet>
+    {data && (
+      <MyCaseDocumentsDialog
+        open={docsOpen}
+        onOpenChange={setDocsOpen}
+        caseId={data.id}
+        caseName={data.name}
+      />
+    )}
+    </>
   );
 }

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -2,7 +2,14 @@
 
 import { useState, useMemo } from "react";
 import { useTheme } from "next-themes";
-import { Search, ArrowUpDown, Upload, MessageSquare } from "lucide-react";
+import {
+  Search,
+  ArrowUpDown,
+  Upload,
+  MessageSquare,
+  RotateCcw,
+  Loader2,
+} from "lucide-react";
 
 import { themeClasses } from "@/lib/theme-classes";
 import {
@@ -12,16 +19,61 @@ import {
   STATUS_LABELS,
   getStatusColor,
 } from "@/lib/formatters";
-import type { CaseRow } from "@/types";
+import type { CaseRow, ApprovedByOption } from "@/types";
+import type { DropdownOptionsByCategory } from "@/hooks/useDashboard";
 import CaseDetailSheet from "./CaseDetailSheet";
 import ImportCasesModal from "@/components/modals/ImportCasesModal";
 import NotesModal from "@/components/modals/NotesModal";
+import { AcknowledgeAndCloseDialog } from "./AcknowledgeAndCloseDialog";
 
 interface FeeRecordsTableProps {
   cases: CaseRow[];
   dateRange?: { from: string; to: string } | null;
   onImported?: () => Promise<void> | void;
+  // Active dashboard (default) shows the Approved By dropdown + close flow.
+  // "closed" renders a read-only view for /fees-closed.
+  mode?: "active" | "closed";
+  approvedByOptions?: ApprovedByOption[];
+  // Per-category option lists for the other inline dropdowns (Assigned,
+  // Fees Confirmation, Case Status). Optional — an empty list just yields
+  // an empty dropdown with the current value preserved as a fallback.
+  dropdownOptions?: DropdownOptionsByCategory;
 }
+
+// Whether a field lives on the `fee_records` row or the `cases` row.
+// The PATCH endpoint splits its body into `feeFields` and `caseFields`.
+type CaseField = "claimTypeLabel" | "levelWon";
+type FeeField =
+  | "assignedTo"
+  | "approvedBy"
+  | "feesConfirmation"
+  | "caseStatus"
+  | "winSheetStatus";
+
+// Sends a single-field patch and logs an activity entry so the side
+// panel keeps a trail of who changed what.
+const patchSingleField = async (
+  caseId: number,
+  target: "case" | "fee",
+  field: CaseField | FeeField,
+  value: string | null,
+  fieldLabel: string,
+) => {
+  const payload =
+    target === "case"
+      ? { caseFields: { [field]: value } }
+      : { feeFields: { [field]: value } };
+  await fetch(`/api/cases/${caseId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      ...payload,
+      logMessage: value
+        ? `${fieldLabel} set to "${value}"`
+        : `${fieldLabel} cleared`,
+    }),
+  });
+};
 
 const currency = (v: number) => (v > 0 ? fmtFull(v) : "—");
 const dateStr = (d: string | null) => (d ? fmtDate(d) : "—");
@@ -55,10 +107,48 @@ export const FeeRecordsTable = ({
   cases,
   dateRange,
   onImported,
+  mode = "active",
+  approvedByOptions = [],
+  dropdownOptions = {},
 }: FeeRecordsTableProps) => {
   const { resolvedTheme } = useTheme();
   const dark = resolvedTheme === "dark";
   const t = themeClasses(dark);
+
+  const assignedOptions = dropdownOptions.assigned_to ?? [];
+  const feesConfirmationOptions = dropdownOptions.fees_confirmation ?? [];
+  const caseStatusOptions = dropdownOptions.case_status ?? [];
+  const caseLevelOptions = dropdownOptions.case_level ?? [];
+  const claimTypeOptions = dropdownOptions.claim_type ?? [];
+  const winSheetStatusOptions = dropdownOptions.win_sheet_status ?? [];
+
+  // Keys for varchar cells that support inline-edit dropdowns. `status` is
+  // the win_sheet_status row field; `level`/`claim` live on the cases row.
+  type DropdownRowKey =
+    | "assigned"
+    | "approvedBy"
+    | "feesConfirmation"
+    | "caseStatus"
+    | "level"
+    | "claim"
+    | "status";
+
+  // Optimistic overrides keyed by case id — the row value is patched
+  // immediately on change, and the server reconciles on the next refresh.
+  const [pending, setPending] = useState<
+    Record<number, Partial<Record<DropdownRowKey, string>>>
+  >({});
+
+  // Case row whose dropdown change should prompt the "mark closed?" modal.
+  // Currently triggered by Fees Confirmation = "Paid In Full"; the dialog is
+  // field-agnostic so it can host future triggers without another branch.
+  const [ackTarget, setAckTarget] = useState<{
+    caseId: number;
+    caseName: string;
+    triggerField: string;
+    triggerValue: string;
+    triggerLabel: string;
+  } | null>(null);
 
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState("all");
@@ -93,14 +183,21 @@ export const FeeRecordsTable = ({
       );
     }
     if (statusFilter !== "all") {
+      // win_sheet_status is now varchar — accept both the legacy enum
+      // groupings AND the worksheet labels saved via the dropdown.
       if (statusFilter === "finished") {
         d = d.filter((c) =>
-          ["pending_payment", "partially_paid", "paid_in_full"].includes(
-            c.status,
-          ),
+          [
+            "pending_payment",
+            "partially_paid",
+            "paid_in_full",
+            "Finished",
+          ].includes(c.status),
         );
       } else if (statusFilter === "started") {
-        d = d.filter((c) => ["started", "in_progress"].includes(c.status));
+        d = d.filter((c) =>
+          ["started", "in_progress", "Started"].includes(c.status),
+        );
       } else {
         d = d.filter((c) => c.status === statusFilter);
       }
@@ -156,6 +253,93 @@ export const FeeRecordsTable = ({
     }
   };
 
+  // Resolve the value the table should show for a varchar dropdown cell,
+  // preferring an in-flight optimistic edit over the server-loaded row.
+  const cellValue = (c: CaseRow, key: DropdownRowKey): string => {
+    const override = pending[c.id]?.[key];
+    if (override !== undefined) return override ?? "";
+    // `assigned`, `level`, `claim` come back as "—" from the API when null;
+    // treat that as empty so the select shows the placeholder option.
+    if (key === "assigned") return c.assigned === "—" ? "" : c.assigned;
+    if (key === "level") return c.level === "—" ? "" : c.level;
+    if (key === "claim") return c.claim === "—" ? "" : c.claim;
+    if (key === "status") return c.status ?? "";
+    if (key === "approvedBy") return c.approvedBy ?? "";
+    return c[key] ?? "";
+  };
+
+  // Optimistically patch the local row + fire the API call; on failure,
+  // roll back the override and surface the error in the console for now.
+  const handleVarcharChange = async (
+    c: CaseRow,
+    target: "case" | "fee",
+    field: CaseField | FeeField,
+    rowKey: DropdownRowKey,
+    fieldLabel: string,
+    next: string,
+  ) => {
+    const value = next || null;
+    setPending((prev) => ({
+      ...prev,
+      [c.id]: { ...prev[c.id], [rowKey]: value ?? "" },
+    }));
+    try {
+      await patchSingleField(c.id, target, field, value, fieldLabel);
+    } catch (err) {
+      console.error(`Failed to update ${fieldLabel}:`, err);
+      setPending((prev) => {
+        const copy = { ...prev };
+        if (copy[c.id]) {
+          const { [rowKey]: _drop, ...rest } = copy[c.id];
+          void _drop;
+          copy[c.id] = rest;
+        }
+        return copy;
+      });
+    }
+  };
+
+  // Track per-row reopen state so the button can show a spinner + disable
+  // while the PATCH is in flight. Cleared on refresh (the row leaves the
+  // closed list).
+  const [reopeningId, setReopeningId] = useState<number | null>(null);
+
+  // Reopen a closed case from /fees-closed: flip isClosed=false (the API
+  // also stamps closed_at NULL) and clear feesConfirmation so the case
+  // doesn't immediately re-trigger the "mark closed?" modal when the user
+  // sees it back on the dashboard.
+  const handleReopen = async (c: CaseRow) => {
+    if (reopeningId !== null) return;
+    if (
+      !window.confirm(
+        `Reopen "${c.name}"? It will move back to the active dashboard and Fees Confirmation will be cleared.`,
+      )
+    )
+      return;
+    setReopeningId(c.id);
+    try {
+      const res = await fetch(`/api/cases/${c.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          feeFields: { isClosed: false, feesConfirmation: null },
+          logMessage:
+            "Reopened from Fees Closed — moved back to the active dashboard and Fees Confirmation cleared.",
+        }),
+      });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        throw new Error(j.error || `Reopen failed (${res.status})`);
+      }
+      await onImported?.();
+    } catch (err) {
+      console.error("Failed to reopen case:", err);
+      window.alert((err as Error).message);
+    } finally {
+      setReopeningId(null);
+    }
+  };
+
   const rowBorder = dark ? "border-neutral-800/50" : "border-neutral-100";
   const rowHover = dark ? "hover:bg-neutral-800/40" : "hover:bg-neutral-50/80";
   const thBase = `py-2 px-3 text-[10px] font-semibold uppercase tracking-wider whitespace-nowrap`;
@@ -163,6 +347,27 @@ export const FeeRecordsTable = ({
   const groupBorder = dark
     ? "border-l border-neutral-700/50"
     : "border-l border-neutral-200";
+
+  // Frozen left columns: Case Name (192px) + Assigned (160px). Each sticky
+  // cell needs an opaque background matching the card surface, plus a
+  // `group-hover` rule so it inherits the row's hover state from the <tr>
+  // (which carries the `group` class). The thead cells use the same bg
+  // without hover. The second column gets a right divider so the freeze
+  // boundary reads clearly when the rest of the table scrolls under it.
+  const stickyBg = dark ? "bg-neutral-900" : "bg-white";
+  const stickyHover = dark
+    ? "group-hover:bg-neutral-800/40"
+    : "group-hover:bg-neutral-50/80";
+  const stickyDivider = dark
+    ? "border-r border-neutral-700/60"
+    : "border-r border-neutral-200";
+  const stickyTh1 = `sticky left-0 z-20 w-48 min-w-48 ${stickyBg}`;
+  const stickyTh2 = `sticky left-48 z-20 w-40 min-w-40 ${stickyBg} ${stickyDivider}`;
+  // Group-row header that spans BOTH frozen columns (colSpan=2). Same z-index
+  // as the row-2 sticky headers so it stays pinned during horizontal scroll.
+  const stickyGroup = `sticky left-0 z-20 ${stickyBg} ${stickyDivider}`;
+  const stickyTd1 = `sticky left-0 z-10 w-48 min-w-48 ${stickyBg} ${stickyHover}`;
+  const stickyTd2 = `sticky left-48 z-10 w-40 min-w-40 ${stickyBg} ${stickyHover} ${stickyDivider}`;
   // const groupHeaderBg = (color: string) =>
   //   dark ? `bg-${color}-900/20` : `bg-${color}-50/60`;
 
@@ -237,9 +442,22 @@ export const FeeRecordsTable = ({
           {/* Group headers */}
           <thead>
             <tr className={`border-b ${t.borderLight}`}>
-              <th colSpan={6} className={`${thBase} ${t.textSub} text-left`}>
+              {/* Split into a frozen 2-col label + a scrolling 4-col spacer
+                  so the "Case Info" group label stays pinned above the
+                  frozen Case Name + Assigned columns during horizontal
+                  scroll. */}
+              <th
+                colSpan={2}
+                className={`${thBase} ${t.textSub} text-left ${stickyGroup}`}
+              >
                 Case Info
               </th>
+              <th
+                colSpan={4}
+                aria-hidden="true"
+                className={`${thBase} ${t.textSub} text-left`}
+              />
+
               <th
                 colSpan={5}
                 className={`${thBase} text-center ${groupBorder} ${dark ? "text-indigo-400" : "text-indigo-600"}`}
@@ -265,7 +483,7 @@ export const FeeRecordsTable = ({
                 Totals
               </th>
               <th
-                colSpan={5}
+                colSpan={mode === "closed" ? 8 : 7}
                 className={`${thBase} text-center ${groupBorder} ${t.textSub}`}
               >
                 Workflow
@@ -273,16 +491,20 @@ export const FeeRecordsTable = ({
             </tr>
             {/* Column headers */}
             <tr className={`border-b ${t.borderLight}`}>
-              {/* Case Info */}
+              {/* Case Info — first two columns are frozen */}
               <th
-                className={`${thBase} ${t.textSub} text-left cursor-pointer`}
+                className={`${thBase} ${t.textSub} text-left cursor-pointer ${stickyTh1}`}
                 onClick={() => toggleSort("name")}
               >
                 <span className="flex items-center gap-1">
                   Case Name <ArrowUpDown className="h-3 w-3" />
                 </span>
               </th>
-              <th className={`${thBase} ${t.textSub} text-left`}>Assigned</th>
+              <th
+                className={`${thBase} ${t.textSub} text-left ${stickyTh2}`}
+              >
+                Assigned
+              </th>
               <th className={`${thBase} ${t.textSub} text-left`}>Level</th>
               <th className={`${thBase} ${t.textSub} text-left`}>Claim</th>
               <th
@@ -373,6 +595,12 @@ export const FeeRecordsTable = ({
                 Approved By
               </th>
               <th className={`${thBase} ${t.textSub} text-left`}>
+                Fees Conf
+              </th>
+              <th className={`${thBase} ${t.textSub} text-left`}>
+                Case Status
+              </th>
+              <th className={`${thBase} ${t.textSub} text-left`}>
                 Recent Update
               </th>
               <th className={`${thBase} ${t.textSub} text-center`}>Notes</th>
@@ -384,6 +612,11 @@ export const FeeRecordsTable = ({
                   Days <ArrowUpDown className="h-3 w-3" />
                 </span>
               </th>
+              {mode === "closed" && (
+                <th className={`${thBase} ${t.textSub} text-center`}>
+                  Action
+                </th>
+              )}
             </tr>
           </thead>
           <tbody>
@@ -393,37 +626,236 @@ export const FeeRecordsTable = ({
                 onClick={() => setSelectedCaseId(c.id)}
                 className={`border-b ${rowBorder} ${rowHover} transition-colors cursor-pointer group`}
               >
-                {/* Case Info */}
+                {/* Case Info — first two columns are frozen */}
                 <td
-                  className={`${tdBase} ${t.text} font-semibold max-w-45 truncate`}
+                  className={`${tdBase} ${t.text} font-semibold truncate ${stickyTd1}`}
                   title={c.name}
                 >
                   {c.name}
                 </td>
-                <td className={`${tdBase} ${t.textSub}`}>{c.assigned}</td>
-                <td className={`${tdBase}`}>
-                  <span
-                    className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${t.pillBg}`}
-                  >
-                    {c.level}
-                  </span>
+                <td
+                  className={`${tdBase} ${t.textSub} ${stickyTd2}`}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {mode === "closed" ? (
+                    c.assigned
+                  ) : (
+                    <select
+                      value={cellValue(c, "assigned")}
+                      onClick={(e) => e.stopPropagation()}
+                      onChange={(e) =>
+                        handleVarcharChange(
+                          c,
+                          "fee",
+                          "assignedTo",
+                          "assigned",
+                          "Assigned To",
+                          e.target.value,
+                        )
+                      }
+                      className={`h-7 px-2 rounded-md border text-[11px] outline-none cursor-pointer ${t.inputBg}`}
+                      title={
+                        assignedOptions.length === 0
+                          ? "No options configured — add them in Settings"
+                          : undefined
+                      }
+                    >
+                      <option value="">— Select —</option>
+                      {/* Preserve the current value if it's no longer in the
+                          configured list (e.g. imported from the sheet). */}
+                      {(() => {
+                        const v = cellValue(c, "assigned");
+                        return (
+                          v &&
+                          !assignedOptions.some((o) => o.name === v) && (
+                            <option value={v}>{v}</option>
+                          )
+                        );
+                      })()}
+                      {assignedOptions
+                        .filter(
+                          (o) =>
+                            o.isActive ||
+                            o.name === cellValue(c, "assigned"),
+                        )
+                        .map((o) => (
+                          <option key={o.id} value={o.name}>
+                            {o.name}
+                          </option>
+                        ))}
+                    </select>
+                  )}
                 </td>
-                <td className={`${tdBase}`}>
-                  <span
-                    className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${t.pillBg}`}
-                  >
-                    {fmtClaim(c.claim)}
-                  </span>
+                {/* Level — varchar; lives on the cases row. */}
+                <td
+                  className={`${tdBase}`}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {mode === "closed" ? (
+                    <span
+                      className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${t.pillBg}`}
+                    >
+                      {cellValue(c, "level") || "—"}
+                    </span>
+                  ) : (
+                    <select
+                      value={cellValue(c, "level")}
+                      onClick={(e) => e.stopPropagation()}
+                      onChange={(e) =>
+                        handleVarcharChange(
+                          c,
+                          "case",
+                          "levelWon",
+                          "level",
+                          "Case Level",
+                          e.target.value,
+                        )
+                      }
+                      className={`h-7 px-2 rounded-md border text-[11px] outline-none cursor-pointer ${t.inputBg}`}
+                      title={
+                        caseLevelOptions.length === 0
+                          ? "No options configured — add them in Settings"
+                          : undefined
+                      }
+                    >
+                      <option value="">— Select —</option>
+                      {(() => {
+                        const v = cellValue(c, "level");
+                        return (
+                          v &&
+                          !caseLevelOptions.some((o) => o.name === v) && (
+                            <option value={v}>{v}</option>
+                          )
+                        );
+                      })()}
+                      {caseLevelOptions
+                        .filter(
+                          (o) =>
+                            o.isActive || o.name === cellValue(c, "level"),
+                        )
+                        .map((o) => (
+                          <option key={o.id} value={o.name}>
+                            {o.name}
+                          </option>
+                        ))}
+                    </select>
+                  )}
+                </td>
+                {/* Claim — varchar; lives on the cases row. Display still
+                    routes through fmtClaim so legacy "T2_T16" → "CONC". */}
+                <td
+                  className={`${tdBase}`}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {mode === "closed" ? (
+                    <span
+                      className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${t.pillBg}`}
+                    >
+                      {fmtClaim(cellValue(c, "claim")) || "—"}
+                    </span>
+                  ) : (
+                    <select
+                      value={cellValue(c, "claim")}
+                      onClick={(e) => e.stopPropagation()}
+                      onChange={(e) =>
+                        handleVarcharChange(
+                          c,
+                          "case",
+                          "claimTypeLabel",
+                          "claim",
+                          "Claim Type",
+                          e.target.value,
+                        )
+                      }
+                      className={`h-7 px-2 rounded-md border text-[11px] outline-none cursor-pointer ${t.inputBg}`}
+                      title={
+                        claimTypeOptions.length === 0
+                          ? "No options configured — add them in Settings"
+                          : undefined
+                      }
+                    >
+                      <option value="">— Select —</option>
+                      {(() => {
+                        const v = cellValue(c, "claim");
+                        return (
+                          v &&
+                          !claimTypeOptions.some((o) => o.name === v) && (
+                            <option value={v}>{v}</option>
+                          )
+                        );
+                      })()}
+                      {claimTypeOptions
+                        .filter(
+                          (o) =>
+                            o.isActive || o.name === cellValue(c, "claim"),
+                        )
+                        .map((o) => (
+                          <option key={o.id} value={o.name}>
+                            {o.name}
+                          </option>
+                        ))}
+                    </select>
+                  )}
                 </td>
                 <td className={`${tdBase} ${t.textSub} tabular-nums`}>
                   {dateStr(c.date)}
                 </td>
-                <td className={`${tdBase}`}>
-                  <span
-                    className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold ${getStatusColor(c.status, dark)}`}
-                  >
-                    {STATUS_LABELS[c.status]}
-                  </span>
+                {/* Win-sheet Status — varchar; lives on fee_records. */}
+                <td
+                  className={`${tdBase}`}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {mode === "closed" ? (
+                    <span
+                      className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold ${getStatusColor(cellValue(c, "status"), dark)}`}
+                    >
+                      {STATUS_LABELS[cellValue(c, "status")] ||
+                        cellValue(c, "status") ||
+                        "—"}
+                    </span>
+                  ) : (
+                    <select
+                      value={cellValue(c, "status")}
+                      onClick={(e) => e.stopPropagation()}
+                      onChange={(e) =>
+                        handleVarcharChange(
+                          c,
+                          "fee",
+                          "winSheetStatus",
+                          "status",
+                          "Win Sheet Status",
+                          e.target.value,
+                        )
+                      }
+                      className={`h-7 px-2 rounded-md border text-[11px] outline-none cursor-pointer ${t.inputBg}`}
+                      title={
+                        winSheetStatusOptions.length === 0
+                          ? "No options configured — add them in Settings"
+                          : undefined
+                      }
+                    >
+                      <option value="">— Select —</option>
+                      {(() => {
+                        const v = cellValue(c, "status");
+                        return (
+                          v &&
+                          !winSheetStatusOptions.some(
+                            (o) => o.name === v,
+                          ) && <option value={v}>{v}</option>
+                        );
+                      })()}
+                      {winSheetStatusOptions
+                        .filter(
+                          (o) =>
+                            o.isActive || o.name === cellValue(c, "status"),
+                        )
+                        .map((o) => (
+                          <option key={o.id} value={o.name}>
+                            {o.name}
+                          </option>
+                        ))}
+                    </select>
+                  )}
                 </td>
 
                 {/* T16 */}
@@ -522,8 +954,179 @@ export const FeeRecordsTable = ({
                     </span>
                   )}
                 </td>
-                <td className={`${tdBase} ${t.textSub}`}>
-                  {c.approvedBy || "—"}
+                <td
+                  className={`${tdBase} ${t.textSub}`}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {mode === "closed" ? (
+                    cellValue(c, "approvedBy") || "—"
+                  ) : (
+                    <select
+                      value={cellValue(c, "approvedBy")}
+                      onClick={(e) => e.stopPropagation()}
+                      onChange={(e) =>
+                        handleVarcharChange(
+                          c,
+                          "fee",
+                          "approvedBy",
+                          "approvedBy",
+                          "Approved By",
+                          e.target.value,
+                        )
+                      }
+                      className={`h-7 px-2 rounded-md border text-[11px] outline-none cursor-pointer ${t.inputBg}`}
+                      title={
+                        approvedByOptions.length === 0
+                          ? "No options configured — add them in Settings"
+                          : undefined
+                      }
+                    >
+                      <option value="">— Select —</option>
+                      {/* Keep the current value visible even if it's no longer
+                          a configured option (e.g. imported from the sheet). */}
+                      {(() => {
+                        const v = cellValue(c, "approvedBy");
+                        return (
+                          v &&
+                          !approvedByOptions.some((o) => o.name === v) && (
+                            <option value={v}>{v}</option>
+                          )
+                        );
+                      })()}
+                      {approvedByOptions
+                        .filter(
+                          (o) =>
+                            o.isActive || o.name === cellValue(c, "approvedBy"),
+                        )
+                        .map((o) => (
+                          <option key={o.id} value={o.name}>
+                            {o.name}
+                          </option>
+                        ))}
+                    </select>
+                  )}
+                </td>
+                {/* Fees Confirmation — picking "Paid In Full" prompts the
+                    "mark closed?" modal (case-insensitive so a user-renamed
+                    option like "Paid in Full" still triggers it). Other
+                    values save inline like the rest of the dropdowns. */}
+                <td
+                  className={`${tdBase} ${t.textSub}`}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {mode === "closed" ? (
+                    cellValue(c, "feesConfirmation") || "—"
+                  ) : (
+                    <select
+                      value={cellValue(c, "feesConfirmation")}
+                      onClick={(e) => e.stopPropagation()}
+                      onChange={(e) => {
+                        const next = e.target.value;
+                        if (
+                          next &&
+                          next.toLowerCase() === "paid in full" &&
+                          next !== cellValue(c, "feesConfirmation")
+                        ) {
+                          setAckTarget({
+                            caseId: c.id,
+                            caseName: c.name,
+                            triggerField: "feesConfirmation",
+                            triggerValue: next,
+                            triggerLabel: "Fees Confirmation",
+                          });
+                          return;
+                        }
+                        handleVarcharChange(
+                          c,
+                          "fee",
+                          "feesConfirmation",
+                          "feesConfirmation",
+                          "Fees Confirmation",
+                          next,
+                        );
+                      }}
+                      className={`h-7 px-2 rounded-md border text-[11px] outline-none cursor-pointer ${t.inputBg}`}
+                      title={
+                        feesConfirmationOptions.length === 0
+                          ? "No options configured — add them in Settings"
+                          : undefined
+                      }
+                    >
+                      <option value="">— Select —</option>
+                      {(() => {
+                        const v = cellValue(c, "feesConfirmation");
+                        return (
+                          v &&
+                          !feesConfirmationOptions.some(
+                            (o) => o.name === v,
+                          ) && <option value={v}>{v}</option>
+                        );
+                      })()}
+                      {feesConfirmationOptions
+                        .filter(
+                          (o) =>
+                            o.isActive ||
+                            o.name === cellValue(c, "feesConfirmation"),
+                        )
+                        .map((o) => (
+                          <option key={o.id} value={o.name}>
+                            {o.name}
+                          </option>
+                        ))}
+                    </select>
+                  )}
+                </td>
+                {/* Case Status */}
+                <td
+                  className={`${tdBase} ${t.textSub}`}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {mode === "closed" ? (
+                    cellValue(c, "caseStatus") || "—"
+                  ) : (
+                    <select
+                      value={cellValue(c, "caseStatus")}
+                      onClick={(e) => e.stopPropagation()}
+                      onChange={(e) =>
+                        handleVarcharChange(
+                          c,
+                          "fee",
+                          "caseStatus",
+                          "caseStatus",
+                          "Case Status",
+                          e.target.value,
+                        )
+                      }
+                      className={`h-7 px-2 rounded-md border text-[11px] outline-none cursor-pointer ${t.inputBg}`}
+                      title={
+                        caseStatusOptions.length === 0
+                          ? "No options configured — add them in Settings"
+                          : undefined
+                      }
+                    >
+                      <option value="">— Select —</option>
+                      {(() => {
+                        const v = cellValue(c, "caseStatus");
+                        return (
+                          v &&
+                          !caseStatusOptions.some((o) => o.name === v) && (
+                            <option value={v}>{v}</option>
+                          )
+                        );
+                      })()}
+                      {caseStatusOptions
+                        .filter(
+                          (o) =>
+                            o.isActive ||
+                            o.name === cellValue(c, "caseStatus"),
+                        )
+                        .map((o) => (
+                          <option key={o.id} value={o.name}>
+                            {o.name}
+                          </option>
+                        ))}
+                    </select>
+                  )}
                 </td>
                 <td
                   className={`${tdBase} ${t.textSub} max-w-65 truncate`}
@@ -570,6 +1173,30 @@ export const FeeRecordsTable = ({
                     "—"
                   )}
                 </td>
+                {mode === "closed" && (
+                  <td
+                    className={`${tdBase} text-center`}
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleReopen(c);
+                      }}
+                      disabled={reopeningId !== null}
+                      className={`inline-flex items-center gap-1 h-7 px-2 rounded-md text-[11px] font-semibold border ${t.outlineBtn} disabled:opacity-40`}
+                      title="Move this case back to the active dashboard and clear Fees Confirmation"
+                    >
+                      {reopeningId === c.id ? (
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                      ) : (
+                        <RotateCcw className="h-3 w-3" />
+                      )}
+                      Reopen
+                    </button>
+                  </td>
+                )}
               </tr>
             ))}
           </tbody>
@@ -600,6 +1227,20 @@ export const FeeRecordsTable = ({
           onClose={() => setNotesFor(null)}
         />
       )}
+
+      <AcknowledgeAndCloseDialog
+        open={ackTarget !== null}
+        caseId={ackTarget?.caseId ?? null}
+        caseName={ackTarget?.caseName ?? ""}
+        triggerField={ackTarget?.triggerField ?? ""}
+        triggerValue={ackTarget?.triggerValue ?? ""}
+        triggerLabel={ackTarget?.triggerLabel ?? ""}
+        onClose={() => setAckTarget(null)}
+        onAcknowledged={() => {
+          setAckTarget(null);
+          onImported?.();
+        }}
+      />
     </div>
   );
 };

--- a/src/components/cases/MyCaseDocumentsDialog.tsx
+++ b/src/components/cases/MyCaseDocumentsDialog.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useTheme } from "next-themes";
+import { FileText, Search, Loader2, AlertCircle } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { themeClasses } from "@/lib/theme-classes";
+import { fmtDate } from "@/lib/formatters";
+
+type Doc = {
+  id: number;
+  name: string;
+  filename: string | null;
+  path: string | null;
+  description: string | null;
+  assigned_date: string | null;
+  case: { id: number } | null;
+  created_at: string | null;
+  updated_at: string | null;
+  self_url: string | null;
+  folder: { id: number } | null;
+};
+
+interface MyCaseDocumentsDialogProps {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  caseId: number;
+  caseName?: string;
+}
+
+export function MyCaseDocumentsDialog({
+  open,
+  onOpenChange,
+  caseId,
+  caseName,
+}: MyCaseDocumentsDialogProps) {
+  const { resolvedTheme } = useTheme();
+  const dark = resolvedTheme === "dark";
+  const t = themeClasses(dark);
+
+  const [docs, setDocs] = useState<Doc[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  const abortRef = useRef<AbortController | null>(null);
+
+  // Fetch when the dialog opens. Abort if it closes mid-flight.
+  useEffect(() => {
+    if (!open || !Number.isFinite(caseId)) {
+      setDocs([]);
+      setError(null);
+      setQuery("");
+      return;
+    }
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setLoading(true);
+    setError(null);
+    (async () => {
+      try {
+        const res = await fetch(`/api/mycase/cases/${caseId}/documents`, {
+          signal: controller.signal,
+        });
+        if (!res.ok) {
+          const j: { error?: string } = await res
+            .json()
+            .catch(() => ({}));
+          throw new Error(j.error || `Failed to load documents (${res.status})`);
+        }
+        const json = await res.json();
+        setDocs(Array.isArray(json.data) ? json.data : []);
+      } catch (err) {
+        if ((err as Error).name === "AbortError") return;
+        setError((err as Error).message);
+      } finally {
+        if (abortRef.current === controller) setLoading(false);
+      }
+    })();
+    return () => controller.abort();
+  }, [open, caseId]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return docs;
+    return docs.filter((d) =>
+      [d.name, d.filename, d.path].some((s) =>
+        s ? s.toLowerCase().includes(q) : false,
+      ),
+    );
+  }, [docs, query]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>
+            Documents{caseName ? ` · ${caseName}` : ""}
+          </DialogTitle>
+          <DialogDescription>
+            {loading
+              ? "Loading documents from MyCase…"
+              : error
+                ? "Could not load documents."
+                : `${docs.length} document${docs.length === 1 ? "" : "s"} from MyCase`}
+          </DialogDescription>
+        </DialogHeader>
+
+        {!loading && !error && docs.length > 0 && (
+          <div className="relative">
+            <Search
+              aria-hidden="true"
+              className={`absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 ${t.textMuted}`}
+            />
+            <Input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Filter by name, filename, or folder path…"
+              className="pl-8"
+            />
+          </div>
+        )}
+
+        <div
+          className={`mt-2 max-h-[60vh] overflow-y-auto rounded-md border ${t.borderLight}`}
+        >
+          {loading ? (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 className={`h-5 w-5 animate-spin ${t.textMuted}`} />
+              <span className={`ml-3 text-sm ${t.textSub}`}>
+                Loading documents…
+              </span>
+            </div>
+          ) : error ? (
+            <div
+              role="alert"
+              className={`p-4 flex items-start gap-2 text-sm ${dark ? "text-red-400" : "text-red-700"}`}
+            >
+              <AlertCircle className="h-4 w-4 shrink-0 mt-0.5" />
+              <span>{error}</span>
+            </div>
+          ) : filtered.length === 0 ? (
+            <div className="py-10 text-center">
+              <FileText
+                aria-hidden="true"
+                className={`h-7 w-7 mx-auto opacity-30 ${t.textMuted}`}
+              />
+              <p className={`mt-2 text-sm ${t.textMuted}`}>
+                {docs.length === 0
+                  ? "No documents on this case in MyCase."
+                  : "No documents match your filter."}
+              </p>
+            </div>
+          ) : (
+            <ul>
+              {filtered.map((d) => (
+                <li
+                  key={d.id}
+                  className={`px-3 py-2.5 border-b last:border-b-0 ${t.borderLight} ${dark ? "hover:bg-neutral-800/40" : "hover:bg-neutral-50"} transition-colors`}
+                >
+                  <div className="flex items-center gap-3">
+                    <FileText
+                      aria-hidden="true"
+                      className={`h-4 w-4 shrink-0 ${t.textMuted}`}
+                    />
+                    <div className="flex-1 min-w-0">
+                      <p
+                        className={`text-[13px] font-medium ${t.text} truncate`}
+                        title={d.filename || d.name}
+                      >
+                        {d.filename || d.name}
+                      </p>
+                      {d.path && (
+                        <p
+                          className={`text-[10px] ${t.textMuted} truncate`}
+                          title={d.path}
+                        >
+                          {d.path}
+                        </p>
+                      )}
+                    </div>
+                    <span className={`text-[10px] ${t.textMuted} shrink-0`}>
+                      {fmtDate(d.assigned_date || d.created_at)}
+                    </span>
+                  </div>
+                  {d.description && (
+                    <p className={`mt-1 ml-7 text-[11px] ${t.textSub}`}>
+                      {d.description}
+                    </p>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/cases/MyCaseDocumentsDialog.tsx
+++ b/src/components/cases/MyCaseDocumentsDialog.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTheme } from "next-themes";
-import { FileText, Search, Loader2, AlertCircle } from "lucide-react";
+import { FileText, Search, Loader2, AlertCircle, ExternalLink } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -186,9 +186,20 @@ export function MyCaseDocumentsDialog({
                         </p>
                       )}
                     </div>
-                    <span className={`text-[10px] ${t.textMuted} shrink-0`}>
-                      {fmtDate(d.assigned_date || d.created_at)}
-                    </span>
+                    <div className="flex items-center gap-3 shrink-0">
+                      <span className={`text-[10px] ${t.textMuted}`}>
+                        {fmtDate(d.assigned_date || d.created_at)}
+                      </span>
+                      <a
+                        href={`/api/mycase/documents/${d.id}/file`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={`inline-flex items-center gap-1 text-[11px] font-medium ${dark ? "text-indigo-400" : "text-indigo-600"} hover:underline`}
+                      >
+                        View
+                        <ExternalLink aria-hidden="true" className="h-3 w-3" />
+                      </a>
+                    </div>
                   </div>
                   {d.description && (
                     <p className={`mt-1 ml-7 text-[11px] ${t.textSub}`}>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -23,6 +23,7 @@ import {
   LogOut,
   Shield,
   KeyRound,
+  Scale,
 } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
 import { fmtClaim } from "@/lib/formatters";
@@ -59,6 +60,7 @@ const NAV_ITEMS: { section: string; items: NavItem[] }[] = [
       { path: "/chronicle", icon: Database, label: "Chronicle Sync" },
       { path: "/fee-petitions", icon: Gavel, label: "Fee Petitions" },
       { path: "/overpaid-cases", icon: TrendingDown, label: "Overpaid Cases" },
+      { path: "/mycase", icon: Scale, label: "MyCase" },
       { path: "/reports", icon: FileText, label: "Reports" },
       { path: "/notifications", icon: Bell, label: "Notifications" },
     ],

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -24,6 +24,7 @@ import {
   Shield,
   KeyRound,
   Scale,
+  CheckCircle2,
 } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
 import { fmtClaim } from "@/lib/formatters";
@@ -56,6 +57,7 @@ const NAV_ITEMS: { section: string; items: NavItem[] }[] = [
     section: "General",
     items: [
       { path: "/", icon: Home, label: "Overview" },
+      { path: "/fees-closed", icon: CheckCircle2, label: "Fees Closed" },
       { path: "/scoreboard", icon: Trophy, label: "Scoreboard" },
       { path: "/chronicle", icon: Database, label: "Chronicle Sync" },
       { path: "/fee-petitions", icon: Gavel, label: "Fee Petitions" },

--- a/src/components/mycase/MyCaseCases.tsx
+++ b/src/components/mycase/MyCaseCases.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { Scale, ExternalLink, AlertCircle } from "lucide-react";
+import { themeClasses } from "@/lib/theme-classes";
+import { fmtDate, fmtFull } from "@/lib/formatters";
+
+export type MyCaseRow = {
+  id: number;
+  name: string;
+  caseNumber: string | null;
+  status: string | null;
+  openedDate: string | null;
+  closedDate: string | null;
+  outstandingBalance: number | null;
+  updatedAt: string | null;
+};
+
+interface MyCaseCasesProps {
+  cases: MyCaseRow[];
+  error: string | null;
+}
+
+// The firm's MyCase subdomain (matches the deep-link in CaseDetailSheet).
+const MYCASE_BASE = "https://rgdr.mycase.com/court_cases";
+
+export function MyCaseCases({ cases, error }: MyCaseCasesProps) {
+  const { resolvedTheme } = useTheme();
+  const dark = resolvedTheme === "dark";
+  const t = themeClasses(dark);
+
+  const sectionCard = `rounded-xl border ${t.card}`;
+  const thBase = `py-2 px-3 text-[10px] font-semibold uppercase tracking-wider whitespace-nowrap ${t.textSub}`;
+  const tdBase = `py-2 px-3 text-[12px] whitespace-nowrap`;
+  const rowBorder = dark ? "border-neutral-800/50" : "border-neutral-100";
+  const rowHover = dark ? "hover:bg-neutral-800/40" : "hover:bg-neutral-50/80";
+
+  return (
+    <div className="space-y-4">
+      {/* Page header */}
+      <div className={`${sectionCard} p-4 md:p-5`}>
+        <div className="flex items-center gap-3">
+          <div
+            className={`w-10 h-10 rounded-lg flex items-center justify-center ${dark ? "bg-indigo-900/40" : "bg-indigo-50"}`}
+          >
+            <Scale
+              aria-hidden="true"
+              className={`h-5 w-5 ${dark ? "text-indigo-400" : "text-indigo-600"}`}
+            />
+          </div>
+          <div>
+            <h3 className={`text-sm font-bold ${t.text}`}>MyCase Cases</h3>
+            <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
+              Social Security · 10 Fully Favorable ALJ Hearing Decision · Hogan
+              Smith office — pulled from the MyCase database
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {error ? (
+        <div
+          role="alert"
+          className={`rounded-xl border p-4 flex items-center gap-3 ${dark ? "bg-red-900/20 border-red-800 text-red-400" : "bg-red-50 border-red-200 text-red-700"}`}
+        >
+          <AlertCircle className="h-4 w-4 shrink-0" />
+          <span className="text-sm">{error}</span>
+        </div>
+      ) : (
+        <div className={sectionCard}>
+          {/* Toolbar */}
+          <div className={`p-4 border-b ${t.borderLight}`}>
+            <h3 className={`text-sm font-bold ${t.text}`}>Cases</h3>
+            <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
+              {cases.length === 1 ? "1 case" : `${cases.length} cases`}
+            </p>
+          </div>
+
+          {/* Table */}
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-200">
+              <thead>
+                <tr className={`border-b ${t.borderLight}`}>
+                  <th className={`${thBase} text-left`}>Case</th>
+                  <th className={`${thBase} text-left`}>Case #</th>
+                  <th className={`${thBase} text-left`}>Status</th>
+                  <th className={`${thBase} text-left`}>Opened</th>
+                  <th className={`${thBase} text-left`}>Closed</th>
+                  <th className={`${thBase} text-right`}>Outstanding</th>
+                  <th className={`${thBase} text-left`}>Updated</th>
+                  <th className={`${thBase} text-right`}>MyCase</th>
+                </tr>
+              </thead>
+              <tbody>
+                {cases.length === 0 ? (
+                  <tr>
+                    <td
+                      colSpan={8}
+                      className={`${tdBase} text-center py-12 ${t.textMuted}`}
+                    >
+                      <div className="flex flex-col items-center gap-2">
+                        <Scale aria-hidden="true" className="h-8 w-8 opacity-30" />
+                        <p className="text-sm font-medium">
+                          No matching cases found in MyCase.
+                        </p>
+                      </div>
+                    </td>
+                  </tr>
+                ) : (
+                  cases.map((c) => (
+                    <tr
+                      key={c.id}
+                      className={`border-b ${rowBorder} ${rowHover} transition-colors`}
+                    >
+                      <td className={`${tdBase} ${t.text} font-semibold`}>
+                        {c.name}
+                      </td>
+                      <td className={`${tdBase} ${t.textMuted}`}>
+                        {c.caseNumber || "—"}
+                      </td>
+                      <td className={`${tdBase} ${t.textSub}`}>
+                        {c.status || "—"}
+                      </td>
+                      <td className={`${tdBase} ${t.textMuted}`}>
+                        {fmtDate(c.openedDate)}
+                      </td>
+                      <td className={`${tdBase} ${t.textMuted}`}>
+                        {fmtDate(c.closedDate)}
+                      </td>
+                      <td className={`${tdBase} text-right font-semibold ${t.text}`}>
+                        {c.outstandingBalance != null
+                          ? fmtFull(c.outstandingBalance)
+                          : "—"}
+                      </td>
+                      <td className={`${tdBase} ${t.textMuted}`}>
+                        {fmtDate(c.updatedAt)}
+                      </td>
+                      <td className={`${tdBase} text-right`}>
+                        <a
+                          href={`${MYCASE_BASE}/${c.id}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className={`inline-flex items-center gap-1 ${dark ? "text-indigo-400" : "text-indigo-600"} hover:underline`}
+                        >
+                          Open
+                          <ExternalLink aria-hidden="true" className="h-3 w-3" />
+                        </a>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/settings/DropdownOptionsCard.tsx
+++ b/src/components/settings/DropdownOptionsCard.tsx
@@ -1,0 +1,349 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useTheme } from "next-themes";
+import {
+  Plus,
+  Trash2,
+  Loader2,
+  AlertCircle,
+  ListChecks,
+  Pencil,
+  Check,
+  X,
+} from "lucide-react";
+import { themeClasses } from "@/lib/theme-classes";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import type { DropdownCategory } from "@/lib/dropdown-categories";
+
+type Option = {
+  id: number;
+  category: string;
+  name: string;
+  isActive: boolean;
+  sortOrder: number;
+  createdAt: string | null;
+  updatedAt: string | null;
+};
+
+type Props = {
+  category: DropdownCategory;
+  label: string;
+  description?: string;
+};
+
+/**
+ * Admin-managed list of options for a single dropdown category (e.g.
+ * "Approved By", "Assigned To"). Add / rename / activate / delete supported.
+ * Backed by the generic `dropdown_options` table — filtered by `category`.
+ */
+export function DropdownOptionsCard({ category, label, description }: Props) {
+  const { resolvedTheme } = useTheme();
+  const dark = resolvedTheme === "dark";
+  const t = themeClasses(dark);
+
+  const [options, setOptions] = useState<Option[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<number | "new" | null>(null);
+  const [newName, setNewName] = useState("");
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editName, setEditName] = useState("");
+
+  const sectionCard = `rounded-xl border ${t.card}`;
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/settings/dropdown-options?category=${encodeURIComponent(category)}`,
+      );
+      if (!res.ok) throw new Error("Failed to load options");
+      const json = await res.json();
+      setOptions(json.data || []);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, [category]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleAdd = async () => {
+    const name = newName.trim();
+    if (!name || busyId !== null) return;
+    setBusyId("new");
+    setError(null);
+    try {
+      const res = await fetch("/api/settings/dropdown-options", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ category, name }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(json.error || "Failed to add");
+      setNewName("");
+      await load();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const handleUpdate = async (
+    id: number,
+    patch: Partial<Pick<Option, "name" | "isActive">>,
+  ) => {
+    if (busyId !== null) return;
+    setBusyId(id);
+    setError(null);
+    try {
+      const res = await fetch(`/api/settings/dropdown-options/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(patch),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(json.error || "Failed to update");
+      setEditingId(null);
+      await load();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const handleDelete = async (opt: Option) => {
+    if (busyId !== null) return;
+    if (
+      !window.confirm(
+        `Delete "${opt.name}"? Existing records that already use this value keep it; the dropdown just won't offer it going forward.`,
+      )
+    )
+      return;
+    setBusyId(opt.id);
+    setError(null);
+    try {
+      const res = await fetch(`/api/settings/dropdown-options/${opt.id}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        throw new Error(j.error || "Failed to delete");
+      }
+      await load();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const startEdit = (opt: Option) => {
+    setEditingId(opt.id);
+    setEditName(opt.name);
+  };
+  const cancelEdit = () => {
+    setEditingId(null);
+    setEditName("");
+  };
+  const saveEdit = (id: number) => {
+    const name = editName.trim();
+    if (!name) return;
+    handleUpdate(id, { name });
+  };
+
+  return (
+    <div className={sectionCard}>
+      <div
+        className={`p-4 border-b ${t.borderLight} flex items-center justify-between`}
+      >
+        <h4 className={`text-xs font-bold ${t.text} flex items-center gap-2`}>
+          <ListChecks className="h-3.5 w-3.5" /> {label} Options
+        </h4>
+        <span className={`text-[11px] ${t.textMuted}`}>
+          {loading
+            ? "Loading…"
+            : options.length === 1
+              ? "1 option"
+              : `${options.length} options`}
+        </span>
+      </div>
+
+      <div className="p-4 space-y-3">
+        {description && (
+          <p className={`text-[11px] ${t.textMuted}`}>{description}</p>
+        )}
+
+        {error && (
+          <div
+            role="alert"
+            className={`flex items-center gap-2 rounded-md border p-2 text-xs ${dark ? "bg-red-900/20 border-red-800 text-red-400" : "bg-red-50 border-red-200 text-red-700"}`}
+          >
+            <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+            {error}
+          </div>
+        )}
+
+        {/* Add new */}
+        <div className="flex items-center gap-2">
+          <Input
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleAdd();
+              }
+            }}
+            placeholder={`Add a ${label.toLowerCase()} option`}
+            maxLength={150}
+            disabled={busyId !== null}
+            className="h-8 text-xs"
+          />
+          <Button
+            type="button"
+            size="sm"
+            onClick={handleAdd}
+            disabled={!newName.trim() || busyId !== null}
+          >
+            {busyId === "new" ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Plus className="h-3.5 w-3.5" />
+            )}
+            Add
+          </Button>
+        </div>
+
+        {/* List */}
+        {loading ? (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className={`h-5 w-5 animate-spin ${t.textMuted}`} />
+          </div>
+        ) : options.length === 0 ? (
+          <div
+            className={`py-8 text-center text-[11px] ${t.textMuted} border rounded-md ${t.borderLight}`}
+          >
+            No options yet. Add the first one above to populate the dropdown.
+          </div>
+        ) : (
+          <ul className={`rounded-md border ${t.borderLight} divide-y`}>
+            {options.map((opt) => {
+              const rowBusy = busyId === opt.id;
+              const isEditing = editingId === opt.id;
+              return (
+                <li
+                  key={opt.id}
+                  className={`flex items-center gap-2 p-2 ${dark ? "divide-neutral-800" : "divide-neutral-100"}`}
+                >
+                  {isEditing ? (
+                    <>
+                      <Input
+                        value={editName}
+                        onChange={(e) => setEditName(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") {
+                            e.preventDefault();
+                            saveEdit(opt.id);
+                          } else if (e.key === "Escape") {
+                            cancelEdit();
+                          }
+                        }}
+                        autoFocus
+                        maxLength={150}
+                        disabled={rowBusy}
+                        className="h-7 text-xs flex-1"
+                      />
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        onClick={() => saveEdit(opt.id)}
+                        disabled={
+                          !editName.trim() ||
+                          rowBusy ||
+                          editName.trim() === opt.name
+                        }
+                        className="h-7"
+                      >
+                        {rowBusy ? (
+                          <Loader2 className="h-3 w-3 animate-spin" />
+                        ) : (
+                          <Check className="h-3 w-3" />
+                        )}
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        onClick={cancelEdit}
+                        disabled={rowBusy}
+                        className="h-7"
+                      >
+                        <X className="h-3 w-3" />
+                      </Button>
+                    </>
+                  ) : (
+                    <>
+                      <span
+                        className={`flex-1 text-xs ${opt.isActive ? t.text : t.textMuted} ${opt.isActive ? "" : "line-through"}`}
+                      >
+                        {opt.name}
+                      </span>
+                      <div className="flex items-center gap-1.5 mr-2">
+                        <Switch
+                          checked={opt.isActive}
+                          onCheckedChange={(v) =>
+                            handleUpdate(opt.id, { isActive: v })
+                          }
+                          disabled={rowBusy}
+                          aria-label={`${opt.isActive ? "Deactivate" : "Activate"} ${opt.name}`}
+                        />
+                        <span className={`text-[10px] ${t.textMuted} w-12`}>
+                          {opt.isActive ? "Active" : "Inactive"}
+                        </span>
+                      </div>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        onClick={() => startEdit(opt)}
+                        disabled={rowBusy}
+                        className="h-7"
+                      >
+                        <Pencil className="h-3 w-3" />
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        onClick={() => handleDelete(opt)}
+                        disabled={rowBusy}
+                        className={`h-7 ${dark ? "text-red-400" : "text-red-600"}`}
+                      >
+                        {rowBusy ? (
+                          <Loader2 className="h-3 w-3 animate-spin" />
+                        ) : (
+                          <Trash2 className="h-3 w-3" />
+                        )}
+                      </Button>
+                    </>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/DropdownOptionsManager.tsx
+++ b/src/components/settings/DropdownOptionsManager.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState } from "react";
+import { useTheme } from "next-themes";
+import { themeClasses } from "@/lib/theme-classes";
+import {
+  DROPDOWN_CATEGORIES,
+  type DropdownCategory,
+} from "@/lib/dropdown-categories";
+import { DropdownOptionsCard } from "./DropdownOptionsCard";
+
+/**
+ * Sub-tab navigator for every dropdown category. Each sub-tab renders a
+ * `DropdownOptionsCard` for one category (Approved By, Assigned To, etc.).
+ */
+export function DropdownOptionsManager() {
+  const { resolvedTheme } = useTheme();
+  const dark = resolvedTheme === "dark";
+  const t = themeClasses(dark);
+
+  const [active, setActive] = useState<DropdownCategory>(
+    DROPDOWN_CATEGORIES[0].key,
+  );
+
+  const activeMeta =
+    DROPDOWN_CATEGORIES.find((c) => c.key === active) ?? DROPDOWN_CATEGORIES[0];
+
+  return (
+    <div className="space-y-4">
+      {/* Sub-tab strip */}
+      <div
+        role="tablist"
+        aria-label="Dropdown categories"
+        className={`flex flex-wrap gap-1.5 p-1 rounded-lg border ${t.borderLight} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"}`}
+      >
+        {DROPDOWN_CATEGORIES.map((cat) => {
+          const isActive = cat.key === active;
+          return (
+            <button
+              key={cat.key}
+              role="tab"
+              aria-selected={isActive}
+              type="button"
+              onClick={() => setActive(cat.key)}
+              className={`px-2.5 py-1 rounded-md text-[11px] font-medium transition-colors ${
+                isActive
+                  ? dark
+                    ? "bg-neutral-800 text-neutral-100"
+                    : "bg-white text-neutral-900 shadow-sm"
+                  : `${t.textMuted} hover:${t.text}`
+              }`}
+            >
+              {cat.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <DropdownOptionsCard
+        key={activeMeta.key}
+        category={activeMeta.key}
+        label={activeMeta.label}
+        description={activeMeta.description}
+      />
+    </div>
+  );
+}

--- a/src/hooks/useDashboard.ts
+++ b/src/hooks/useDashboard.ts
@@ -6,13 +6,21 @@ import type {
   DashboardSummary,
   MonthlyData,
   TeamMember,
+  ApprovedByOption,
 } from "@/types";
+import type { DropdownCategory } from "@/lib/dropdown-categories";
+
+export type DropdownOptionsByCategory = Partial<
+  Record<DropdownCategory, ApprovedByOption[]>
+>;
 
 interface DashboardData {
   cases: CaseRow[];
   summary: DashboardSummary;
   monthlyData: MonthlyData[];
   team: TeamMember[];
+  approvedByOptions: ApprovedByOption[];
+  dropdownOptions: DropdownOptionsByCategory;
   loading: boolean; // summary + team (fast — powers KPI cards + collections chart)
   casesLoading: boolean; // the heavier /api/cases list (powers the fee records table)
   error: string | null;
@@ -34,6 +42,11 @@ export const useDashboard = (): DashboardData => {
   const [summary, setSummary] = useState<DashboardSummary>(EMPTY_SUMMARY);
   const [monthlyData, setMonthlyData] = useState<MonthlyData[]>([]);
   const [team, setTeam] = useState<TeamMember[]>([]);
+  const [approvedByOptions, setApprovedByOptions] = useState<
+    ApprovedByOption[]
+  >([]);
+  const [dropdownOptions, setDropdownOptions] =
+    useState<DropdownOptionsByCategory>({});
   const [loading, setLoading] = useState(true);
   const [casesLoading, setCasesLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -43,11 +56,14 @@ export const useDashboard = (): DashboardData => {
     setCasesLoading(true);
     setError(null);
 
-    // Summary + team are quick and power the KPI cards and collections chart.
+    // Summary + team + ALL dropdown_options (one round-trip, grouped by
+    // category on the client) power the KPI cards and the inline-editable
+    // dropdowns in the fee records table.
     const summaryTask = (async () => {
-      const [dashRes, teamRes] = await Promise.all([
+      const [dashRes, teamRes, optRes] = await Promise.all([
         fetch("/api/dashboard"),
         fetch("/api/team-members"),
+        fetch("/api/settings/dropdown-options"),
       ]);
       if (!dashRes.ok || !teamRes.ok) {
         throw new Error("Failed to fetch dashboard data");
@@ -57,12 +73,26 @@ export const useDashboard = (): DashboardData => {
       setSummary(dashJson.summary);
       setMonthlyData(dashJson.monthlyData);
       setTeam(teamJson.data);
+      // Options are non-critical: an empty list just yields an empty dropdown.
+      if (optRes.ok) {
+        const optJson = await optRes.json();
+        const all: (ApprovedByOption & { category: DropdownCategory })[] =
+          optJson.data || [];
+        // Group by category for fast per-cell lookup in the table.
+        const grouped: DropdownOptionsByCategory = {};
+        for (const o of all) {
+          (grouped[o.category] ||= []).push(o);
+        }
+        setDropdownOptions(grouped);
+        setApprovedByOptions(grouped.approved_by || []);
+      }
     })();
 
     // The cases list is heavier; let it resolve independently so the table
-    // doesn't hold up the rest of the dashboard.
+    // doesn't hold up the rest of the dashboard. Active (non-closed) only —
+    // closed cases live on /fees-closed.
     const casesTask = (async () => {
-      const casesRes = await fetch("/api/cases");
+      const casesRes = await fetch("/api/cases?isClosed=false");
       if (!casesRes.ok) throw new Error("Failed to fetch cases");
       const casesJson = await casesRes.json();
       setCases(casesJson.data);
@@ -80,6 +110,7 @@ export const useDashboard = (): DashboardData => {
   }, []);
 
   useEffect(() => {
+    // Deliberate fetch-on-mount; fetchAll owns its loading/error state.
     fetchAll();
   }, [fetchAll]);
 
@@ -88,6 +119,8 @@ export const useDashboard = (): DashboardData => {
     summary,
     monthlyData,
     team,
+    approvedByOptions,
+    dropdownOptions,
     loading,
     casesLoading,
     error,

--- a/src/lib/db/mycase.ts
+++ b/src/lib/db/mycase.ts
@@ -1,0 +1,24 @@
+import "server-only";
+import postgres from "postgres";
+
+// Read-only connection to the MyCase mirror database — a separate Neon project,
+// kept in sync from MyCase by an external (n8n) workflow. This app only ever
+// SELECTs from it; never write here.
+const connectionString = process.env.MYCASE_DB_URL!;
+
+// Cached on globalThis so HMR reloads / warm serverless instances reuse the
+// connection instead of paying the TLS handshake each time (see lib/db/index.ts).
+const globalForMyCaseDb = globalThis as unknown as {
+  _myCaseDb?: ReturnType<typeof postgres>;
+};
+
+export const myCaseDb =
+  globalForMyCaseDb._myCaseDb ??
+  postgres(connectionString, {
+    max: 5,
+    prepare: false,
+    idle_timeout: 300,
+    connect_timeout: 10,
+  });
+
+globalForMyCaseDb._myCaseDb = myCaseDb;

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -13,7 +13,7 @@ import {
   jsonb,
   index,
   unique,
-  // uniqueIndex,
+  uniqueIndex,
 } from "drizzle-orm/pg-core";
 import { relations } from "drizzle-orm";
 
@@ -77,8 +77,13 @@ export const cases = pgTable(
 
     // Claim info
     claimType: text("claim_type").array().notNull().default([]),
-    claimTypeLabel: claimTypeEnum("claim_type_label"),
-    levelWon: levelWonEnum("level_won"),
+    // Loosened from pg enum to varchar so admins can manage the option list
+    // via /settings → Dropdown Options without code changes. Legacy values
+    // (T2/T16/T2_T16 and INITIAL/RECON/HEARING/AC/FEDERAL_COURT/FEE_PETITION)
+    // are preserved verbatim; new values (CONC, FEE PETITION, DWB, etc.)
+    // are accepted as-is. Display helpers in formatters.ts tolerate both.
+    claimTypeLabel: varchar("claim_type_label", { length: 50 }),
+    levelWon: varchar("level_won", { length: 50 }),
     t2Decision: decisionOutcomeEnum("t2_decision").default("unknown"),
     t16Decision: decisionOutcomeEnum("t16_decision").default("unknown"),
 
@@ -192,8 +197,10 @@ export const feeRecords = pgTable(
 
     // Assignment & Workflow
     assignedTo: varchar("assigned_to", { length: 100 }),
-    winSheetStatus:
-      winSheetStatusEnum("win_sheet_status").default("not_started"),
+    // Loosened from pg enum to varchar — see note on claimTypeLabel above.
+    winSheetStatus: varchar("win_sheet_status", { length: 50 }).default(
+      "not_started",
+    ),
     winSheetLink: text("win_sheet_link"),
     caseStatus: varchar("case_status", { length: 100 }),
     feesConfirmation: varchar("fees_confirmation", { length: 50 }),
@@ -251,6 +258,11 @@ export const feeRecords = pgTable(
     pifReadyToClose: boolean("pif_ready_to_close").default(false),
     approvedBy: varchar("approved_by", { length: 100 }),
     approvedAt: timestamp("approved_at", { withTimezone: true }),
+    // True when an admin acknowledged the case as closed via the dashboard
+    // (Approved By dropdown → confirm); these rows leave the active dashboard
+    // and appear on /fees-closed.
+    isClosed: boolean("is_closed").notNull().default(false),
+    closedAt: timestamp("closed_at", { withTimezone: true }),
 
     // Fee Computation Metadata
     feeMethod: feeMethodEnum("fee_method").default("fee_agreement"),
@@ -281,6 +293,7 @@ export const feeRecords = pgTable(
     index("idx_fee_records_win_sheet_status").on(table.winSheetStatus),
     index("idx_fee_records_sync_status").on(table.syncStatus),
     index("idx_fee_records_pif").on(table.pifReadyToClose),
+    index("idx_fee_records_is_closed").on(table.isClosed),
   ],
 );
 
@@ -381,6 +394,53 @@ export const teamMembers = pgTable("team_members", {
   role: varchar("role", { length: 100 }).default("collections_specialist"),
   isActive: boolean("is_active").default(true),
   createdAt: timestamp("created_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
+// ============================================================================
+// DROPDOWN_OPTIONS — Admin-managed option lists for the worksheet's dropdown
+// columns (Assigned To, Case Level, Claim Type, Win Sheet Status, Fees
+// Confirmation, Case Status, Approved By). Managed in /settings → Dropdown
+// Options. `category` keys the list; `name` is the displayed option.
+// ============================================================================
+
+export const dropdownOptions = pgTable(
+  "dropdown_options",
+  {
+    id: serial("id").primaryKey(),
+    category: varchar("category", { length: 50 }).notNull(),
+    name: varchar("name", { length: 150 }).notNull(),
+    isActive: boolean("is_active").notNull().default(true),
+    sortOrder: integer("sort_order").notNull().default(0),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("uq_dropdown_options_category_name").on(
+      table.category,
+      table.name,
+    ),
+    index("idx_dropdown_options_category").on(table.category),
+  ],
+);
+
+// Superseded by dropdown_options (category = 'approved_by'). Kept as an
+// unused table so the migration is a clean create (no rename prompt); safe to
+// drop in a later migration once confirmed empty.
+export const approvedByOptions = pgTable("approved_by_options", {
+  id: serial("id").primaryKey(),
+  name: varchar("name", { length: 100 }).notNull().unique(),
+  isActive: boolean("is_active").notNull().default(true),
+  sortOrder: integer("sort_order").notNull().default(0),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
     .notNull()
     .defaultNow(),
 });

--- a/src/lib/dropdown-categories.ts
+++ b/src/lib/dropdown-categories.ts
@@ -1,0 +1,25 @@
+/**
+ * Canonical list of dropdown-option categories that back the fee-collections
+ * worksheet columns. Keys match the `category` column in `dropdown_options`
+ * and are used by both the settings UI (sub-tab navigation) and the
+ * /api/settings/dropdown-options route (validation + filtering).
+ */
+export const DROPDOWN_CATEGORIES = [
+  { key: "approved_by", label: "Approved By", description: "Reviewer who signed off on the fee record." },
+  { key: "assigned_to", label: "Assigned To", description: "Team member handling the case." },
+  { key: "case_level", label: "Case Level", description: "Stage of the case (initial, recon, hearing, etc.)." },
+  { key: "claim_type", label: "Claim Type", description: "Benefit type for the claim (T2, T16, CONC, etc.)." },
+  { key: "win_sheet_status", label: "Win Sheet Status", description: "Win-sheet progress states." },
+  { key: "fees_confirmation", label: "Fees Confirmation", description: "Final fee disposition labels." },
+  { key: "case_status", label: "Case Status", description: "Workflow status shown in the dashboard." },
+] as const;
+
+export type DropdownCategory = (typeof DROPDOWN_CATEGORIES)[number]["key"];
+
+export const DROPDOWN_CATEGORY_KEYS = DROPDOWN_CATEGORIES.map((c) => c.key) as readonly DropdownCategory[];
+
+export const isDropdownCategory = (value: string): value is DropdownCategory =>
+  (DROPDOWN_CATEGORY_KEYS as readonly string[]).includes(value);
+
+export const getDropdownCategoryLabel = (key: DropdownCategory): string =>
+  DROPDOWN_CATEGORIES.find((c) => c.key === key)?.label ?? key;

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -19,15 +19,22 @@ export const fmtDate = (d: string | null | undefined): string => {
   return `${m}/${day}/${y}`;
 };
 
-// Claim type display: T2_T16 → CONC, T2/T16 → CONC
+// Claim type display: T2_T16 → CONC, T2/T16 → CONC.
+// Worksheet-style values (CONC, DWB, DAC, AUX) pass through unchanged so
+// rows saved directly via the dashboard dropdowns render verbatim.
 export const fmtClaim = (claim: string): string => {
   if (claim === "T2_T16" || claim === "T2/T16") return "CONC";
   return claim;
 };
 
-// Win sheet status labels matching the spreadsheet
-// DB has granular statuses → sheet shows simplified labels
+// Win sheet status labels matching the spreadsheet.
+// The DB used to enforce a 7-state enum; it's now varchar so the dropdown
+// values from /settings can be saved directly. The lookup covers BOTH the
+// legacy enum keys (`not_started`, `paid_in_full`, …) and the
+// worksheet-friendly labels (`Started`, `Finished`) — anything else falls
+// back to the raw string in the cell.
 export const STATUS_LABELS: Record<string, string> = {
+  // Legacy enum values
   not_started: "Not Started",
   started: "Started",
   in_progress: "Started", // sheet groups these as "Started"
@@ -35,6 +42,10 @@ export const STATUS_LABELS: Record<string, string> = {
   partially_paid: "Finished", // some fees received = Finished in sheet
   paid_in_full: "Finished", // all fees received = Finished
   closed: "Closed",
+  // Worksheet-direct values (pass-through)
+  Started: "Started",
+  Finished: "Finished",
+  Closed: "Closed",
 };
 
 // Detailed status for case detail page (keeps granularity)
@@ -55,7 +66,9 @@ export const SYNC_LABELS: Record<string, string> = {
   error: "Error",
 };
 
-// Level display
+// Level display. Accepts both the legacy enum values (FEE_PETITION,
+// FEDERAL_COURT, …) and the worksheet-style label ("FEE PETITION") so
+// dropdown saves and historical rows both render cleanly.
 export const LEVEL_LABELS: Record<string, string> = {
   INITIAL: "Initial",
   RECON: "Recon",
@@ -63,6 +76,7 @@ export const LEVEL_LABELS: Record<string, string> = {
   AC: "AC",
   FEDERAL_COURT: "Fed Court",
   FEE_PETITION: "Fee Petition",
+  "FEE PETITION": "Fee Petition",
 };
 
 const STATUS_FALLBACK: [string, string] = [
@@ -74,16 +88,22 @@ export const getStatusColor = (
   status: WinSheetStatus | string,
   dark: boolean,
 ): string => {
+  const FINISHED_COLORS: [string, string] = [
+    "bg-emerald-100 text-emerald-700",
+    "bg-emerald-900/40 text-emerald-400",
+  ];
+  const STARTED_COLORS: [string, string] = [
+    "bg-blue-100 text-blue-700",
+    "bg-blue-900/40 text-blue-400",
+  ];
   const map: Record<string, [string, string]> = {
-    paid_in_full: [
-      "bg-emerald-100 text-emerald-700",
-      "bg-emerald-900/40 text-emerald-400",
-    ],
+    // Legacy enum values
+    paid_in_full: FINISHED_COLORS,
     partially_paid: [
       "bg-amber-100 text-amber-700",
       "bg-amber-900/40 text-amber-400",
     ],
-    started: ["bg-blue-100 text-blue-700", "bg-blue-900/40 text-blue-400"],
+    started: STARTED_COLORS,
     in_progress: [
       "bg-orange-100 text-orange-700",
       "bg-orange-900/40 text-orange-400",
@@ -97,6 +117,13 @@ export const getStatusColor = (
       "bg-neutral-800 text-neutral-400",
     ],
     not_started: [
+      "bg-neutral-100 text-neutral-500",
+      "bg-neutral-800 text-neutral-400",
+    ],
+    // Worksheet-direct values
+    Started: STARTED_COLORS,
+    Finished: FINISHED_COLORS,
+    Closed: [
       "bg-neutral-100 text-neutral-500",
       "bg-neutral-800 text-neutral-400",
     ],

--- a/src/lib/mycase-proxy.ts
+++ b/src/lib/mycase-proxy.ts
@@ -8,6 +8,8 @@ import "server-only";
 
 const WEBHOOK_URL = process.env.N8N_MYCASE_DOCS_WEBHOOK_URL;
 const WEBHOOK_TOKEN = process.env.N8N_MYCASE_DOCS_WEBHOOK_TOKEN;
+// Separate webhook for single-document downloads; shares the same auth token.
+const DOC_FILE_WEBHOOK_URL = process.env.N8N_MYCASE_DOC_FILE_WEBHOOK_URL;
 const AUTH_HEADER = "Fee-Collections-Docs-App-Token";
 
 // Shape returned by MyCase's GET /v1/cases/{id}/documents endpoint.
@@ -69,6 +71,80 @@ export async function fetchCaseDocuments(
     return flattenFolderTree(json);
   }
   return [];
+}
+
+/**
+ * Resolves a single MyCase document to a directly-openable file URL.
+ *
+ * MyCase's `GET /v1/documents/{id}/data` returns a 302 redirect to a temporary
+ * (presigned) file URL. The n8n webhook calls that endpoint with redirects
+ * disabled and returns the `Location` header, which we hand back to the browser.
+ */
+export async function fetchDocumentDownloadUrl(
+  documentId: number,
+): Promise<string> {
+  if (!DOC_FILE_WEBHOOK_URL || !WEBHOOK_TOKEN) {
+    throw new Error(
+      "MyCase document-file webhook is not configured (N8N_MYCASE_DOC_FILE_WEBHOOK_URL / N8N_MYCASE_DOCS_WEBHOOK_TOKEN)",
+    );
+  }
+
+  const res = await fetch(DOC_FILE_WEBHOOK_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      [AUTH_HEADER]: WEBHOOK_TOKEN,
+    },
+    body: JSON.stringify({ id: documentId }),
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `MyCase document-file webhook returned ${res.status}${text ? `: ${text.slice(0, 200)}` : ""}`,
+    );
+  }
+
+  const json = await res.json();
+  const url = pickUrl(json);
+
+  if (!url) {
+    throw new Error(
+      `MyCase document-file webhook did not return a file URL. Got: ${JSON.stringify(json).slice(0, 400)}`,
+    );
+  }
+  return url;
+}
+
+// Recursively dig an http(s) URL out of whatever shape the webhook returns:
+// a bare string, { url } / { location } / { Location }, a wrapped { data } /
+// { json } / { headers: { location } }, or an array of any of those.
+function pickUrl(value: unknown): string | null {
+  if (!value) return null;
+  if (typeof value === "string") {
+    return value.startsWith("http") ? value : null;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = pickUrl(item);
+      if (found) return found;
+    }
+    return null;
+  }
+  if (typeof value === "object") {
+    const o = value as Record<string, unknown>;
+    return (
+      pickUrl(o.url) ??
+      pickUrl(o.location) ??
+      pickUrl(o.Location) ??
+      pickUrl(o.headers) ??
+      pickUrl(o.data) ??
+      pickUrl(o.json) ??
+      null
+    );
+  }
+  return null;
 }
 
 // ---- helpers ----------------------------------------------------------------

--- a/src/lib/mycase-proxy.ts
+++ b/src/lib/mycase-proxy.ts
@@ -1,0 +1,109 @@
+import "server-only";
+
+/**
+ * Calls the n8n webhook that proxies MyCase Open API. MyCase OAuth credentials
+ * live in n8n; this app never holds them. The webhook is protected with a
+ * static header secret (`Fee-Collections-Docs-App-Token`) so the URL alone isn't enough to call it.
+ */
+
+const WEBHOOK_URL = process.env.N8N_MYCASE_DOCS_WEBHOOK_URL;
+const WEBHOOK_TOKEN = process.env.N8N_MYCASE_DOCS_WEBHOOK_TOKEN;
+const AUTH_HEADER = "Fee-Collections-Docs-App-Token";
+
+// Shape returned by MyCase's GET /v1/cases/{id}/documents endpoint.
+export type MyCaseDocument = {
+  id: number;
+  name: string;
+  filename: string | null;
+  path: string | null;
+  description: string | null;
+  assigned_date: string | null;
+  case: { id: number } | null;
+  created_at: string | null;
+  updated_at: string | null;
+  self_url: string | null;
+  folder: { id: number } | null;
+};
+
+export async function fetchCaseDocuments(
+  caseId: number,
+): Promise<MyCaseDocument[]> {
+  if (!WEBHOOK_URL || !WEBHOOK_TOKEN) {
+    throw new Error(
+      "MyCase documents webhook is not configured (N8N_MYCASE_DOCS_WEBHOOK_URL / N8N_MYCASE_DOCS_WEBHOOK_TOKEN)",
+    );
+  }
+
+  const res = await fetch(WEBHOOK_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      [AUTH_HEADER]: WEBHOOK_TOKEN,
+    },
+    // The n8n "Get Case Documents" HTTP node references {{ $json.id }}, so
+    // pass the case id under `id` in the request body.
+    body: JSON.stringify({ id: caseId }),
+    // Document lists can change as MyCase syncs; never cache.
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `MyCase documents webhook returned ${res.status}${text ? `: ${text.slice(0, 200)}` : ""}`,
+    );
+  }
+
+  const json = await res.json();
+
+  // Tolerate three response shapes the n8n workflow might emit:
+  //  (a) bare array of docs                        — simplest flat list
+  //  (b) { data: [...] } / { items: [...] }        — wrapped flat list
+  //  (c) { folders: [...], unfiled_documents: [] } — the full folder-tree
+  //      crawl (current workflow). Flatten the tree to a flat doc list; each
+  //      doc still carries its `path` so the dialog shows folder context.
+  if (Array.isArray(json)) return json as MyCaseDocument[];
+  if (Array.isArray(json?.data)) return json.data as MyCaseDocument[];
+  if (Array.isArray(json?.items)) return json.items as MyCaseDocument[];
+  if (Array.isArray(json?.folders) || Array.isArray(json?.unfiled_documents)) {
+    return flattenFolderTree(json);
+  }
+  return [];
+}
+
+// ---- helpers ----------------------------------------------------------------
+
+type TreeFolder = {
+  id: number;
+  name: string | null;
+  documents?: MyCaseDocument[];
+  subfolders?: TreeFolder[];
+};
+
+type TreeResponse = {
+  folders?: TreeFolder[];
+  unfiled_documents?: MyCaseDocument[];
+};
+
+function flattenFolderTree(tree: TreeResponse): MyCaseDocument[] {
+  const out: MyCaseDocument[] = [];
+  const seen = new Set<number>();
+
+  const push = (d: MyCaseDocument, folder: TreeFolder | null) => {
+    if (d?.id == null || seen.has(d.id)) return;
+    seen.add(d.id);
+    out.push({
+      ...d,
+      folder: d.folder ?? (folder ? { id: folder.id } : null),
+    });
+  };
+
+  const walk = (folder: TreeFolder) => {
+    for (const d of folder.documents ?? []) push(d, folder);
+    for (const sf of folder.subfolders ?? []) walk(sf);
+  };
+
+  for (const root of tree.folders ?? []) walk(root);
+  for (const d of tree.unfiled_documents ?? []) push(d, null);
+  return out;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -63,6 +63,10 @@ export interface CaseRow {
   // Workflow
   pif: PifStatus;
   approvedBy: string | null;
+  feesConfirmation: string | null;
+  caseStatus: string | null;
+  isClosed: boolean;
+  closedAt: string | null;
   update: string;
   sync: SyncStatus;
 
@@ -75,6 +79,14 @@ export interface CaseRow {
 
   // Notes
   notesCount: number;
+}
+
+// Admin-managed option for the dashboard's "Approved By" dropdown (/settings).
+export interface ApprovedByOption {
+  id: number;
+  name: string;
+  isActive: boolean;
+  sortOrder: number;
 }
 
 export interface DashboardSummary {


### PR DESCRIPTION
## Summary
- New **MyCase** read-only page + per-case Documents dialog + inline doc viewer (via n8n webhook proxy)
- New **Fees Closed** workflow: cases with Fees Confirmation = "Paid In Full" prompt for close, move to a dedicated `/fees-closed` page, and can be reopened back to the dashboard
- New **Dropdown Options** settings tab — admins manage all 7 worksheet column dropdowns (Assigned To, Case Level, Claim Type, Win Sheet Status, Fees Confirmation, Case Status, Approved By); every column is now an inline-editable dropdown on the dashboard

## MyCase integration
- `/mycase` page lists 94 fully-favorable Social Security Hogan Smith cases from the MyCase mirror DB
- Per-case **Documents** dialog calls n8n webhook (`auto.simple.biz`) which brokers MyCase OAuth and returns a document list
- Inline document viewer renders supported types via presigned URL
- n8n header auth via `Fee-Collections-Docs-App-Token`

## Fees Closed workflow
- `fee_records.is_closed` (boolean) + `closed_at` (timestamptz) added in migration `0010`
- New `/fees-closed` page (sidebar entry: "Fees Closed", icon `CheckCircle2`) renders the same fee-records table in read-only `mode="closed"`
- Dashboard summary + active list filter `COALESCE(is_closed, false) = false`
- `AcknowledgeAndCloseDialog` generalized — takes `triggerField` / `triggerValue` / `triggerLabel`, so any future dropdown trigger can reuse it
- Trigger: picking **Fees Confirmation = "Paid In Full"** (case-insensitive) opens the dialog. "Yes" → `isClosed=true` + `closed_at=NOW()`; "No" → saves the value but stays on dashboard; "Cancel" → reverts
- **Reopen** button on `/fees-closed` rows: PATCHes `isClosed=false` (API auto-NULLs `closed_at`) and clears Fees Confirmation so the case doesn't immediately re-prompt

## Dropdown Options settings
- New `dropdown_options` table (`category`, `name`, `is_active`, `sort_order`) seeded with the worksheet's defaults in migration `0011` (~70 rows across 7 categories, `ON CONFLICT DO NOTHING`)
- New API: `GET/POST /api/settings/dropdown-options` + `PATCH/DELETE /api/settings/dropdown-options/[id]`, category validated against `src/lib/dropdown-categories.ts`
- New **Dropdown Options** tab on `/settings` with sub-tabs per category (replaces the prior "Approvals" tab)
- All 7 dashboard columns now inline `<select>` cells sourced from `dropdown_options`. Each cell preserves its current value as a fallback `<option>` so legacy rows still render even if the option list doesn't include them
- Old `approved_by_options` table + its routes + its card are removed from the codebase; the table itself stays in the DB as orphan storage (its rows were carried into `dropdown_options` via migration `0011`)

## Schema loosening (migration `0012`)
- `cases.claim_type_label`, `cases.level_won`, `fee_records.win_sheet_status` converted from `pgEnum` → `varchar(50)` via `ALTER COLUMN … USING …::text`
- Reason: the `dropdown_options` table is now the canonical source of truth — hardcoded enums would force a migration every time an admin wants a new option
- Display helpers (`STATUS_LABELS`, `LEVEL_LABELS`, `fmtClaim`, `getStatusColor`) accept both the legacy enum strings (`T2_T16`, `FEE_PETITION`, `paid_in_full`) and the worksheet-direct labels (`CONC`, `FEE PETITION`, `Finished`) — existing data renders unchanged
- `/api/fee-petitions` filter widened to `WHERE level_won IN ('FEE_PETITION', 'FEE PETITION')` so the petitions page picks up rows tagged via either form

## UI polish
- Dashboard table: **Case Name** and **Assigned** columns are now frozen (`position: sticky`) during horizontal scroll; the "Case Info" group label stays pinned above them via a split colSpan
- New `scripts/preflight-migrate.mjs` — lists applied vs pending migrations against any `DATABASE_URL`, useful before `npm run db:migrate` on prod

## Database
**Prod has already been migrated** to `0012` (Neon, verified via the preflight + a post-migrate check). The migrations are idempotent (`ON CONFLICT DO NOTHING` on the seed) so re-running is safe.

Migrations included:
- `0010_fees_closed_and_approved_by_options` — adds `is_closed`, `closed_at`, and the (now-orphan) `approved_by_options` table
- `0011_dropdown_options_and_seed` — creates `dropdown_options` + seeds ~70 worksheet defaults
- `0012_loosen_enum_columns_to_varchar` — converts the three enum columns to varchar (preserves all existing data verbatim)

## Test plan
- [ ] `/mycase` lists cases; opening a case's Documents dialog returns a list; clicking a document renders the viewer
- [ ] Dashboard table loads with all 7 columns as inline dropdowns
- [ ] Case Name + Assigned stay frozen while scrolling right; "Case Info" group header stays above them
- [ ] Picking any Assigned / Approved By / Case Level / Claim Type / Win Sheet Status / Case Status value saves inline (no modal); activity log shows the change
- [ ] Picking Fees Confirmation = "Paid In Full" opens the close-confirmation dialog
- [ ] "Yes, mark closed" → case leaves the dashboard, appears on `/fees-closed`
- [ ] "No, keep on dashboard" → case stays on dashboard with Fees Confirmation = Paid In Full
- [ ] "Cancel" → no save; dropdown reverts to previous value
- [ ] Clicking **Reopen** on `/fees-closed` → confirm prompt → case returns to dashboard with Fees Confirmation cleared
- [ ] `/settings` → Dropdown Options tab → add/rename/deactivate/delete options in each sub-tab
- [ ] Settings changes reflect in the dashboard dropdowns on next load
- [ ] Legacy rows (with enum values like `T2_T16`, `FEE_PETITION`, `paid_in_full`) still render their display labels correctly