### PR TITLE
feat: send welcome email on new user creation

### DIFF
--- a/drizzle/0014_faithful_aqueduct.sql
+++ b/drizzle/0014_faithful_aqueduct.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users" ADD COLUMN "must_change_password" boolean DEFAULT false NOT NULL;

--- a/drizzle/meta/0014_snapshot.json
+++ b/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,2669 @@
+{
+  "id": "8fbb22e6-e793-4333-b78f-a87ba41027e4",
+  "prevId": "6b80f5eb-140d-4892-aecd-e3197eb77c8a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_log": {
+      "name": "activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_record_id": {
+          "name": "fee_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_activity_log_case_id": {
+          "name": "idx_activity_log_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_log_created_at": {
+          "name": "idx_activity_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_log_case_id_cases_client_id_fk": {
+          "name": "activity_log_case_id_cases_client_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_log_fee_record_id_fee_records_id_fk": {
+          "name": "activity_log_fee_record_id_fee_records_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "fee_records",
+          "columnsFrom": [
+            "fee_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_settings": {
+      "name": "app_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approved_by_options": {
+      "name": "approved_by_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "approved_by_options_name_unique": {
+          "name": "approved_by_options_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cases": {
+      "name": "cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dob": {
+          "name": "dob",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last4_ssn": {
+          "name": "last4_ssn",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_type": {
+          "name": "claim_type",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "claim_type_label": {
+          "name": "claim_type_label",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level_won": {
+          "name": "level_won",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "t2_decision": {
+          "name": "t2_decision",
+          "type": "decision_outcome_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'unknown'"
+        },
+        "t16_decision": {
+          "name": "t16_decision",
+          "type": "decision_outcome_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'unknown'"
+        },
+        "application_date": {
+          "name": "application_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alleged_onset_date": {
+          "name": "alleged_onset_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_date": {
+          "name": "approval_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_date": {
+          "name": "closure_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_held_date": {
+          "name": "hearing_held_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_scheduled_date": {
+          "name": "hearing_scheduled_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_scheduled_datetime": {
+          "name": "hearing_scheduled_datetime",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_timezone": {
+          "name": "hearing_timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "office_with_jurisdiction": {
+          "name": "office_with_jurisdiction",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alj_first_name": {
+          "name": "alj_first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alj_last_name": {
+          "name": "alj_last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimant_location": {
+          "name": "claimant_location",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representative_location": {
+          "name": "representative_location",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_expert": {
+          "name": "medical_expert",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vocational_expert": {
+          "name": "vocational_expert",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_file_link": {
+          "name": "all_file_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exhibits_file_link": {
+          "name": "exhibits_file_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_file_updated_at": {
+          "name": "all_file_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exhibits_file_updated_at": {
+          "name": "exhibits_file_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_ssn": {
+          "name": "full_ssn",
+          "type": "varchar(11)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_diagnosis": {
+          "name": "primary_diagnosis",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_diagnosis_code": {
+          "name": "primary_diagnosis_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secondary_diagnosis": {
+          "name": "secondary_diagnosis",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secondary_diagnosis_code": {
+          "name": "secondary_diagnosis_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allegations": {
+          "name": "allegations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blind_dli": {
+          "name": "blind_dli",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firm_name": {
+          "name": "firm_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firm_ein": {
+          "name": "firm_ein",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_office": {
+          "name": "hearing_office",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representatives": {
+          "name": "representatives",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_history": {
+          "name": "decision_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_type": {
+          "name": "report_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expedited_case": {
+          "name": "expedited_case",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_of_case": {
+          "name": "status_of_case",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_date": {
+          "name": "status_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_date": {
+          "name": "request_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_date": {
+          "name": "receipt_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_date_assigned": {
+          "name": "first_date_assigned",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_fqr_starts": {
+          "name": "date_fqr_starts",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_insured": {
+          "name": "last_insured",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_created_at": {
+          "name": "source_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_updated_at": {
+          "name": "source_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ere_session_date": {
+          "name": "last_ere_session_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status_report_date": {
+          "name": "last_status_report_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documents_last_added_at": {
+          "name": "documents_last_added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invalid_ssn": {
+          "name": "invalid_ssn",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ssn_encrypted": {
+          "name": "ssn_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_link": {
+          "name": "case_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_pulled_at": {
+          "name": "last_pulled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_cases_client_id": {
+          "name": "idx_cases_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_external_id": {
+          "name": "idx_cases_external_id",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_claim_type_label": {
+          "name": "idx_cases_claim_type_label",
+          "columns": [
+            {
+              "expression": "claim_type_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_approval_date": {
+          "name": "idx_cases_approval_date",
+          "columns": [
+            {
+              "expression": "approval_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_last_name": {
+          "name": "idx_cases_last_name",
+          "columns": [
+            {
+              "expression": "last_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cases_client_id_unique": {
+          "name": "cases_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chronicle_documents": {
+      "name": "chronicle_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mycase_client_id": {
+          "name": "mycase_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chronicle_client_id": {
+          "name": "chronicle_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chronicle_document_id": {
+          "name": "chronicle_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_name": {
+          "name": "document_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_category": {
+          "name": "document_category",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_document": {
+          "name": "raw_document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chronicle_documents_case_id": {
+          "name": "idx_chronicle_documents_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chronicle_documents_case_id_cases_client_id_fk": {
+          "name": "chronicle_documents_case_id_cases_client_id_fk",
+          "tableFrom": "chronicle_documents",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chronicle_documents_case_id_chronicle_document_id_unique": {
+          "name": "chronicle_documents_case_id_chronicle_document_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id",
+            "chronicle_document_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_metrics": {
+      "name": "daily_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_date": {
+          "name": "metric_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ssa_calls": {
+          "name": "ssa_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "client_calls_ib": {
+          "name": "client_calls_ib",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "client_calls_ob": {
+          "name": "client_calls_ob",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_metrics_agent": {
+          "name": "idx_daily_metrics_agent",
+          "columns": [
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_metrics_date": {
+          "name": "idx_daily_metrics_date",
+          "columns": [
+            {
+              "expression": "metric_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_metrics_agent_name_team_members_name_fk": {
+          "name": "daily_metrics_agent_name_team_members_name_fk",
+          "tableFrom": "daily_metrics",
+          "tableTo": "team_members",
+          "columnsFrom": [
+            "agent_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dropdown_options": {
+      "name": "dropdown_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(150)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_dropdown_options_category_name": {
+          "name": "uq_dropdown_options_category_name",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dropdown_options_category": {
+          "name": "idx_dropdown_options_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_cap_history": {
+      "name": "fee_cap_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cap_amount": {
+          "name": "cap_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fee_cap_history_effective_date_unique": {
+          "name": "fee_cap_history_effective_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "effective_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_petitions": {
+      "name": "fee_petitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "noa": {
+          "name": "noa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "time_delineation": {
+          "name": "time_delineation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "fee_petition_doc": {
+          "name": "fee_petition_doc",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ltr_to_clmt": {
+          "name": "ltr_to_clmt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ltr_to_clmt_with_signature": {
+          "name": "ltr_to_clmt_with_signature",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ltr_to_alj": {
+          "name": "ltr_to_alj",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "fax_conf_fee_pet": {
+          "name": "fax_conf_fee_pet",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "update_note": {
+          "name": "update_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fee_petitions_case_id": {
+          "name": "idx_fee_petitions_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fee_petitions_case_id_cases_client_id_fk": {
+          "name": "fee_petitions_case_id_cases_client_id_fk",
+          "tableFrom": "fee_petitions",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fee_petitions_case_id_unique": {
+          "name": "fee_petitions_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_records": {
+      "name": "fee_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "win_sheet_status": {
+          "name": "win_sheet_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'not_started'"
+        },
+        "win_sheet_link": {
+          "name": "win_sheet_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "win_sheet_link_text": {
+          "name": "win_sheet_link_text",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_status": {
+          "name": "case_status",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fees_confirmation": {
+          "name": "fees_confirmation",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_assigned_to_agent": {
+          "name": "date_assigned_to_agent",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "t16_retro": {
+          "name": "t16_retro",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_fee_due": {
+          "name": "t16_fee_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_fee_received": {
+          "name": "t16_fee_received",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_pending": {
+          "name": "t16_pending",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_fee_received_date": {
+          "name": "t16_fee_received_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "t2_retro": {
+          "name": "t2_retro",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_fee_due": {
+          "name": "t2_fee_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_fee_received": {
+          "name": "t2_fee_received",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_pending": {
+          "name": "t2_pending",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_fee_received_date": {
+          "name": "t2_fee_received_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aux_retro": {
+          "name": "aux_retro",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_fee_due": {
+          "name": "aux_fee_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_fee_received": {
+          "name": "aux_fee_received",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_pending": {
+          "name": "aux_pending",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_fee_received_date": {
+          "name": "aux_fee_received_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_retro_due": {
+          "name": "total_retro_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "total_fees_expected": {
+          "name": "total_fees_expected",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "total_fees_paid": {
+          "name": "total_fees_paid",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "pif_ready_to_close": {
+          "name": "pif_ready_to_close",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_closed": {
+          "name": "is_closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_method": {
+          "name": "fee_method",
+          "type": "fee_method_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'fee_agreement'"
+        },
+        "applicable_fee_cap": {
+          "name": "applicable_fee_cap",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'9200'"
+        },
+        "fee_cap_applied": {
+          "name": "fee_cap_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "fee_computed": {
+          "name": "fee_computed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "fee_computed_at": {
+          "name": "fee_computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "days_after_approval": {
+          "name": "days_after_approval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_category": {
+          "name": "approval_category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fees_status": {
+          "name": "fees_status",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "week_assigned_to_agent": {
+          "name": "week_assigned_to_agent",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "month_assigned_to_agent": {
+          "name": "month_assigned_to_agent",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "sync_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'not_synced'"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mycase_record_id": {
+          "name": "mycase_record_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fee_records_case_id": {
+          "name": "idx_fee_records_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_assigned_to": {
+          "name": "idx_fee_records_assigned_to",
+          "columns": [
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_win_sheet_status": {
+          "name": "idx_fee_records_win_sheet_status",
+          "columns": [
+            {
+              "expression": "win_sheet_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_sync_status": {
+          "name": "idx_fee_records_sync_status",
+          "columns": [
+            {
+              "expression": "sync_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_pif": {
+          "name": "idx_fee_records_pif",
+          "columns": [
+            {
+              "expression": "pif_ready_to_close",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_is_closed": {
+          "name": "idx_fee_records_is_closed",
+          "columns": [
+            {
+              "expression": "is_closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fee_records_case_id_cases_client_id_fk": {
+          "name": "fee_records_case_id_cases_client_id_fk",
+          "tableFrom": "fee_records",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fee_records_case_id_unique": {
+          "name": "fee_records_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mycase_notice_documents": {
+      "name": "mycase_notice_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mycase_client_id": {
+          "name": "mycase_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mycase_document_id": {
+          "name": "mycase_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_name": {
+          "name": "document_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_pattern": {
+          "name": "matched_pattern",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_document": {
+          "name": "raw_document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mycase_notice_documents_case_id": {
+          "name": "idx_mycase_notice_documents_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mycase_notice_documents_case_id_cases_client_id_fk": {
+          "name": "mycase_notice_documents_case_id_cases_client_id_fk",
+          "tableFrom": "mycase_notice_documents",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mycase_notice_documents_case_id_mycase_document_id_unique": {
+          "name": "mycase_notice_documents_case_id_mycase_document_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id",
+            "mycase_document_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "notification_severity_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notifications_type": {
+          "name": "idx_notifications_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_is_read": {
+          "name": "idx_notifications_is_read",
+          "columns": [
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_created_at": {
+          "name": "idx_notifications_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_agent": {
+          "name": "idx_notifications_agent",
+          "columns": [
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_case_id_cases_client_id_fk": {
+          "name": "notifications_case_id_cases_client_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.overpaid_cases": {
+      "name": "overpaid_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "op_ltr_received": {
+          "name": "op_ltr_received",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checks_cleared": {
+          "name": "checks_cleared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "update_note": {
+          "name": "update_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_overpaid_cases_case_id": {
+          "name": "idx_overpaid_cases_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "overpaid_cases_case_id_cases_client_id_fk": {
+          "name": "overpaid_cases_case_id_cases_client_id_fk",
+          "tableFrom": "overpaid_cases",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "overpaid_cases_case_id_unique": {
+          "name": "overpaid_cases_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pull_logs": {
+      "name": "pull_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_records_pulled": {
+          "name": "total_records_pulled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "new_cases": {
+          "name": "new_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_cases": {
+          "name": "updated_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "errors": {
+          "name": "errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_at": {
+          "name": "triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_logs": {
+      "name": "sync_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cases": {
+          "name": "total_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "case_ids": {
+          "name": "case_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_at": {
+          "name": "triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_sync_logs_triggered_at": {
+          "name": "idx_sync_logs_triggered_at",
+          "columns": [
+            {
+              "expression": "triggered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'collections_specialist'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_members_name_unique": {
+          "name": "team_members_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_details": {
+      "name": "user_details",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chronicle_id": {
+          "name": "chronicle_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line_1": {
+          "name": "address_line_1",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line_2": {
+          "name": "address_line_2",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip_code": {
+          "name": "zip_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cell_phone": {
+          "name": "cell_phone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssn": {
+          "name": "ssn",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssn_last4": {
+          "name": "ssn_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age_at_approval": {
+          "name": "age_at_approval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "place_of_birth": {
+          "name": "place_of_birth",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mothers_first_name_and_maiden_name": {
+          "name": "mothers_first_name_and_maiden_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fathers_first_and_last_name": {
+          "name": "fathers_first_and_last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_details_case_id": {
+          "name": "idx_user_details_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_details_case_id_cases_client_id_fk": {
+          "name": "user_details_case_id_cases_client_id_fk",
+          "tableFrom": "user_details",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_details_case_id_unique": {
+          "name": "user_details_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        },
+        "user_details_chronicle_id_unique": {
+          "name": "user_details_chronicle_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chronicle_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.claim_type_enum": {
+      "name": "claim_type_enum",
+      "schema": "public",
+      "values": [
+        "T2",
+        "T16",
+        "T2_T16"
+      ]
+    },
+    "public.decision_outcome_enum": {
+      "name": "decision_outcome_enum",
+      "schema": "public",
+      "values": [
+        "fully_favorable",
+        "partially_favorable",
+        "unfavorable",
+        "dismissed",
+        "remand",
+        "unknown"
+      ]
+    },
+    "public.fee_method_enum": {
+      "name": "fee_method_enum",
+      "schema": "public",
+      "values": [
+        "fee_agreement",
+        "fee_petition"
+      ]
+    },
+    "public.level_won_enum": {
+      "name": "level_won_enum",
+      "schema": "public",
+      "values": [
+        "INITIAL",
+        "RECON",
+        "HEARING",
+        "AC",
+        "FEDERAL_COURT",
+        "FEE_PETITION"
+      ]
+    },
+    "public.notification_severity_enum": {
+      "name": "notification_severity_enum",
+      "schema": "public",
+      "values": [
+        "info",
+        "warning",
+        "critical"
+      ]
+    },
+    "public.notification_type_enum": {
+      "name": "notification_type_enum",
+      "schema": "public",
+      "values": [
+        "case_aging",
+        "fee_payment",
+        "call_target_missed",
+        "case_assigned"
+      ]
+    },
+    "public.sync_status_enum": {
+      "name": "sync_status_enum",
+      "schema": "public",
+      "values": [
+        "not_synced",
+        "syncing",
+        "synced",
+        "error"
+      ]
+    },
+    "public.user_role_enum": {
+      "name": "user_role_enum",
+      "schema": "public",
+      "values": [
+        "admin",
+        "member",
+        "system_admin"
+      ]
+    },
+    "public.win_sheet_status_enum": {
+      "name": "win_sheet_status_enum",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "started",
+        "in_progress",
+        "pending_payment",
+        "partially_paid",
+        "paid_in_full",
+        "closed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1779897512004,
       "tag": "0013_add_sheets_sync",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1780930560930,
+      "tag": "0014_faithful_aqueduct",
+      "breakpoints": true
     }
   ]
 }

--- a/n8n/new-user-email-workflow.json
+++ b/n8n/new-user-email-workflow.json
@@ -1,0 +1,92 @@
+{
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "hsl-new-user-email",
+        "responseMode": "lastNode",
+        "options": {}
+      },
+      "id": "5f29bc21-af23-4b49-8c0d-dff848b956a4",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [
+        128,
+        720
+      ],
+      "webhookId": "55555555-5555-5555-5555-555555555555"
+    },
+    {
+      "parameters": {
+        "jsCode": "const body = $input.first().json.body ?? $input.first().json;\n\nconst ROLE_LABELS = {\n  system_admin: 'System Admin',\n  admin: 'Admin',\n  member: 'Member',\n};\n\nconst ROLE_BADGE_COLORS = {\n  system_admin: 'background-color:#fef3c7;color:#92400e;',\n  admin: 'background-color:#dbeafe;color:#1e40af;',\n  member: 'background-color:#e0e7ff;color:#3730a3;',\n};\n\nconst humanize = (s) => String(s).split('_').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');\n\nconst email       = body.email ?? '';\nconst password    = body.password ?? '';\nconst displayName = body.name || email;\nconst roleLabel   = ROLE_LABELS[body.role] ?? humanize(body.role || 'member');\nconst roleBadge   = ROLE_BADGE_COLORS[body.role] ?? 'background-color:#f1f5f9;color:#475569;';\n\nconst SIGN_IN_URL = 'https://hsl-fee-collections-dashboard-ten.vercel.app/';\n\nconst htmlBody = `<!DOCTYPE html>\n<html lang='en'>\n<head>\n  <meta charset='UTF-8'>\n  <meta name='viewport' content='width=device-width,initial-scale=1.0'>\n  <title>Your HSL Dashboard Access</title>\n</head>\n<body style='margin:0;padding:0;background-color:#f1f5f9;font-family:-apple-system,BlinkMacSystemFont,Roboto,Oxygen,sans-serif;'>\n\n  <table width='100%' cellpadding='0' cellspacing='0' style='background-color:#f1f5f9;padding:48px 16px;'>\n    <tr>\n      <td align='center'>\n        <table width='100%' cellpadding='0' cellspacing='0' style='max-width:560px;'>\n\n          <!-- Header -->\n          <tr>\n            <td style='background-color:#0f172a;border-radius:14px 14px 0 0;padding:36px 44px 32px;text-align:center;'>\n              <p style='margin:0 0 8px;font-size:10px;font-weight:700;letter-spacing:0.18em;text-transform:uppercase;color:#475569;'>Hogan Smith Legal</p>\n              <h1 style='margin:0 0 6px;font-size:22px;font-weight:700;color:#f8fafc;letter-spacing:-0.02em;line-height:1.2;'>Fee Collections Dashboard</h1>\n              <p style='margin:0;font-size:12px;color:#64748b;letter-spacing:0.02em;'>Account Access &nbsp;&middot;&nbsp; Welcome Email</p>\n            </td>\n          </tr>\n\n          <!-- Accent bar -->\n          <tr>\n            <td style='height:4px;background:linear-gradient(90deg,#6366f1 0%,#8b5cf6 50%,#06b6d4 100%);'></td>\n          </tr>\n\n          <!-- Body -->\n          <tr>\n            <td style='background-color:#ffffff;padding:40px 44px 36px;'>\n\n              <h2 style='margin:0 0 8px;font-size:18px;font-weight:700;color:#0f172a;letter-spacing:-0.01em;'>Welcome, ${displayName}!</h2>\n              <p style='margin:0 0 32px;font-size:13.5px;color:#64748b;line-height:1.7;'>Your account on the <strong style='color:#0f172a;'>HSL Fee Collections Dashboard</strong> has been created and is ready to use. Find your account details below.</p>\n\n              <!-- Account details card -->\n              <table width='100%' cellpadding='0' cellspacing='0' style='background-color:#f8fafc;border:1.5px solid #e2e8f0;border-radius:12px;margin-bottom:32px;overflow:hidden;'>\n                <tr>\n                  <td style='padding:0;'>\n\n                    <!-- Card header -->\n                    <table width='100%' cellpadding='0' cellspacing='0'>\n                      <tr>\n                        <td style='background-color:#f1f5f9;border-bottom:1px solid #e2e8f0;padding:12px 24px;'>\n                          <p style='margin:0;font-size:10px;font-weight:700;letter-spacing:0.14em;text-transform:uppercase;color:#94a3b8;'>Your Login Credentials</p>\n                        </td>\n                      </tr>\n                    </table>\n\n                    <!-- Email row -->\n                    <table width='100%' cellpadding='0' cellspacing='0'>\n                      <tr>\n                        <td style='padding:18px 24px 16px;border-bottom:1px solid #e2e8f0;'>\n                          <p style='margin:0 0 4px;font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:0.1em;color:#94a3b8;'>Email address</p>\n                          <p style='margin:0;font-size:14px;font-weight:600;color:#0f172a;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;word-break:break-all;'>${email}</p>\n                        </td>\n                      </tr>\n                    </table>\n\n                    <!-- Password row -->\n                    <table width='100%' cellpadding='0' cellspacing='0'>\n                      <tr>\n                        <td style='padding:16px 24px;border-bottom:1px solid #e2e8f0;'>\n                          <p style='margin:0 0 4px;font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:0.1em;color:#94a3b8;'>Password</p>\n                          <p style='margin:0;font-size:15px;font-weight:700;color:#1e293b;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;letter-spacing:0.08em;'>${password}</p>\n                        </td>\n                      </tr>\n                    </table>\n\n                    <!-- Role row -->\n                    <table width='100%' cellpadding='0' cellspacing='0'>\n                      <tr>\n                        <td style='padding:16px 24px;'>\n                          <p style='margin:0 0 8px;font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:0.1em;color:#94a3b8;'>Role</p>\n                          <span style='display:inline-block;${roleBadge}font-size:11px;font-weight:700;letter-spacing:0.07em;text-transform:uppercase;padding:4px 12px;border-radius:9999px;'>${roleLabel}</span>\n                        </td>\n                      </tr>\n                    </table>\n\n                  </td>\n                </tr>\n              </table>\n\n              <!-- CTA button -->\n              <table width='100%' cellpadding='0' cellspacing='0' style='margin-bottom:32px;'>\n                <tr>\n                  <td align='center'>\n                    <a href='${SIGN_IN_URL}'\n                       target='_blank'\n                       rel='noopener noreferrer'\n                       style='display:inline-block;background-color:#1e293b;color:#f8fafc;font-size:13px;font-weight:600;text-decoration:none;padding:14px 40px;border-radius:9px;letter-spacing:0.03em;'>\n                      Sign In to Dashboard &nbsp;&rarr;\n                    </a>\n                  </td>\n                </tr>\n              </table>\n\n              <!-- Note -->\n              <table width='100%' cellpadding='0' cellspacing='0'>\n                <tr>\n                  <td style='background-color:#fffbeb;border:1px solid #fde68a;border-radius:10px;padding:16px 18px;'>\n                    <table cellpadding='0' cellspacing='0'>\n                      <tr>\n                        <td style='padding-right:10px;vertical-align:top;padding-top:1px;'>\n                          <span style='font-size:15px;'>&#x26a0;&#xfe0f;</span>\n                        </td>\n                        <td>\n                          <p style='margin:0;font-size:12.5px;color:#78350f;line-height:1.65;'>\n                            <strong>Security reminder:</strong> Please change your password after your first sign-in. Never share your credentials with anyone.\n                          </p>\n                        </td>\n                      </tr>\n                    </table>\n                  </td>\n                </tr>\n              </table>\n\n            </td>\n          </tr>\n\n          <!-- Footer -->\n          <tr>\n            <td style='background-color:#f8fafc;border-top:1px solid #e2e8f0;border-radius:0 0 14px 14px;padding:22px 44px;text-align:center;'>\n              <p style='margin:0 0 4px;font-size:11px;color:#94a3b8;line-height:1.6;'>This is an automated message from the <strong>HSL Fee Collections</strong> system.</p>\n              <p style='margin:0;font-size:11px;color:#cbd5e1;'>If you did not expect this email, please contact your system administrator.</p>\n            </td>\n          </tr>\n\n        </table>\n      </td>\n    </tr>\n  </table>\n\n</body>\n</html>`;\n\nreturn [{ json: { email, displayName, htmlBody } }];"
+      },
+      "id": "e15a97a5-96e9-46ea-aba0-b8df25fce7ed",
+      "name": "Build Email",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        368,
+        720
+      ]
+    },
+    {
+      "parameters": {
+        "fromEmail": "hearingdashboard@hogansmith.com",
+        "toEmail": "={{ $json.email }}",
+        "subject": "=Your HSL Fee Collections Account is Ready",
+        "html": "={{ $json.htmlBody }}",
+        "options": {
+          "appendAttribution": false
+        }
+      },
+      "id": "796b4ab0-bcde-4788-aba1-e36d267aef7f",
+      "name": "Send an Email",
+      "type": "n8n-nodes-base.emailSend",
+      "maxTries": 3,
+      "position": [
+        608,
+        720
+      ],
+      "webhookId": "522063a0-d981-42e8-8d17-5ea6852264b8",
+      "retryOnFail": true,
+      "typeVersion": 2.1,
+      "waitBetweenTries": 5000,
+      "credentials": {
+        "smtp": {
+          "id": "jvnkR6FhSgBfd2EV",
+          "name": "hearingdashboard@hogansmith.com"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Build Email",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Email": {
+      "main": [
+        [
+          {
+            "node": "Send an Email",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "pinData": {},
+  "meta": {
+    "templateCredsSetupCompleted": true,
+    "instanceId": "11d1e5febe5cccf14212f53d0231fc2668bea5400c633d6171c207137b8bdf5f"
+  }
+}

--- a/src/app/(dashboard)/admin/actions.ts
+++ b/src/app/(dashboard)/admin/actions.ts
@@ -66,6 +66,7 @@ export async function createUser(input: {
       name: input.name?.trim() || null,
       passwordHash,
       role: input.role,
+      mustChangePassword: true,
     });
 
     revalidatePath("/admin");
@@ -206,7 +207,7 @@ export async function resetUserPassword(input: {
     const passwordHash = await bcrypt.hash(input.password, 12);
     const result = await db
       .update(users)
-      .set({ passwordHash, updatedAt: new Date() })
+      .set({ passwordHash, mustChangePassword: true, updatedAt: new Date() })
       .where(eq(users.id, input.userId));
 
     if (result.length === 0) {

--- a/src/app/(dashboard)/admin/actions.ts
+++ b/src/app/(dashboard)/admin/actions.ts
@@ -83,7 +83,7 @@ export async function createUser(input: {
             name: input.name?.trim() || null,
             role: input.role,
           }),
-          signal: AbortSignal.timeout(5_000),
+          signal: AbortSignal.timeout(15_000),
         });
         if (!emailRes.ok) {
           console.error("Welcome email webhook failed:", emailRes.status);

--- a/src/app/(dashboard)/admin/actions.ts
+++ b/src/app/(dashboard)/admin/actions.ts
@@ -82,14 +82,15 @@ export async function createUser(input: {
             name: input.name?.trim() || null,
             role: input.role,
           }),
+          signal: AbortSignal.timeout(5_000),
         });
         if (!emailRes.ok) {
           console.error("Welcome email webhook failed:", emailRes.status);
-          return { ok: true, warning: "User created but welcome email could not be sent." };
+          return { ok: true, warning: `User created but welcome email could not be sent (webhook ${emailRes.status}).` };
         }
       } catch (err) {
         console.error("Welcome email webhook error:", err);
-        return { ok: true, warning: "User created but welcome email could not be sent." };
+        return { ok: true, warning: "User created but welcome email could not be sent (network error)." };
       }
     }
 

--- a/src/app/(dashboard)/admin/actions.ts
+++ b/src/app/(dashboard)/admin/actions.ts
@@ -9,8 +9,8 @@ import { users } from "@/lib/db/schema";
 import { requireAdmin } from "@/lib/auth-helpers";
 
 type ActionResult<T = void> = T extends void
-  ? { ok: true } | { ok: false; error: string }
-  : ({ ok: true } & T) | { ok: false; error: string };
+  ? { ok: true; warning?: string } | { ok: false; error: string }
+  : ({ ok: true; warning?: string } & T) | { ok: false; error: string };
 
 const EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
 const MIN_PASSWORD_LEN = 8;
@@ -69,6 +69,30 @@ export async function createUser(input: {
     });
 
     revalidatePath("/admin");
+
+    const webhookUrl = process.env.N8N_NEW_USER_EMAIL_WEBHOOK_URL;
+    if (webhookUrl) {
+      try {
+        const emailRes = await fetch(webhookUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            email,
+            password: input.password,
+            name: input.name?.trim() || null,
+            role: input.role,
+          }),
+        });
+        if (!emailRes.ok) {
+          console.error("Welcome email webhook failed:", emailRes.status);
+          return { ok: true, warning: "User created but welcome email could not be sent." };
+        }
+      } catch (err) {
+        console.error("Welcome email webhook error:", err);
+        return { ok: true, warning: "User created but welcome email could not be sent." };
+      }
+    }
+
     return { ok: true };
   } catch (error) {
     console.error("createUser error:", error);

--- a/src/app/(dashboard)/admin/actions.ts
+++ b/src/app/(dashboard)/admin/actions.ts
@@ -39,6 +39,7 @@ export async function createUser(input: {
   password: string;
   name?: string | null;
   role: Role;
+  mustChangePassword?: boolean;
 }): Promise<ActionResult> {
   const guard = await requireAdmin();
   if (!guard.ok) return { ok: false, error: guard.error };
@@ -66,7 +67,7 @@ export async function createUser(input: {
       name: input.name?.trim() || null,
       passwordHash,
       role: input.role,
-      mustChangePassword: true,
+      mustChangePassword: input.mustChangePassword ?? true,
     });
 
     revalidatePath("/admin");
@@ -194,6 +195,7 @@ export async function setUserActive(input: {
 export async function resetUserPassword(input: {
   userId: number;
   password: string;
+  mustChangePassword?: boolean;
 }): Promise<ActionResult> {
   const guard = await requireAdmin();
   if (!guard.ok) return { ok: false, error: guard.error };
@@ -207,7 +209,7 @@ export async function resetUserPassword(input: {
     const passwordHash = await bcrypt.hash(input.password, 12);
     const result = await db
       .update(users)
-      .set({ passwordHash, mustChangePassword: true, updatedAt: new Date() })
+      .set({ passwordHash, mustChangePassword: input.mustChangePassword ?? true, updatedAt: new Date() })
       .where(eq(users.id, input.userId));
 
     if (result.length === 0) {

--- a/src/app/cases/[id]/page.tsx
+++ b/src/app/cases/[id]/page.tsx
@@ -877,10 +877,6 @@ const CaseDetailPage = () => {
                     <p className={val}>#{caseData.id}</p>
                   </div>
                   <div>
-                    <p className={lbl}>External ID</p>
-                    <p className={val}>{caseData.externalId || "—"}</p>
-                  </div>
-                  <div>
                     <p className={lbl}>First Name</p>
                     {editing ? (
                       <input

--- a/src/app/change-password/actions.ts
+++ b/src/app/change-password/actions.ts
@@ -1,0 +1,52 @@
+"use server";
+
+import bcrypt from "bcryptjs";
+import { eq } from "drizzle-orm";
+
+import { db } from "@/lib/db";
+import { users } from "@/lib/db/schema";
+import { auth, signOut } from "@/auth";
+
+const MIN_PASSWORD_LEN = 8;
+
+type Result = { ok: true } | { ok: false; error: string };
+
+export async function setNewPassword(input: {
+  newPassword: string;
+  confirmPassword: string;
+}): Promise<Result> {
+  const session = await auth();
+  if (!session?.user) return { ok: false, error: "Not signed in" };
+
+  const userId = Number(session.user.id);
+  if (!Number.isFinite(userId)) return { ok: false, error: "Invalid session" };
+
+  if (input.newPassword.length < MIN_PASSWORD_LEN) {
+    return { ok: false, error: `Password must be at least ${MIN_PASSWORD_LEN} characters` };
+  }
+  if (input.newPassword !== input.confirmPassword) {
+    return { ok: false, error: "Passwords do not match" };
+  }
+
+  try {
+    const [user] = await db
+      .select({ id: users.id, isActive: users.isActive })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1);
+
+    if (!user || !user.isActive) return { ok: false, error: "Account not found" };
+
+    const passwordHash = await bcrypt.hash(input.newPassword, 12);
+    await db
+      .update(users)
+      .set({ passwordHash, mustChangePassword: false, updatedAt: new Date() })
+      .where(eq(users.id, userId));
+
+    await signOut({ redirect: false });
+    return { ok: true };
+  } catch (error) {
+    console.error("setNewPassword error:", error);
+    return { ok: false, error: "Server error" };
+  }
+}

--- a/src/app/change-password/change-password-form.tsx
+++ b/src/app/change-password/change-password-form.tsx
@@ -74,7 +74,7 @@ export function ChangePasswordForm() {
       )}
 
       <Button type="submit" className="mt-2 w-full" disabled={submitting}>
-        {submitting && <Loader2 className="h-4 w-4 animate-spin" />}
+        {submitting && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
         {submitting ? "Saving…" : "Set password"}
       </Button>
     </form>

--- a/src/app/change-password/change-password-form.tsx
+++ b/src/app/change-password/change-password-form.tsx
@@ -3,9 +3,6 @@
 import { useState } from "react";
 import { AlertCircle, Loader2 } from "lucide-react";
 import { setNewPassword as submitNewPassword } from "./actions";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 
 export function ChangePasswordForm() {
   const [newPassword, setNewPassword] = useState("");
@@ -33,8 +30,10 @@ export function ChangePasswordForm() {
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
       <div className="flex flex-col gap-2">
-        <Label htmlFor="new-password">New password</Label>
-        <Input
+        <label htmlFor="new-password" className="text-sm font-medium text-neutral-700">
+          New password
+        </label>
+        <input
           id="new-password"
           type="password"
           autoComplete="new-password"
@@ -45,12 +44,15 @@ export function ChangePasswordForm() {
           value={newPassword}
           onChange={(e) => setNewPassword(e.target.value)}
           disabled={submitting}
+          className="h-9 w-full rounded-md border border-neutral-200 bg-white px-3 text-sm text-neutral-900 placeholder:text-neutral-400 outline-none focus-visible:border-neutral-400 disabled:opacity-50"
         />
       </div>
 
       <div className="flex flex-col gap-2">
-        <Label htmlFor="confirm-password">Confirm password</Label>
-        <Input
+        <label htmlFor="confirm-password" className="text-sm font-medium text-neutral-700">
+          Confirm password
+        </label>
+        <input
           id="confirm-password"
           type="password"
           autoComplete="new-password"
@@ -60,23 +62,25 @@ export function ChangePasswordForm() {
           value={confirmPassword}
           onChange={(e) => setConfirmPassword(e.target.value)}
           disabled={submitting}
+          className="h-9 w-full rounded-md border border-neutral-200 bg-white px-3 text-sm text-neutral-900 placeholder:text-neutral-400 outline-none focus-visible:border-neutral-400 disabled:opacity-50"
         />
       </div>
 
       {error && (
-        <p
-          role="alert"
-          className="flex items-center gap-2 text-sm text-destructive"
-        >
+        <p role="alert" className="flex items-center gap-2 text-sm text-red-600">
           <AlertCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
           {error}
         </p>
       )}
 
-      <Button type="submit" className="mt-2 w-full" disabled={submitting}>
+      <button
+        type="submit"
+        disabled={submitting}
+        className="mt-2 h-9 w-full rounded-md bg-neutral-900 text-white text-sm font-semibold hover:bg-neutral-800 transition-colors disabled:opacity-50 flex items-center justify-center gap-2"
+      >
         {submitting && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
         {submitting ? "Saving…" : "Set password"}
-      </Button>
+      </button>
     </form>
   );
 }

--- a/src/app/change-password/change-password-form.tsx
+++ b/src/app/change-password/change-password-form.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState } from "react";
+import { AlertCircle, Loader2 } from "lucide-react";
+import { setNewPassword as submitNewPassword } from "./actions";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+export function ChangePasswordForm() {
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (submitting) return;
+    setError(null);
+    setSubmitting(true);
+    try {
+      const result = await submitNewPassword({ newPassword, confirmPassword });
+      if (!result.ok) {
+        setError(result.error);
+      } else {
+        window.location.assign("/login?changed=1");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="new-password">New password</Label>
+        <Input
+          id="new-password"
+          type="password"
+          autoComplete="new-password"
+          placeholder="At least 8 characters"
+          required
+          minLength={8}
+          autoFocus
+          value={newPassword}
+          onChange={(e) => setNewPassword(e.target.value)}
+          disabled={submitting}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="confirm-password">Confirm password</Label>
+        <Input
+          id="confirm-password"
+          type="password"
+          autoComplete="new-password"
+          placeholder="Re-enter your new password"
+          required
+          minLength={8}
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          disabled={submitting}
+        />
+      </div>
+
+      {error && (
+        <p
+          role="alert"
+          className="flex items-center gap-2 text-sm text-destructive"
+        >
+          <AlertCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
+          {error}
+        </p>
+      )}
+
+      <Button type="submit" className="mt-2 w-full" disabled={submitting}>
+        {submitting && <Loader2 className="h-4 w-4 animate-spin" />}
+        {submitting ? "Saving…" : "Set password"}
+      </Button>
+    </form>
+  );
+}

--- a/src/app/change-password/page.tsx
+++ b/src/app/change-password/page.tsx
@@ -19,7 +19,7 @@ export default function ChangePasswordPage() {
       <div className="w-full max-w-sm">
         <div className="mb-6 flex flex-col items-center gap-3 text-center">
           <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-neutral-900">
-            <DollarSign className="h-5 w-5 text-white" />
+            <DollarSign className="h-5 w-5 text-white" aria-hidden="true" />
           </div>
           <div>
             <h1 className="text-lg font-bold text-neutral-900">

--- a/src/app/change-password/page.tsx
+++ b/src/app/change-password/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
-import { CheckCircle2, DollarSign } from "lucide-react";
-import { LoginForm } from "./login-form";
+import { DollarSign } from "lucide-react";
+import { ChangePasswordForm } from "./change-password-form";
 import {
   Card,
   CardContent,
@@ -10,16 +10,10 @@ import {
 } from "@/components/ui/card";
 
 export const metadata: Metadata = {
-  title: "Sign in · SSA Fee Collections",
+  title: "Set new password · SSA Fee Collections",
 };
 
-export default async function LoginPage({
-  searchParams,
-}: {
-  searchParams: Promise<{ changed?: string }>;
-}) {
-  const { changed } = await searchParams;
-
+export default function ChangePasswordPage() {
   return (
     <main className="flex min-h-svh items-center justify-center bg-neutral-50 px-4">
       <div className="w-full max-w-sm">
@@ -35,32 +29,17 @@ export default async function LoginPage({
           </div>
         </div>
 
-        {changed === "1" && (
-          <div
-            role="alert"
-            className="mb-4 flex items-center gap-2 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2.5 text-sm text-emerald-700"
-          >
-            <CheckCircle2 className="h-4 w-4 shrink-0" aria-hidden="true" />
-            Password updated — please sign in with your new password.
-          </div>
-        )}
-
         <Card>
           <CardHeader>
-            <CardTitle>Sign in</CardTitle>
+            <CardTitle>Set a new password</CardTitle>
             <CardDescription>
-              Enter your credentials to access the dashboard.
+              Your account requires a password change before you can continue.
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <LoginForm />
+            <ChangePasswordForm />
           </CardContent>
         </Card>
-
-        <p className="mt-6 text-center text-xs text-neutral-400">
-          Access is restricted to authorized staff. Contact an administrator if
-          you need an account.
-        </p>
       </div>
     </main>
   );

--- a/src/app/change-password/page.tsx
+++ b/src/app/change-password/page.tsx
@@ -1,13 +1,6 @@
 import type { Metadata } from "next";
 import { DollarSign } from "lucide-react";
 import { ChangePasswordForm } from "./change-password-form";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 
 export const metadata: Metadata = {
   title: "Set new password · SSA Fee Collections",
@@ -29,17 +22,22 @@ export default function ChangePasswordPage() {
           </div>
         </div>
 
-        <Card>
-          <CardHeader>
-            <CardTitle>Set a new password</CardTitle>
-            <CardDescription>
+        <div className="rounded-xl border border-neutral-200 bg-white shadow-sm">
+          <div className="px-6 pt-6 pb-4">
+            <p className="text-base font-semibold text-neutral-900">Set a new password</p>
+            <p className="text-sm text-neutral-500 mt-1">
               Your account requires a password change before you can continue.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
+            </p>
+          </div>
+          <div className="px-6 pb-6">
             <ChangePasswordForm />
-          </CardContent>
-        </Card>
+          </div>
+        </div>
+
+        <p className="mt-6 text-center text-xs text-neutral-400">
+          Access is restricted to authorized staff. Contact an administrator if
+          you need an account.
+        </p>
       </div>
     </main>
   );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -25,7 +25,7 @@ export default async function LoginPage({
       <div className="w-full max-w-sm">
         <div className="mb-6 flex flex-col items-center gap-3 text-center">
           <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-neutral-900">
-            <DollarSign className="h-5 w-5 text-white" />
+            <DollarSign className="h-5 w-5 text-white" aria-hidden="true" />
           </div>
           <div>
             <h1 className="text-lg font-bold text-neutral-900">

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -18,28 +18,42 @@ export const authConfig = {
     authorized({ auth, request: { nextUrl } }) {
       const isLoggedIn = !!auth?.user;
       const isOnLogin = nextUrl.pathname === "/login";
+      const isOnChangePassword = nextUrl.pathname === "/change-password";
+      const mustChange = auth?.user?.mustChangePassword ?? false;
 
       if (isOnLogin) {
-        // Already authenticated users shouldn't see the login page.
-        if (isLoggedIn) return Response.redirect(new URL("/", nextUrl));
+        if (isLoggedIn) {
+          const dest = mustChange ? "/change-password" : "/";
+          return Response.redirect(new URL(dest, nextUrl));
+        }
         return true;
+      }
+
+      if (isOnChangePassword) {
+        return isLoggedIn;
+      }
+
+      if (isLoggedIn && mustChange) {
+        return Response.redirect(new URL("/change-password", nextUrl));
       }
 
       return isLoggedIn;
     },
-    // Persist id/role onto the JWT at sign-in.
+    // Persist id/role/mustChangePassword onto the JWT at sign-in.
     jwt({ token, user }) {
       if (user) {
         token.id = user.id;
         token.role = user.role;
+        token.mustChangePassword = user.mustChangePassword ?? false;
       }
       return token;
     },
-    // Expose id/role on the session for client and server consumers.
+    // Expose id/role/mustChangePassword on the session for client and server consumers.
     session({ session, token }) {
       if (session.user) {
         if (token.id) session.user.id = token.id;
         if (token.role) session.user.role = token.role;
+        session.user.mustChangePassword = token.mustChangePassword ?? false;
       }
       return session;
     },

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -62,6 +62,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
           email: user.email,
           name: user.name,
           role: user.role,
+          mustChangePassword: user.mustChangePassword,
         };
       },
     }),

--- a/src/components/admin/UsersTable.tsx
+++ b/src/components/admin/UsersTable.tsx
@@ -156,7 +156,7 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
           </p>
         </div>
         <Button size="sm" onClick={() => setNewOpen(true)}>
-          <UserPlus className="h-4 w-4" />
+          <UserPlus className="h-4 w-4" aria-hidden="true" />
           New user
         </Button>
       </div>
@@ -176,9 +176,9 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
           }`}
         >
           {banner.kind === "error" ? (
-            <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+            <AlertCircle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
           ) : (
-            <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
+            <CheckCircle2 className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
           )}
           <span className="flex-1">{banner.text}</span>
           <button
@@ -186,7 +186,7 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
             aria-label="Dismiss"
             className="hover:opacity-70"
           >
-            <X className="h-3 w-3" />
+            <X className="h-3 w-3" aria-hidden="true" />
           </button>
         </div>
       )}
@@ -306,7 +306,7 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
                           disabled={rowBusy}
                           className="h-7 text-[11px]"
                         >
-                          <KeyRound className="h-3 w-3" />
+                          <KeyRound className="h-3 w-3" aria-hidden="true" />
                           Reset password
                         </Button>
                       </div>

--- a/src/components/admin/UsersTable.tsx
+++ b/src/components/admin/UsersTable.tsx
@@ -7,6 +7,7 @@ import {
   KeyRound,
   Loader2,
   AlertCircle,
+  AlertTriangle,
   CheckCircle2,
   X,
 } from "lucide-react";
@@ -85,6 +86,7 @@ interface UsersTableProps {
 
 type Banner =
   | { kind: "error"; text: string }
+  | { kind: "warning"; text: string }
   | { kind: "success"; text: string }
   | null;
 
@@ -100,7 +102,7 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
 
   const run = async (
     userId: number | null,
-    fn: () => Promise<{ ok: true } | { ok: false; error: string }>,
+    fn: () => Promise<{ ok: true; warning?: string } | { ok: false; error: string }>,
     successText: string,
   ) => {
     setBusyId(userId);
@@ -108,6 +110,7 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
     try {
       const result = await fn();
       if (!result.ok) setBanner({ kind: "error", text: result.error });
+      else if (result.warning) setBanner({ kind: "warning", text: result.warning });
       else setBanner({ kind: "success", text: successText });
       return result;
     } finally {
@@ -158,21 +161,27 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
       {/* Banner */}
       {banner && (
         <div
-          role={banner.kind === "error" ? "alert" : "status"}
+          role="alert"
           className={`mx-4 mt-3 rounded-md border p-2.5 flex items-center gap-2 text-xs ${
             banner.kind === "error"
               ? dark
                 ? "bg-red-900/20 border-red-800 text-red-400"
                 : "bg-red-50 border-red-200 text-red-700"
-              : dark
-                ? "bg-emerald-900/20 border-emerald-800 text-emerald-300"
-                : "bg-emerald-50 border-emerald-200 text-emerald-700"
+              : banner.kind === "warning"
+                ? dark
+                  ? "bg-amber-900/20 border-amber-700 text-amber-400"
+                  : "bg-amber-50 border-amber-300 text-amber-700"
+                : dark
+                  ? "bg-emerald-900/20 border-emerald-800 text-emerald-300"
+                  : "bg-emerald-50 border-emerald-200 text-emerald-700"
           }`}
         >
           {banner.kind === "error" ? (
-            <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+            <AlertCircle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+          ) : banner.kind === "warning" ? (
+            <AlertTriangle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
           ) : (
-            <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
+            <CheckCircle2 className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
           )}
           <span className="flex-1">{banner.text}</span>
           <button

--- a/src/components/admin/UsersTable.tsx
+++ b/src/components/admin/UsersTable.tsx
@@ -352,6 +352,24 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
   );
 }
 
+// ---------------- Password helpers ----------------
+
+const CHARSET = "abcdefghjkmnpqrstuvwxyzABCDEFGHJKMNPQRSTUVWXYZ23456789!@#$%";
+
+const generatePassword = (): string => {
+  // Rejection sampling: discard bytes >= limit so every charset position is equally likely.
+  const limit = 256 - (256 % CHARSET.length);
+  const result: string[] = [];
+  while (result.length < 12) {
+    const buf = new Uint8Array(24);
+    crypto.getRandomValues(buf);
+    for (const b of buf) {
+      if (b < limit && result.length < 12) result.push(CHARSET[b % CHARSET.length]);
+    }
+  }
+  return result.join("");
+};
+
 // ---------------- New user dialog ----------------
 
 type NewUserValues = {
@@ -372,7 +390,6 @@ function NewUserDialog({
 }) {
   const [email, setEmail] = useState("");
   const [name, setName] = useState("");
-  const [password, setPassword] = useState("");
   const [role, setRole] = useState<AdminUser["role"]>("member");
   const [submitting, setSubmitting] = useState(false);
 
@@ -381,7 +398,6 @@ function NewUserDialog({
     if (v) {
       setEmail("");
       setName("");
-      setPassword("");
       setRole("member");
     }
     onOpenChange(v);
@@ -395,7 +411,7 @@ function NewUserDialog({
       await onSubmit({
         email: email.trim(),
         name: name.trim() || null,
-        password,
+        password: generatePassword(),
         role,
       });
     } finally {
@@ -409,8 +425,8 @@ function NewUserDialog({
         <DialogHeader>
           <DialogTitle>New user</DialogTitle>
           <DialogDescription>
-            Accounts are admin-seeded. Pass the password to the user
-            out-of-band; they can sign in immediately.
+            A temporary password will be generated and emailed to the user.
+            They will be prompted to change it on first login.
           </DialogDescription>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="flex flex-col gap-3">
@@ -435,20 +451,6 @@ function NewUserDialog({
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="Jane Doe"
-              disabled={submitting}
-            />
-          </div>
-          <div className="flex flex-col gap-1.5">
-            <Label htmlFor="nu-password">Password</Label>
-            <Input
-              id="nu-password"
-              type="password"
-              autoComplete="new-password"
-              required
-              minLength={8}
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder="At least 8 characters"
               disabled={submitting}
             />
           </div>
@@ -500,53 +502,31 @@ function ResetPasswordDialog({
   onClose: () => void;
   onSubmit: (password: string) => Promise<void>;
 }) {
-  const [password, setPassword] = useState("");
   const [submitting, setSubmitting] = useState(false);
-
-  // Clear field when the target changes.
-  const handleOpenChange = (v: boolean) => {
-    if (!v) onClose();
-    if (v) setPassword("");
-  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (submitting) return;
     setSubmitting(true);
     try {
-      await onSubmit(password);
+      await onSubmit(generatePassword());
     } finally {
       setSubmitting(false);
     }
   };
 
   return (
-    <Dialog open={target != null} onOpenChange={handleOpenChange}>
+    <Dialog open={target != null} onOpenChange={(v) => { if (!v) onClose(); }}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>Reset password</DialogTitle>
           <DialogDescription>
-            Set a new password for{" "}
-            <span className="font-semibold">{target?.email}</span>. Share it
-            with them out-of-band — they can sign in immediately.
+            A new temporary password will be generated and emailed to{" "}
+            <span className="font-semibold">{target?.email}</span>. They will
+            be prompted to change it on next login.
           </DialogDescription>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="flex flex-col gap-3">
-          <div className="flex flex-col gap-1.5">
-            <Label htmlFor="rp-password">New password</Label>
-            <Input
-              id="rp-password"
-              type="password"
-              autoComplete="new-password"
-              required
-              minLength={8}
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder="At least 8 characters"
-              disabled={submitting}
-              autoFocus
-            />
-          </div>
           <DialogFooter className="mt-2">
             <Button
               type="button"

--- a/src/components/admin/UsersTable.tsx
+++ b/src/components/admin/UsersTable.tsx
@@ -7,11 +7,16 @@ import {
   KeyRound,
   Loader2,
   AlertCircle,
-  AlertTriangle,
   CheckCircle2,
   X,
+  Eye,
+  EyeOff,
+  RefreshCw,
+  Copy,
+  Check,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
@@ -86,7 +91,6 @@ interface UsersTableProps {
 
 type Banner =
   | { kind: "error"; text: string }
-  | { kind: "warning"; text: string }
   | { kind: "success"; text: string }
   | null;
 
@@ -102,7 +106,7 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
 
   const run = async (
     userId: number | null,
-    fn: () => Promise<{ ok: true; warning?: string } | { ok: false; error: string }>,
+    fn: () => Promise<{ ok: true } | { ok: false; error: string }>,
     successText: string,
   ) => {
     setBusyId(userId);
@@ -110,7 +114,6 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
     try {
       const result = await fn();
       if (!result.ok) setBanner({ kind: "error", text: result.error });
-      else if (result.warning) setBanner({ kind: "warning", text: result.warning });
       else setBanner({ kind: "success", text: successText });
       return result;
     } finally {
@@ -161,27 +164,21 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
       {/* Banner */}
       {banner && (
         <div
-          role="alert"
+          role={banner.kind === "error" ? "alert" : "status"}
           className={`mx-4 mt-3 rounded-md border p-2.5 flex items-center gap-2 text-xs ${
             banner.kind === "error"
               ? dark
                 ? "bg-red-900/20 border-red-800 text-red-400"
                 : "bg-red-50 border-red-200 text-red-700"
-              : banner.kind === "warning"
-                ? dark
-                  ? "bg-amber-900/20 border-amber-700 text-amber-400"
-                  : "bg-amber-50 border-amber-300 text-amber-700"
-                : dark
-                  ? "bg-emerald-900/20 border-emerald-800 text-emerald-300"
-                  : "bg-emerald-50 border-emerald-200 text-emerald-700"
+              : dark
+                ? "bg-emerald-900/20 border-emerald-800 text-emerald-300"
+                : "bg-emerald-50 border-emerald-200 text-emerald-700"
           }`}
         >
           {banner.kind === "error" ? (
-            <AlertCircle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-          ) : banner.kind === "warning" ? (
-            <AlertTriangle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            <AlertCircle className="h-3.5 w-3.5 shrink-0" />
           ) : (
-            <CheckCircle2 className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
           )}
           <span className="flex-1">{banner.text}</span>
           <button
@@ -335,14 +332,15 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
         }}
       />
 
+
       <ResetPasswordDialog
         target={resetTarget}
         onClose={() => setResetTarget(null)}
-        onSubmit={async (password) => {
+        onSubmit={async (password, mustChangePassword) => {
           if (!resetTarget) return;
           const result = await run(
             resetTarget.id,
-            () => resetUserPassword({ userId: resetTarget.id, password }),
+            () => resetUserPassword({ userId: resetTarget.id, password, mustChangePassword }),
             `Password reset for ${resetTarget.email}`,
           );
           if (result.ok) setResetTarget(null);
@@ -352,12 +350,10 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
   );
 }
 
-// ---------------- Password helpers ----------------
+// ---------------- New user dialog ----------------
 
 const CHARSET = "abcdefghjkmnpqrstuvwxyzABCDEFGHJKMNPQRSTUVWXYZ23456789!@#$%";
-
 const generatePassword = (): string => {
-  // Rejection sampling: discard bytes >= limit so every charset position is equally likely.
   const limit = 256 - (256 % CHARSET.length);
   const result: string[] = [];
   while (result.length < 12) {
@@ -370,13 +366,12 @@ const generatePassword = (): string => {
   return result.join("");
 };
 
-// ---------------- New user dialog ----------------
-
 type NewUserValues = {
   email: string;
   password: string;
   name: string | null;
   role: AdminUser["role"];
+  mustChangePassword: boolean;
 };
 
 function NewUserDialog({
@@ -390,17 +385,31 @@ function NewUserDialog({
 }) {
   const [email, setEmail] = useState("");
   const [name, setName] = useState("");
+  const [password, setPassword] = useState(() => generatePassword());
+  const [showPassword, setShowPassword] = useState(false);
+  const [copied, setCopied] = useState(false);
   const [role, setRole] = useState<AdminUser["role"]>("member");
+  const [mustChangePassword, setMustChangePassword] = useState(true);
   const [submitting, setSubmitting] = useState(false);
 
-  // Reset form whenever the dialog opens.
   const handleOpenChange = (v: boolean) => {
     if (v) {
       setEmail("");
       setName("");
+      setPassword(generatePassword());
+      setShowPassword(false);
+      setCopied(false);
       setRole("member");
+      setMustChangePassword(true);
     }
     onOpenChange(v);
+  };
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(password).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -408,12 +417,7 @@ function NewUserDialog({
     if (submitting) return;
     setSubmitting(true);
     try {
-      await onSubmit({
-        email: email.trim(),
-        name: name.trim() || null,
-        password: generatePassword(),
-        role,
-      });
+      await onSubmit({ email: email.trim(), name: name.trim() || null, password, role, mustChangePassword });
     } finally {
       setSubmitting(false);
     }
@@ -425,11 +429,22 @@ function NewUserDialog({
         <DialogHeader>
           <DialogTitle>New user</DialogTitle>
           <DialogDescription>
-            A temporary password will be generated and emailed to the user.
-            They will be prompted to change it on first login.
+            A temporary password is generated automatically. Copy it and share
+            with the user out-of-band before closing this dialog.
           </DialogDescription>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="nu-name">Full name (optional)</Label>
+            <Input
+              id="nu-name"
+              autoComplete="off"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="John Smith"
+              disabled={submitting}
+            />
+          </div>
           <div className="flex flex-col gap-1.5">
             <Label htmlFor="nu-email">Email</Label>
             <Input
@@ -439,20 +454,57 @@ function NewUserDialog({
               required
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              placeholder="someone@hogansmith.com"
+              placeholder="john@hogansmith.com"
               disabled={submitting}
             />
           </div>
           <div className="flex flex-col gap-1.5">
-            <Label htmlFor="nu-name">Name (optional)</Label>
-            <Input
-              id="nu-name"
-              autoComplete="off"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="Jane Doe"
-              disabled={submitting}
-            />
+            <Label htmlFor="nu-password">Password</Label>
+            <div className="flex gap-1.5">
+              <Input
+                id="nu-password"
+                type={showPassword ? "text" : "password"}
+                autoComplete="new-password"
+                readOnly
+                value={password}
+                className="flex-1 font-mono"
+                disabled={submitting}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={() => setShowPassword((v) => !v)}
+                aria-label={showPassword ? "Hide password" : "Show password"}
+                disabled={submitting}
+              >
+                {showPassword
+                  ? <EyeOff className="h-4 w-4" aria-hidden="true" />
+                  : <Eye className="h-4 w-4" aria-hidden="true" />}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={() => { setPassword(generatePassword()); setCopied(false); }}
+                aria-label="Regenerate password"
+                disabled={submitting}
+              >
+                <RefreshCw className="h-4 w-4" aria-hidden="true" />
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={handleCopy}
+                aria-label="Copy password"
+                disabled={submitting}
+              >
+                {copied
+                  ? <Check className="h-4 w-4 text-emerald-600" aria-hidden="true" />
+                  : <Copy className="h-4 w-4" aria-hidden="true" />}
+              </Button>
+            </div>
           </div>
           <div className="flex flex-col gap-1.5">
             <Label htmlFor="nu-role">Role</Label>
@@ -471,6 +523,17 @@ function NewUserDialog({
               </SelectContent>
             </Select>
           </div>
+          <div className="flex items-center gap-2 pt-0.5">
+            <Checkbox
+              id="nu-force-pw"
+              checked={mustChangePassword}
+              onCheckedChange={(v) => setMustChangePassword(v === true)}
+              disabled={submitting}
+            />
+            <Label htmlFor="nu-force-pw" className="font-normal cursor-pointer">
+              Require password change on first login
+            </Label>
+          </div>
           <DialogFooter className="mt-2">
             <Button
               type="button"
@@ -481,7 +544,7 @@ function NewUserDialog({
               Cancel
             </Button>
             <Button type="submit" disabled={submitting}>
-              {submitting && <Loader2 className="h-4 w-4 animate-spin" />}
+              {submitting && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
               {submitting ? "Creating…" : "Create user"}
             </Button>
           </DialogFooter>
@@ -500,33 +563,113 @@ function ResetPasswordDialog({
 }: {
   target: AdminUser | null;
   onClose: () => void;
-  onSubmit: (password: string) => Promise<void>;
+  onSubmit: (password: string, mustChangePassword: boolean) => Promise<void>;
 }) {
+  const [password, setPassword] = useState(() => generatePassword());
+  const [showPassword, setShowPassword] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [mustChangePassword, setMustChangePassword] = useState(true);
   const [submitting, setSubmitting] = useState(false);
+
+  const handleOpenChange = (v: boolean) => {
+    if (!v) onClose();
+    if (v) {
+      setPassword(generatePassword());
+      setShowPassword(false);
+      setCopied(false);
+      setMustChangePassword(true);
+    }
+  };
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(password).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (submitting) return;
     setSubmitting(true);
     try {
-      await onSubmit(generatePassword());
+      await onSubmit(password, mustChangePassword);
     } finally {
       setSubmitting(false);
     }
   };
 
   return (
-    <Dialog open={target != null} onOpenChange={(v) => { if (!v) onClose(); }}>
+    <Dialog open={target != null} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>Reset password</DialogTitle>
           <DialogDescription>
-            A new temporary password will be generated and emailed to{" "}
-            <span className="font-semibold">{target?.email}</span>. They will
-            be prompted to change it on next login.
+            A new temporary password has been generated for{" "}
+            <span className="font-semibold">{target?.email}</span>. Copy it and
+            share out-of-band before closing.
           </DialogDescription>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="rp-password">New password</Label>
+            <div className="flex gap-1.5">
+              <Input
+                id="rp-password"
+                type={showPassword ? "text" : "password"}
+                autoComplete="new-password"
+                readOnly
+                value={password}
+                className="flex-1 font-mono"
+                disabled={submitting}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={() => setShowPassword((v) => !v)}
+                aria-label={showPassword ? "Hide password" : "Show password"}
+                disabled={submitting}
+              >
+                {showPassword
+                  ? <EyeOff className="h-4 w-4" aria-hidden="true" />
+                  : <Eye className="h-4 w-4" aria-hidden="true" />}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={() => { setPassword(generatePassword()); setCopied(false); }}
+                aria-label="Regenerate password"
+                disabled={submitting}
+              >
+                <RefreshCw className="h-4 w-4" aria-hidden="true" />
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={handleCopy}
+                aria-label="Copy password"
+                disabled={submitting}
+              >
+                {copied
+                  ? <Check className="h-4 w-4 text-emerald-600" aria-hidden="true" />
+                  : <Copy className="h-4 w-4" aria-hidden="true" />}
+              </Button>
+            </div>
+          </div>
+          <div className="flex items-center gap-2 pt-0.5">
+            <Checkbox
+              id="rp-force-pw"
+              checked={mustChangePassword}
+              onCheckedChange={(v) => setMustChangePassword(v === true)}
+              disabled={submitting}
+            />
+            <Label htmlFor="rp-force-pw" className="font-normal cursor-pointer">
+              Require password change on first login
+            </Label>
+          </div>
           <DialogFooter className="mt-2">
             <Button
               type="button"
@@ -537,7 +680,7 @@ function ResetPasswordDialog({
               Cancel
             </Button>
             <Button type="submit" disabled={submitting}>
-              {submitting && <Loader2 className="h-4 w-4 animate-spin" />}
+              {submitting && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
               {submitting ? "Saving…" : "Set password"}
             </Button>
           </DialogFooter>

--- a/src/components/cases/FeeEditModal.tsx
+++ b/src/components/cases/FeeEditModal.tsx
@@ -153,8 +153,8 @@ export default function FeeEditModal({
 
   // Styles
   const lbl = `text-[10px] font-semibold uppercase tracking-wider ${t.textMuted}`;
-  const valCls = `text-[13px] font-semibold ${t.text} mt-0.5`;
   const inpCls = `mt-1 h-7 px-2 rounded border text-[12px] outline-none w-full ${t.inputBg}`;
+  const readonlyCls = `mt-1 h-7 px-2 rounded border text-[12px] font-semibold flex items-center select-none ${dark ? "border-neutral-700 bg-neutral-900/40" : "border-neutral-200 bg-neutral-100"}`;
   const amber = dark ? "text-amber-400" : "text-amber-600";
 
   return (
@@ -203,13 +203,8 @@ export default function FeeEditModal({
                 />
               </div>
               <div>
-                <p className={lbl}>
-                  Fee Due{" "}
-                  <span className="text-[8px] normal-case font-normal">
-                    (auto)
-                  </span>
-                </p>
-                <p className={`${valCls} ${amber}`}>{fmtFull(t16Due)}</p>
+                <p className={lbl}>Fee Due <span className="text-[8px] normal-case font-normal">(auto)</span></p>
+                <div className={`${readonlyCls} ${amber}`}>{fmtFull(t16Due)}</div>
               </div>
               <div>
                 <p className={lbl}>Fee Received</p>
@@ -222,15 +217,8 @@ export default function FeeEditModal({
                 />
               </div>
               <div>
-                <p className={lbl}>
-                  Pending{" "}
-                  <span className="text-[8px] normal-case font-normal">
-                    (auto)
-                  </span>
-                </p>
-                <p className={`${valCls} ${t16Pend > 0 ? amber : t.textMuted}`}>
-                  {fmtFull(t16Pend)}
-                </p>
+                <p className={lbl}>Pending <span className="text-[8px] normal-case font-normal">(auto)</span></p>
+                <div className={`${readonlyCls} ${t16Pend > 0 ? amber : t.textMuted}`}>{fmtFull(t16Pend)}</div>
               </div>
               <div>
                 <p className={lbl}>Date Received</p>
@@ -263,13 +251,8 @@ export default function FeeEditModal({
                 />
               </div>
               <div>
-                <p className={lbl}>
-                  Fee Due{" "}
-                  <span className="text-[8px] normal-case font-normal">
-                    (auto)
-                  </span>
-                </p>
-                <p className={`${valCls} ${amber}`}>{fmtFull(t2Due)}</p>
+                <p className={lbl}>Fee Due <span className="text-[8px] normal-case font-normal">(auto)</span></p>
+                <div className={`${readonlyCls} ${amber}`}>{fmtFull(t2Due)}</div>
               </div>
               <div>
                 <p className={lbl}>Fee Received</p>
@@ -282,15 +265,8 @@ export default function FeeEditModal({
                 />
               </div>
               <div>
-                <p className={lbl}>
-                  Pending{" "}
-                  <span className="text-[8px] normal-case font-normal">
-                    (auto)
-                  </span>
-                </p>
-                <p className={`${valCls} ${t2Pend > 0 ? amber : t.textMuted}`}>
-                  {fmtFull(t2Pend)}
-                </p>
+                <p className={lbl}>Pending <span className="text-[8px] normal-case font-normal">(auto)</span></p>
+                <div className={`${readonlyCls} ${t2Pend > 0 ? amber : t.textMuted}`}>{fmtFull(t2Pend)}</div>
               </div>
               <div>
                 <p className={lbl}>Date Received</p>
@@ -323,13 +299,8 @@ export default function FeeEditModal({
                 />
               </div>
               <div>
-                <p className={lbl}>
-                  Fee Due{" "}
-                  <span className="text-[8px] normal-case font-normal">
-                    (auto)
-                  </span>
-                </p>
-                <p className={`${valCls} ${amber}`}>{fmtFull(auxDue)}</p>
+                <p className={lbl}>Fee Due <span className="text-[8px] normal-case font-normal">(auto)</span></p>
+                <div className={`${readonlyCls} ${amber}`}>{fmtFull(auxDue)}</div>
               </div>
               <div>
                 <p className={lbl}>Fee Received</p>
@@ -342,15 +313,8 @@ export default function FeeEditModal({
                 />
               </div>
               <div>
-                <p className={lbl}>
-                  Pending{" "}
-                  <span className="text-[8px] normal-case font-normal">
-                    (auto)
-                  </span>
-                </p>
-                <p className={`${valCls} ${auxPend > 0 ? amber : t.textMuted}`}>
-                  {fmtFull(auxPend)}
-                </p>
+                <p className={lbl}>Pending <span className="text-[8px] normal-case font-normal">(auto)</span></p>
+                <div className={`${readonlyCls} ${auxPend > 0 ? amber : t.textMuted}`}>{fmtFull(auxPend)}</div>
               </div>
               <div>
                 <p className={lbl}>Date Received</p>

--- a/src/components/layout/ChangePasswordDialog.tsx
+++ b/src/components/layout/ChangePasswordDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { signOut } from "next-auth/react";
 import { AlertCircle, CheckCircle2, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -70,8 +71,7 @@ export function ChangePasswordDialog({
         return;
       }
       setDone(true);
-      // Brief success state, then close.
-      setTimeout(() => onOpenChange(false), 1200);
+      setTimeout(() => signOut({ callbackUrl: "/login" }), 1500);
     } catch {
       setError("Something went wrong. Please try again.");
     } finally {
@@ -92,7 +92,7 @@ export function ChangePasswordDialog({
         {done ? (
           <div className="flex items-center gap-2 rounded-md border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-700 dark:border-emerald-800 dark:bg-emerald-900/20 dark:text-emerald-300">
             <CheckCircle2 className="h-4 w-4 shrink-0" />
-            Password updated.
+            Password updated. Signing you out…
           </div>
         ) : (
           <form onSubmit={handleSubmit} className="flex flex-col gap-3">

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -707,6 +707,7 @@ export const users = pgTable(
     passwordHash: text("password_hash").notNull(),
     role: userRoleEnum("role").notNull().default("member"),
     isActive: boolean("is_active").notNull().default(true),
+    mustChangePassword: boolean("must_change_password").notNull().default(false),
     lastLoginAt: timestamp("last_login_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -6,12 +6,14 @@ declare module "next-auth" {
   /** Returned by `authorize` and stored on the session user. */
   interface User {
     role?: UserRole;
+    mustChangePassword?: boolean;
   }
 
   interface Session {
     user: {
       id: string;
       role: UserRole;
+      mustChangePassword: boolean;
     } & DefaultSession["user"];
   }
 }
@@ -22,5 +24,6 @@ declare module "@auth/core/jwt" {
   interface JWT {
     id?: string;
     role?: UserRole;
+    mustChangePassword?: boolean;
   }
 }


### PR DESCRIPTION
## Summary

- `createUser` server action now POSTs `{ email, password, name, role }` to an n8n webhook (`N8N_NEW_USER_EMAIL_WEBHOOK_URL`) after a successful DB insert
- If the webhook returns non-2xx or throws, the user is still created and an amber warning banner is shown to the admin
- `UsersTable` banner system gains a `warning` variant (amber, `AlertTriangle` icon) to surface partial failures
- n8n workflow (`new-user-email-workflow.json`) builds and sends a designed HTML welcome email via Gmail OAuth2; role labels degrade gracefully for future roles via a `humanize` helper