### PR TITLE
fix: handle bare 'v' separator and no-comma names in case link parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,29 @@ This is a [Next.js](https://nextjs.org) dashboard for HSL Fee Collection, using 
    Create a `.env.local` file in the project root with:
 
    ```env
+   # Database (Neon / PostgreSQL)
    DATABASE_URL=your_postgres_connection_string
+
+   # Auth (NextAuth v5)
+   AUTH_SECRET=your_auth_secret
+
+   # Chronicle API
    CHRONICLE_API_URL=https://api.chroniclelegal.com
+   CHRONICLE_BASE_URL=https://app.chroniclelegal.com
    CHRONICLE_API_KEY=your_chronicle_api_key
+
+   # MyCase
+   MYCASE_API_URL=your_mycase_api_url
+   MYCASE_API_KEY=your_mycase_api_key
+   MYCASE_DB_URL=your_mycase_db_connection_string
+
+   # Webhooks
+   SHEETS_SYNC_WEBHOOK_URL=your_sheets_sync_webhook_url
+   SHEETS_PUSH_WEBHOOK_URL=your_sheets_push_webhook_url
+   FEES_CLOSED_SYNC_WEBHOOK_URL=your_fees_closed_sync_webhook_url
+
+   # Misc
+   CALLTOOLS_API_KEY=your_calltools_api_key
    ```
 
    _Do not commit secrets!_
@@ -39,20 +59,29 @@ This is a [Next.js](https://nextjs.org) dashboard for HSL Fee Collection, using 
 - Uses [Drizzle ORM](https://orm.drizzle.team/) for database access.
 - Configure your database connection in `.env.local` (`DATABASE_URL`).
 - Migration config: `src/drizzle.config.ts` (schema in `src/lib/db/schema.ts`).
-- To run migrations (if using drizzle-kit):
 
-  ```bash
-  npx drizzle-kit push
-  ```
+```bash
+npm run db:generate   # generate a new migration from schema changes
+npm run db:migrate    # apply pending migrations
+npm run db:studio     # open Drizzle Studio
+```
 
 ---
 
 ## 🛠️ Scripts
 
-- **Start dev server:** `npm run dev`
-- **Build for production:** `npm run build`
-- **Start production server:** `npm start`
-- **Lint:** `npm run lint`
+| Command | Description |
+|---|---|
+| `npm run dev` | Start dev server |
+| `npm run build` | Build for production |
+| `npm start` | Start production server |
+| `npm run lint` | Lint |
+| `npm run db:generate` | Generate migration from schema diff |
+| `npm run db:migrate` | Apply pending migrations |
+| `npm run db:studio` | Open Drizzle Studio |
+| `npm run user:create` | Create a new user via CLI script |
+| `npm test` | Run test suite (Vitest) |
+| `npm run test:watch` | Run tests in watch mode |
 
 ---
 
@@ -60,17 +89,21 @@ This is a [Next.js](https://nextjs.org) dashboard for HSL Fee Collection, using 
 
 - Next.js (App Router, TypeScript)
 - Tailwind CSS
-- Drizzle ORM (PostgreSQL)
-- React, Radix UI, React Hook Form, Zod, Recharts, etc.
+- Drizzle ORM (PostgreSQL / Neon)
+- NextAuth v5
+- Base UI (`@base-ui/react`), React Hook Form, Zod, Recharts
 
 ---
 
 ## 📝 Project Structure
 
-- `src/app/` — App routes and pages
+- `src/app/` — App routes, pages, and server actions
 - `src/components/` — UI and dashboard components
 - `src/lib/` — Utilities, context, API clients, and DB schema
 - `src/services/api.ts` — API request helpers
+- `src/drizzle.config.ts` — Drizzle Kit config
+- `drizzle/` — SQL migration files
+- `scripts/` — CLI utility scripts
 
 ---
 

--- a/src/app/api/sheets/sync/route.ts
+++ b/src/app/api/sheets/sync/route.ts
@@ -205,7 +205,7 @@ export const POST = async (req: NextRequest) => {
       );
 
 
-      // Pull all DB cases (lightweight: only fields needed for diff + display)
+      // Pull all DB cases + their fee records for diff comparison
       const allDbCases = await db
         .select({
           clientId: cases.clientId,
@@ -213,32 +213,121 @@ export const POST = async (req: NextRequest) => {
           firstName: cases.firstName,
           lastName: cases.lastName,
           approvalDate: cases.approvalDate,
+          levelWon: cases.levelWon,
+          claimType: cases.claimType,
+          claimTypeLabel: cases.claimTypeLabel,
+          aljFirstName: cases.aljFirstName,
+          aljLastName: cases.aljLastName,
+          assignedTo: feeRecords.assignedTo,
+          winSheetStatus: feeRecords.winSheetStatus,
+          caseStatus: feeRecords.caseStatus,
+          feesConfirmation: feeRecords.feesConfirmation,
+          dateAssignedToAgent: feeRecords.dateAssignedToAgent,
+          approvedBy: feeRecords.approvedBy,
+          t16Retro: feeRecords.t16Retro,
+          t16FeeDue: feeRecords.t16FeeDue,
+          t16FeeReceived: feeRecords.t16FeeReceived,
+          t16Pending: feeRecords.t16Pending,
+          t16FeeReceivedDate: feeRecords.t16FeeReceivedDate,
+          t2Retro: feeRecords.t2Retro,
+          t2FeeDue: feeRecords.t2FeeDue,
+          t2FeeReceived: feeRecords.t2FeeReceived,
+          t2Pending: feeRecords.t2Pending,
+          t2FeeReceivedDate: feeRecords.t2FeeReceivedDate,
+          auxRetro: feeRecords.auxRetro,
+          auxFeeDue: feeRecords.auxFeeDue,
+          auxFeeReceived: feeRecords.auxFeeReceived,
+          auxPending: feeRecords.auxPending,
+          auxFeeReceivedDate: feeRecords.auxFeeReceivedDate,
         })
-        .from(cases);
+        .from(cases)
+        .leftJoin(feeRecords, eq(feeRecords.caseId, cases.clientId));
 
-      const dbClientIdSet = new Set(allDbCases.map((c) => c.clientId));
+      type DbRow = (typeof allDbCases)[number];
 
-      // Category 1 & 2: sheet rows — new vs existing
-      const sheetRows = parsed.map((r) => ({
-        clientId: r.clientId,
-        caseName: `${r.lastName}, ${r.firstName}`,
-        caseLink: r.caseLink,
-        externalUrl: r.externalId,
-        approvalDate: r.approvalDate,
-        assignedTo: r.assignedTo,
-        winSheetStatus: r.winSheetStatus,
-        winSheetLink: r.winSheetLink,
-        winSheetLinkText: r.winSheetLinkText,
-        totalExpected:
-          (Number(r.t16FeeDue) || 0) +
-          (Number(r.t2FeeDue) || 0) +
-          (Number(r.auxFeeDue) || 0),
-        hasNotes: !!r.notes,
-        isSynthetic: r.clientId >= SYNTHETIC_ID_BASE,
-        status: dbClientIdSet.has(r.clientId) ? "existing" : "new",
-      }));
+      type ChangedField = { field: string; sheet: string; db: string };
 
-      // Category 3 & 4: DB-only rows
+      const getChangedFields = (r: ParsedCaseRow, db: DbRow): ChangedField[] => {
+        const f: ChangedField[] = [];
+        const s = (field: string, a: string | null | undefined, b: string | null | undefined) => {
+          if ((a ?? null) !== (b ?? null)) f.push({ field, sheet: String(a ?? ""), db: String(b ?? "") });
+        };
+        // Compare monetary amounts with 1-cent tolerance. The sheet formula (0.25 × retro)
+        // produces sub-cent values like 4760.695. Postgres decimal(12,2) stores 4760.70 (rounds
+        // up), but JavaScript IEEE 754 stores 4760.695 as 4760.6949... and any JS rounding
+        // gives 4760.69 — so string/toFixed comparisons always diverge on the boundary.
+        // A difference < $0.01 is purely a precision artifact; any real change is ≥ $1.
+        const n = (field: string, sheet: string, db: string | null | undefined) => {
+          if (Math.abs(Number(sheet) - Number(db ?? "0")) >= 0.01)
+            f.push({ field, sheet, db: db ?? "null" });
+        };
+        const a = (field: string, arr: string[], dbArr: string[] | null | undefined) => {
+          if (JSON.stringify([...(arr ?? [])].sort()) !== JSON.stringify([...(dbArr ?? [])].sort()))
+            f.push({ field, sheet: arr.join(","), db: (dbArr ?? []).join(",") });
+        };
+        s("caseLink", r.caseLink, db.caseLink);
+        s("firstName", r.firstName, db.firstName);
+        s("lastName", r.lastName, db.lastName);
+        s("approvalDate", r.approvalDate, db.approvalDate);
+        s("levelWon", r.levelWon, db.levelWon);
+        a("claimType", r.claimType, db.claimType);
+        s("claimTypeLabel", r.claimTypeLabel, db.claimTypeLabel);
+        s("aljFirstName", r.aljFirstName, db.aljFirstName);
+        s("aljLastName", r.aljLastName, db.aljLastName);
+        s("assignedTo", r.assignedTo, db.assignedTo);
+        s("winSheetStatus", r.winSheetStatus, db.winSheetStatus ?? "not_started");
+        s("caseStatus", r.caseStatus, db.caseStatus);
+        s("feesConfirmation", r.feesConfirmation, db.feesConfirmation);
+        s("dateAssignedToAgent", r.dateAssignedToAgent, db.dateAssignedToAgent);
+        s("approvedBy", r.approvedBy, db.approvedBy);
+        n("t16Retro", r.t16Retro, db.t16Retro);
+        n("t16FeeDue", r.t16FeeDue, db.t16FeeDue);
+        n("t16FeeReceived", r.t16FeeReceived, db.t16FeeReceived);
+        // t16Pending excluded: sheet webhook doesn't reliably return this column;
+        // the DB value is preserved by CASE WHEN in the upsert.
+        s("t16FeeReceivedDate", r.t16FeeReceivedDate, db.t16FeeReceivedDate);
+        n("t2Retro", r.t2Retro, db.t2Retro);
+        n("t2FeeDue", r.t2FeeDue, db.t2FeeDue);
+        n("t2FeeReceived", r.t2FeeReceived, db.t2FeeReceived);
+        // t2Pending excluded — same reason as t16Pending above.
+        s("t2FeeReceivedDate", r.t2FeeReceivedDate, db.t2FeeReceivedDate);
+        n("auxRetro", r.auxRetro, db.auxRetro);
+        n("auxFeeDue", r.auxFeeDue, db.auxFeeDue);
+        n("auxFeeReceived", r.auxFeeReceived, db.auxFeeReceived);
+        // auxPending excluded — same reason as t16Pending above.
+        s("auxFeeReceivedDate", r.auxFeeReceivedDate, db.auxFeeReceivedDate);
+        return f;
+      };
+
+      const dbMap = new Map(allDbCases.map((c) => [c.clientId, c]));
+
+      // Category 1 & 2: sheet rows — new vs changed vs unchanged
+      const sheetRows = parsed.map((r) => {
+        const dbEntry = dbMap.get(r.clientId);
+        const changedFields = dbEntry ? getChangedFields(r, dbEntry) : [];
+        const status = !dbEntry ? "new" : changedFields.length > 0 ? "changed" : "unchanged";
+        return {
+          clientId: r.clientId,
+          caseName: `${r.lastName}, ${r.firstName}`,
+          caseLink: r.caseLink,
+          externalUrl: r.externalId,
+          approvalDate: r.approvalDate,
+          assignedTo: r.assignedTo,
+          winSheetStatus: r.winSheetStatus,
+          winSheetLink: r.winSheetLink,
+          winSheetLinkText: r.winSheetLinkText,
+          totalExpected:
+            (Number(r.t16FeeDue) || 0) +
+            (Number(r.t2FeeDue) || 0) +
+            (Number(r.auxFeeDue) || 0),
+          hasNotes: !!r.notes,
+          isSynthetic: r.clientId >= SYNTHETIC_ID_BASE,
+          status,
+          changedFields,
+        };
+      });
+
+      // Category 3 & 4: DB-only rows (cases table entries not in the sheet)
       const dbOnlyCases = allDbCases.filter(
         (c) => !sheetClientIdSet.has(c.clientId),
       );
@@ -264,6 +353,7 @@ export const POST = async (req: NextRequest) => {
         }));
 
       const newCount = sheetRows.filter((r) => r.status === "new").length;
+      const changedCount = sheetRows.filter((r) => r.status === "changed").length;
 
       return NextResponse.json({
         mode,
@@ -271,7 +361,8 @@ export const POST = async (req: NextRequest) => {
         summary: {
           fetched: parsed.length,
           new: newCount,
-          existing: parsed.length - newCount,
+          changed: changedCount,
+          unchanged: parsed.length - newCount - changedCount,
           feesClosed: feesClosedRows.length,
           missing: missingRows.length,
           synthetic: sheetRows.filter((r) => r.isSynthetic).length,
@@ -371,17 +462,6 @@ export const POST = async (req: NextRequest) => {
     const newRows = candidates.filter((r) => !existingSet.has(r.clientId));
     const updateRows = candidates.filter((r) => existingSet.has(r.clientId));
 
-    const existingLinks =
-      updateRows.length > 0
-        ? await db
-            .select({ caseId: feeRecords.caseId, winSheetLink: feeRecords.winSheetLink })
-            .from(feeRecords)
-            .where(inArray(feeRecords.caseId, updateRows.map((r) => r.clientId)))
-        : [];
-    const existingLinkMap = new Map(
-      existingLinks.map((e) => [e.caseId, e.winSheetLink]),
-    );
-
     let inserted = 0;
     let updated = 0;
     let closed = 0;
@@ -450,106 +530,118 @@ export const POST = async (req: NextRequest) => {
     });
 
     if (updateRows.length > 0) {
-      await Promise.all([
-        db.execute(sql`
-          UPDATE cases SET
-            external_id        = v.external_id,
-            case_link          = v.case_link,
-            first_name         = v.first_name,
-            last_name          = v.last_name,
-            approval_date      = v.approval_date::date,
-            level_won          = v.level_won,
-            claim_type         = v.claim_type::text[],
-            claim_type_label   = v.claim_type_label,
-            alj_first_name     = v.alj_first_name,
-            alj_last_name      = v.alj_last_name,
-            updated_at         = now()
-          FROM (VALUES ${sql.join(
-            updateRows.map((r) => sql`(
-              ${r.clientId},
-              ${r.externalId},
-              ${r.caseLink},
-              ${r.firstName},
-              ${r.lastName},
-              ${r.approvalDate},
-              ${r.levelWon},
-              ${'{' + r.claimType.join(',') + '}'},
-              ${r.claimTypeLabel},
-              ${r.aljFirstName},
-              ${r.aljLastName}
-            )`),
-            sql`,`,
-          )}) AS v(client_id, external_id, case_link, first_name, last_name, approval_date, level_won, claim_type, claim_type_label, alj_first_name, alj_last_name)
-          WHERE cases.client_id = v.client_id::int
-        `),
-        db.execute(sql`
-          UPDATE fee_records SET
-            assigned_to              = v.assigned_to,
-            win_sheet_status         = v.win_sheet_status,
-            win_sheet_link           = v.win_sheet_link,
-            win_sheet_link_text      = v.win_sheet_link_text,
-            case_status              = v.case_status,
-            fees_confirmation        = v.fees_confirmation,
-            date_assigned_to_agent   = v.date_assigned_to_agent::date,
-            approved_by              = v.approved_by,
-            t16_retro                = v.t16_retro::numeric,
-            t16_fee_due              = v.t16_fee_due::numeric,
-            t16_fee_received         = v.t16_fee_received::numeric,
-            t16_pending              = v.t16_pending::numeric,
-            t16_fee_received_date    = v.t16_fee_received_date::date,
-            t2_retro                 = v.t2_retro::numeric,
-            t2_fee_due               = v.t2_fee_due::numeric,
-            t2_fee_received          = v.t2_fee_received::numeric,
-            t2_pending               = v.t2_pending::numeric,
-            t2_fee_received_date     = v.t2_fee_received_date::date,
-            aux_retro                = v.aux_retro::numeric,
-            aux_fee_due              = v.aux_fee_due::numeric,
-            aux_fee_received         = v.aux_fee_received::numeric,
-            aux_pending              = v.aux_pending::numeric,
-            aux_fee_received_date    = v.aux_fee_received_date::date,
-            days_after_approval      = v.days_after_approval::int,
-            approval_category        = v.approval_category,
-            fees_status              = v.fees_status,
-            week_assigned_to_agent   = v.week_assigned_to_agent,
-            month_assigned_to_agent  = v.month_assigned_to_agent,
-            updated_at               = now()
-          FROM (VALUES ${sql.join(
-            updateRows.map((r) => sql`(
-              ${r.clientId},
-              ${r.assignedTo},
-              ${r.winSheetStatus},
-              ${existingLinkMap.get(r.clientId) ?? r.winSheetLink},
-              ${r.winSheetLinkText},
-              ${r.caseStatus},
-              ${r.feesConfirmation},
-              ${r.dateAssignedToAgent},
-              ${r.approvedBy},
-              ${r.t16Retro},
-              ${r.t16FeeDue},
-              ${r.t16FeeReceived},
-              ${r.t16Pending},
-              ${r.t16FeeReceivedDate},
-              ${r.t2Retro},
-              ${r.t2FeeDue},
-              ${r.t2FeeReceived},
-              ${r.t2Pending},
-              ${r.t2FeeReceivedDate},
-              ${r.auxRetro},
-              ${r.auxFeeDue},
-              ${r.auxFeeReceived},
-              ${r.auxPending},
-              ${r.auxFeeReceivedDate},
-              ${r.daysAfterApproval},
-              ${r.approvalCategory},
-              ${r.feesStatus},
-              ${r.weekAssignedToAgent},
-              ${r.monthAssignedToAgent}
-            )`),
-            sql`,`,
-          )}) AS v(case_id, assigned_to, win_sheet_status, win_sheet_link, win_sheet_link_text, case_status, fees_confirmation, date_assigned_to_agent, approved_by, t16_retro, t16_fee_due, t16_fee_received, t16_pending, t16_fee_received_date, t2_retro, t2_fee_due, t2_fee_received, t2_pending, t2_fee_received_date, aux_retro, aux_fee_due, aux_fee_received, aux_pending, aux_fee_received_date, days_after_approval, approval_category, fees_status, week_assigned_to_agent, month_assigned_to_agent)
-          WHERE fee_records.case_id = v.case_id::int
-        `),
-      ]);
+      for (const batch of chunked(updateRows, CHUNK)) {
+        await Promise.all([
+          db.execute(sql`
+            UPDATE cases SET
+              external_id        = v.external_id,
+              case_link          = v.case_link,
+              first_name         = v.first_name,
+              last_name          = v.last_name,
+              approval_date      = v.approval_date::date,
+              level_won          = v.level_won,
+              claim_type         = v.claim_type::text[],
+              claim_type_label   = v.claim_type_label,
+              alj_first_name     = v.alj_first_name,
+              alj_last_name      = v.alj_last_name,
+              updated_at         = now()
+            FROM (VALUES ${sql.join(
+              batch.map((r) => sql`(
+                ${r.clientId},
+                ${r.externalId},
+                ${r.caseLink},
+                ${r.firstName},
+                ${r.lastName},
+                ${r.approvalDate},
+                ${r.levelWon},
+                ${'{' + r.claimType.join(',') + '}'},
+                ${r.claimTypeLabel},
+                ${r.aljFirstName},
+                ${r.aljLastName}
+              )`),
+              sql`,`,
+            )}) AS v(client_id, external_id, case_link, first_name, last_name, approval_date, level_won, claim_type, claim_type_label, alj_first_name, alj_last_name)
+            WHERE cases.client_id = v.client_id::int
+          `),
+          // Upsert fee_records so cases that somehow have no fee_record row still get written.
+          // COALESCE preserves the existing DB win_sheet_link rather than overwriting it.
+          db.execute(sql`
+            INSERT INTO fee_records (
+              case_id, assigned_to, win_sheet_status, win_sheet_link, win_sheet_link_text,
+              case_status, fees_confirmation, date_assigned_to_agent, approved_by,
+              t16_retro, t16_fee_due, t16_fee_received, t16_pending, t16_fee_received_date,
+              t2_retro, t2_fee_due, t2_fee_received, t2_pending, t2_fee_received_date,
+              aux_retro, aux_fee_due, aux_fee_received, aux_pending, aux_fee_received_date,
+              days_after_approval, approval_category, fees_status,
+              week_assigned_to_agent, month_assigned_to_agent
+            )
+            VALUES ${sql.join(
+              batch.map((r) => sql`(
+                ${r.clientId},
+                ${r.assignedTo},
+                ${r.winSheetStatus},
+                ${r.winSheetLink},
+                ${r.winSheetLinkText},
+                ${r.caseStatus},
+                ${r.feesConfirmation},
+                ${r.dateAssignedToAgent}::date,
+                ${r.approvedBy},
+                ${r.t16Retro}::numeric,
+                ${r.t16FeeDue}::numeric,
+                ${r.t16FeeReceived}::numeric,
+                ${r.t16Pending}::numeric,
+                ${r.t16FeeReceivedDate}::date,
+                ${r.t2Retro}::numeric,
+                ${r.t2FeeDue}::numeric,
+                ${r.t2FeeReceived}::numeric,
+                ${r.t2Pending}::numeric,
+                ${r.t2FeeReceivedDate}::date,
+                ${r.auxRetro}::numeric,
+                ${r.auxFeeDue}::numeric,
+                ${r.auxFeeReceived}::numeric,
+                ${r.auxPending}::numeric,
+                ${r.auxFeeReceivedDate}::date,
+                ${r.daysAfterApproval}::int,
+                ${r.approvalCategory},
+                ${r.feesStatus},
+                ${r.weekAssignedToAgent},
+                ${r.monthAssignedToAgent}
+              )`),
+              sql`,`,
+            )}
+            ON CONFLICT (case_id) DO UPDATE SET
+              assigned_to              = EXCLUDED.assigned_to,
+              win_sheet_status         = EXCLUDED.win_sheet_status,
+              win_sheet_link           = COALESCE(fee_records.win_sheet_link, EXCLUDED.win_sheet_link),
+              win_sheet_link_text      = EXCLUDED.win_sheet_link_text,
+              case_status              = EXCLUDED.case_status,
+              fees_confirmation        = EXCLUDED.fees_confirmation,
+              date_assigned_to_agent   = EXCLUDED.date_assigned_to_agent,
+              approved_by              = EXCLUDED.approved_by,
+              t16_retro                = EXCLUDED.t16_retro,
+              t16_fee_due              = EXCLUDED.t16_fee_due,
+              t16_fee_received         = EXCLUDED.t16_fee_received,
+              t16_pending              = CASE WHEN EXCLUDED.t16_pending::numeric != 0 THEN EXCLUDED.t16_pending ELSE fee_records.t16_pending END,
+              t16_fee_received_date    = EXCLUDED.t16_fee_received_date,
+              t2_retro                 = EXCLUDED.t2_retro,
+              t2_fee_due               = EXCLUDED.t2_fee_due,
+              t2_fee_received          = EXCLUDED.t2_fee_received,
+              t2_pending               = CASE WHEN EXCLUDED.t2_pending::numeric != 0 THEN EXCLUDED.t2_pending ELSE fee_records.t2_pending END,
+              t2_fee_received_date     = EXCLUDED.t2_fee_received_date,
+              aux_retro                = EXCLUDED.aux_retro,
+              aux_fee_due              = EXCLUDED.aux_fee_due,
+              aux_fee_received         = EXCLUDED.aux_fee_received,
+              aux_pending              = CASE WHEN EXCLUDED.aux_pending::numeric != 0 THEN EXCLUDED.aux_pending ELSE fee_records.aux_pending END,
+              aux_fee_received_date    = EXCLUDED.aux_fee_received_date,
+              days_after_approval      = EXCLUDED.days_after_approval,
+              approval_category        = EXCLUDED.approval_category,
+              fees_status              = EXCLUDED.fees_status,
+              week_assigned_to_agent   = EXCLUDED.week_assigned_to_agent,
+              month_assigned_to_agent  = EXCLUDED.month_assigned_to_agent,
+              updated_at               = now()
+          `),
+        ]);
+      }
       updated = updateRows.length;
     }
 

--- a/src/app/api/sheets/sync/route.ts
+++ b/src/app/api/sheets/sync/route.ts
@@ -214,7 +214,7 @@ export const POST = async (req: NextRequest) => {
         // A difference < $0.01 is purely a precision artifact; any real change is ≥ $1.
         const n = (field: string, sheet: string, db: string | null | undefined) => {
           if (Math.abs(Number(sheet) - Number(db ?? "0")) >= 0.01)
-            f.push({ field, sheet, db: db ?? "null" });
+            f.push({ field, sheet, db: db ?? "" });
         };
         const a = (field: string, arr: string[], dbArr: string[] | null | undefined) => {
           if (JSON.stringify([...(arr ?? [])].sort()) !== JSON.stringify([...(dbArr ?? [])].sort()))

--- a/src/app/api/sheets/sync/route.ts
+++ b/src/app/api/sheets/sync/route.ts
@@ -157,10 +157,10 @@ const toFeeUpdate = (r: ParsedCaseRow, existingWinSheetLink: string | null) => (
   updatedAt: new Date(),
 });
 
-const toClosedAt = (closedDate: string | null): Date => {
-  if (!closedDate) return new Date();
+const toClosedAt = (closedDate: string | null): Date | null => {
+  if (!closedDate) return null;
   const parsed = new Date(`${closedDate}T12:00:00`);
-  return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
 };
 
 // POST /api/sheets/sync

--- a/src/app/api/sheets/sync/route.ts
+++ b/src/app/api/sheets/sync/route.ts
@@ -17,6 +17,10 @@ export const runtime = "nodejs";
 export const maxDuration = 60;
 
 const CHUNK = 500;
+const SHEET_CACHE_TTL = 5 * 60 * 1000;
+
+type SheetCache = { masterRows: SheetRow[]; feesClosedRows: SheetRow[]; ts: number };
+let sheetCache: SheetCache | null = null;
 
 const chunked = <T>(arr: T[], size: number): T[][] => {
   const out: T[][] = [];
@@ -189,6 +193,7 @@ export const POST = async (req: NextRequest) => {
         fetchMasterListRows(),
         fetchFeesClosedSheetRows(),
       ]);
+      sheetCache = { masterRows: masterRaw, feesClosedRows: feesClosedRaw, ts: Date.now() };
 
       const { rows: parsed, warnings } = mapSheetRows(masterRaw);
       const { rows: feesClosedParsed } = mapFeesClosedRows(feesClosedRaw);
@@ -310,10 +315,11 @@ export const POST = async (req: NextRequest) => {
 
     const selectedSet = new Set(ids);
 
-    const [{ rows: rawRows }, feesClosedRaw] = await Promise.all([
-      fetchMasterListRows(),
-      fetchFeesClosedSheetRows(),
-    ]);
+    const cached = sheetCache && Date.now() - sheetCache.ts < SHEET_CACHE_TTL ? sheetCache : null;
+    const [{ rows: rawRows }, feesClosedRaw] = cached
+      ? [{ rows: cached.masterRows }, cached.feesClosedRows]
+      : await Promise.all([fetchMasterListRows(), fetchFeesClosedSheetRows()]);
+    if (!cached) sheetCache = { masterRows: rawRows, feesClosedRows: feesClosedRaw, ts: Date.now() };
     const { rows: parsed } = mapSheetRows(rawRows);
     const { rows: feesClosedParsed } = mapFeesClosedRows(feesClosedRaw);
 
@@ -415,8 +421,37 @@ export const POST = async (req: NextRequest) => {
 
         inserted += insertedRows.length;
       }
-      if (updateRows.length > 0) {
-        await tx.execute(sql`
+      for (const batch of chunked(feesClosedMatches, CHUNK)) {
+        if (batch.length === 0) continue;
+
+        for (const row of batch) {
+          await tx
+            .update(feeRecords)
+            .set({
+              isClosed: true,
+              closedAt: row.closedAt,
+              winSheetStatus: "closed",
+              syncStatus: "synced",
+              syncedAt: new Date(),
+              updatedAt: new Date(),
+            })
+            .where(eq(feeRecords.caseId, row.clientId));
+        }
+
+        await tx.insert(activityLog).values(
+          batch.map((row) => ({
+            caseId: row.clientId,
+            message: "Marked closed from Fees Closed sheet during Google Sheets sync.",
+            createdBy: "Sheet Sync",
+          })),
+        );
+        closed += batch.length;
+      }
+    });
+
+    if (updateRows.length > 0) {
+      await Promise.all([
+        db.execute(sql`
           UPDATE cases SET
             external_id        = v.external_id,
             case_link          = v.case_link,
@@ -446,9 +481,8 @@ export const POST = async (req: NextRequest) => {
             sql`,`,
           )}) AS v(client_id, external_id, case_link, first_name, last_name, approval_date, level_won, claim_type, claim_type_label, alj_first_name, alj_last_name)
           WHERE cases.client_id = v.client_id::int
-        `);
-
-        await tx.execute(sql`
+        `),
+        db.execute(sql`
           UPDATE fee_records SET
             assigned_to              = v.assigned_to,
             win_sheet_status         = v.win_sheet_status,
@@ -480,75 +514,44 @@ export const POST = async (req: NextRequest) => {
             month_assigned_to_agent  = v.month_assigned_to_agent,
             updated_at               = now()
           FROM (VALUES ${sql.join(
-            updateRows.map((r) => {
-              const existingLink = existingLinkMap.get(r.clientId) ?? null;
-              return sql`(
-                ${r.clientId},
-                ${r.assignedTo},
-                ${r.winSheetStatus},
-                ${existingLink ?? r.winSheetLink},
-                ${r.winSheetLinkText},
-                ${r.caseStatus},
-                ${r.feesConfirmation},
-                ${r.dateAssignedToAgent},
-                ${r.approvedBy},
-                ${r.t16Retro},
-                ${r.t16FeeDue},
-                ${r.t16FeeReceived},
-                ${r.t16Pending},
-                ${r.t16FeeReceivedDate},
-                ${r.t2Retro},
-                ${r.t2FeeDue},
-                ${r.t2FeeReceived},
-                ${r.t2Pending},
-                ${r.t2FeeReceivedDate},
-                ${r.auxRetro},
-                ${r.auxFeeDue},
-                ${r.auxFeeReceived},
-                ${r.auxPending},
-                ${r.auxFeeReceivedDate},
-                ${r.daysAfterApproval},
-                ${r.approvalCategory},
-                ${r.feesStatus},
-                ${r.weekAssignedToAgent},
-                ${r.monthAssignedToAgent}
-              )`;
-            }),
+            updateRows.map((r) => sql`(
+              ${r.clientId},
+              ${r.assignedTo},
+              ${r.winSheetStatus},
+              ${existingLinkMap.get(r.clientId) ?? r.winSheetLink},
+              ${r.winSheetLinkText},
+              ${r.caseStatus},
+              ${r.feesConfirmation},
+              ${r.dateAssignedToAgent},
+              ${r.approvedBy},
+              ${r.t16Retro},
+              ${r.t16FeeDue},
+              ${r.t16FeeReceived},
+              ${r.t16Pending},
+              ${r.t16FeeReceivedDate},
+              ${r.t2Retro},
+              ${r.t2FeeDue},
+              ${r.t2FeeReceived},
+              ${r.t2Pending},
+              ${r.t2FeeReceivedDate},
+              ${r.auxRetro},
+              ${r.auxFeeDue},
+              ${r.auxFeeReceived},
+              ${r.auxPending},
+              ${r.auxFeeReceivedDate},
+              ${r.daysAfterApproval},
+              ${r.approvalCategory},
+              ${r.feesStatus},
+              ${r.weekAssignedToAgent},
+              ${r.monthAssignedToAgent}
+            )`),
             sql`,`,
           )}) AS v(case_id, assigned_to, win_sheet_status, win_sheet_link, win_sheet_link_text, case_status, fees_confirmation, date_assigned_to_agent, approved_by, t16_retro, t16_fee_due, t16_fee_received, t16_pending, t16_fee_received_date, t2_retro, t2_fee_due, t2_fee_received, t2_pending, t2_fee_received_date, aux_retro, aux_fee_due, aux_fee_received, aux_pending, aux_fee_received_date, days_after_approval, approval_category, fees_status, week_assigned_to_agent, month_assigned_to_agent)
           WHERE fee_records.case_id = v.case_id::int
-        `);
-
-        updated = updateRows.length;
-      }
-
-      for (const batch of chunked(feesClosedMatches, CHUNK)) {
-        if (batch.length === 0) continue;
-
-        for (const row of batch) {
-          await tx
-            .update(feeRecords)
-            .set({
-              isClosed: true,
-              closedAt: row.closedAt,
-              winSheetStatus: "closed",
-              syncStatus: "synced",
-              syncedAt: new Date(),
-              updatedAt: new Date(),
-            })
-            .where(eq(feeRecords.caseId, row.clientId));
-        }
-
-        await tx.insert(activityLog).values(
-          batch.map((row) => ({
-            caseId: row.clientId,
-            message: "Marked closed from Fees Closed sheet during Google Sheets sync.",
-            createdBy: "Sheet Sync",
-          })),
-        );
-        closed += batch.length;
-      }
-    });
+        `),
+      ]);
+      updated = updateRows.length;
+    }
 
     return NextResponse.json({ inserted, updated, closed });
   } catch (error) {

--- a/src/app/api/sheets/sync/route.ts
+++ b/src/app/api/sheets/sync/route.ts
@@ -14,7 +14,7 @@ import { mapFeesClosedRows } from "@/lib/import/fees-closed-mapper";
 import type { ParsedCaseRow } from "@/lib/import/xlsx-mapper";
 
 export const runtime = "nodejs";
-export const maxDuration = 60;
+export const maxDuration = 120;
 
 const CHUNK = 500;
 const SHEET_CACHE_TTL = 5 * 60 * 1000;
@@ -473,7 +473,7 @@ export const POST = async (req: NextRequest) => {
               ${r.lastName},
               ${r.approvalDate},
               ${r.levelWon},
-              ${JSON.stringify(r.claimType)},
+              ${'{' + r.claimType.join(',') + '}'},
               ${r.claimTypeLabel},
               ${r.aljFirstName},
               ${r.aljLastName}

--- a/src/app/api/sheets/sync/route.ts
+++ b/src/app/api/sheets/sync/route.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import { NextRequest, NextResponse } from "next/server";
-import { inArray, eq } from "drizzle-orm";
+import { inArray, eq, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { cases, feeRecords, activityLog } from "@/lib/db/schema";
 import { requireAdmin } from "@/lib/auth-helpers";
@@ -415,16 +415,111 @@ export const POST = async (req: NextRequest) => {
 
         inserted += insertedRows.length;
       }
-      for (const r of updateRows) {
-        await tx
-          .update(cases)
-          .set(toCaseUpdate(r))
-          .where(eq(cases.clientId, r.clientId));
-        await tx
-          .update(feeRecords)
-          .set(toFeeUpdate(r, existingLinkMap.get(r.clientId) ?? null))
-          .where(eq(feeRecords.caseId, r.clientId));
-        updated++;
+      if (updateRows.length > 0) {
+        await tx.execute(sql`
+          UPDATE cases SET
+            external_id        = v.external_id,
+            case_link          = v.case_link,
+            first_name         = v.first_name,
+            last_name          = v.last_name,
+            approval_date      = v.approval_date::date,
+            level_won          = v.level_won,
+            claim_type         = v.claim_type::text[],
+            claim_type_label   = v.claim_type_label,
+            alj_first_name     = v.alj_first_name,
+            alj_last_name      = v.alj_last_name,
+            updated_at         = now()
+          FROM (VALUES ${sql.join(
+            updateRows.map((r) => sql`(
+              ${r.clientId},
+              ${r.externalId},
+              ${r.caseLink},
+              ${r.firstName},
+              ${r.lastName},
+              ${r.approvalDate},
+              ${r.levelWon},
+              ${JSON.stringify(r.claimType)},
+              ${r.claimTypeLabel},
+              ${r.aljFirstName},
+              ${r.aljLastName}
+            )`),
+            sql`,`,
+          )}) AS v(client_id, external_id, case_link, first_name, last_name, approval_date, level_won, claim_type, claim_type_label, alj_first_name, alj_last_name)
+          WHERE cases.client_id = v.client_id::int
+        `);
+
+        await tx.execute(sql`
+          UPDATE fee_records SET
+            assigned_to              = v.assigned_to,
+            win_sheet_status         = v.win_sheet_status,
+            win_sheet_link           = v.win_sheet_link,
+            win_sheet_link_text      = v.win_sheet_link_text,
+            case_status              = v.case_status,
+            fees_confirmation        = v.fees_confirmation,
+            date_assigned_to_agent   = v.date_assigned_to_agent::date,
+            approved_by              = v.approved_by,
+            t16_retro                = v.t16_retro::numeric,
+            t16_fee_due              = v.t16_fee_due::numeric,
+            t16_fee_received         = v.t16_fee_received::numeric,
+            t16_pending              = v.t16_pending::numeric,
+            t16_fee_received_date    = v.t16_fee_received_date::date,
+            t2_retro                 = v.t2_retro::numeric,
+            t2_fee_due               = v.t2_fee_due::numeric,
+            t2_fee_received          = v.t2_fee_received::numeric,
+            t2_pending               = v.t2_pending::numeric,
+            t2_fee_received_date     = v.t2_fee_received_date::date,
+            aux_retro                = v.aux_retro::numeric,
+            aux_fee_due              = v.aux_fee_due::numeric,
+            aux_fee_received         = v.aux_fee_received::numeric,
+            aux_pending              = v.aux_pending::numeric,
+            aux_fee_received_date    = v.aux_fee_received_date::date,
+            days_after_approval      = v.days_after_approval::int,
+            approval_category        = v.approval_category,
+            fees_status              = v.fees_status,
+            week_assigned_to_agent   = v.week_assigned_to_agent,
+            month_assigned_to_agent  = v.month_assigned_to_agent,
+            updated_at               = now()
+          FROM (VALUES ${sql.join(
+            updateRows.map((r) => {
+              const existingLink = existingLinkMap.get(r.clientId) ?? null;
+              return sql`(
+                ${r.clientId},
+                ${r.assignedTo},
+                ${r.winSheetStatus},
+                ${existingLink ?? r.winSheetLink},
+                ${r.winSheetLinkText},
+                ${r.caseStatus},
+                ${r.feesConfirmation},
+                ${r.dateAssignedToAgent},
+                ${r.approvedBy},
+                ${r.t16Retro},
+                ${r.t16FeeDue},
+                ${r.t16FeeReceived},
+                ${r.t16Pending},
+                ${r.t16FeeReceivedDate},
+                ${r.t2Retro},
+                ${r.t2FeeDue},
+                ${r.t2FeeReceived},
+                ${r.t2Pending},
+                ${r.t2FeeReceivedDate},
+                ${r.auxRetro},
+                ${r.auxFeeDue},
+                ${r.auxFeeReceived},
+                ${r.auxPending},
+                ${r.auxFeeReceivedDate},
+                ${r.daysAfterApproval},
+                ${r.approvalCategory},
+                ${r.feesStatus},
+                ${r.weekAssignedToAgent},
+                ${r.monthAssignedToAgent}
+              )`;
+            }),
+            sql`,`,
+          )}) AS v(case_id, assigned_to, win_sheet_status, win_sheet_link, win_sheet_link_text, case_status, fees_confirmation, date_assigned_to_agent, approved_by, t16_retro, t16_fee_due, t16_fee_received, t16_pending, t16_fee_received_date, t2_retro, t2_fee_due, t2_fee_received, t2_pending, t2_fee_received_date, aux_retro, aux_fee_due, aux_fee_received, aux_pending, aux_fee_received_date, days_after_approval, approval_category, fees_status, week_assigned_to_agent, month_assigned_to_agent)
+          WHERE fee_records.case_id = v.case_id::int
+        `);
+
+        updated = updateRows.length;
       }
 
       for (const batch of chunked(feesClosedMatches, CHUNK)) {

--- a/src/app/api/sheets/sync/route.ts
+++ b/src/app/api/sheets/sync/route.ts
@@ -239,6 +239,7 @@ export const POST = async (req: NextRequest) => {
           auxFeeReceived: feeRecords.auxFeeReceived,
           auxPending: feeRecords.auxPending,
           auxFeeReceivedDate: feeRecords.auxFeeReceivedDate,
+          isClosed: feeRecords.isClosed,
         })
         .from(cases)
         .leftJoin(feeRecords, eq(feeRecords.caseId, cases.clientId));
@@ -333,7 +334,7 @@ export const POST = async (req: NextRequest) => {
       );
 
       const feesClosedRows = dbOnlyCases
-        .filter((c) => c.caseLink && feesClosedCaseNameSet.has(c.caseLink.trim()))
+        .filter((c) => !c.isClosed && c.caseLink && feesClosedCaseNameSet.has(c.caseLink.trim()))
         .map((c) => ({
           clientId: c.clientId,
           caseName: `${c.lastName}, ${c.firstName}`,
@@ -343,7 +344,7 @@ export const POST = async (req: NextRequest) => {
         }));
 
       const missingRows = dbOnlyCases
-        .filter((c) => !c.caseLink || !feesClosedCaseNameSet.has(c.caseLink.trim()))
+        .filter((c) => !c.isClosed && (!c.caseLink || !feesClosedCaseNameSet.has(c.caseLink.trim())))
         .map((c) => ({
           clientId: c.clientId,
           caseName: `${c.lastName}, ${c.firstName}`,
@@ -506,16 +507,26 @@ export const POST = async (req: NextRequest) => {
 
         for (const row of batch) {
           await tx
-            .update(feeRecords)
-            .set({
+            .insert(feeRecords)
+            .values({
+              caseId: row.clientId,
               isClosed: true,
               closedAt: row.closedAt,
               winSheetStatus: "closed",
               syncStatus: "synced",
               syncedAt: new Date(),
-              updatedAt: new Date(),
             })
-            .where(eq(feeRecords.caseId, row.clientId));
+            .onConflictDoUpdate({
+              target: feeRecords.caseId,
+              set: {
+                isClosed: true,
+                closedAt: row.closedAt,
+                winSheetStatus: "closed",
+                syncStatus: "synced",
+                syncedAt: new Date(),
+                updatedAt: new Date(),
+              },
+            });
         }
 
         await tx.insert(activityLog).values(

--- a/src/app/api/sheets/sync/route.ts
+++ b/src/app/api/sheets/sync/route.ts
@@ -115,52 +115,6 @@ const toFeeInsert = (r: ParsedCaseRow) => ({
   monthAssignedToAgent: r.monthAssignedToAgent,
 });
 
-const toCaseUpdate = (r: ParsedCaseRow) => ({
-  externalId: r.externalId,
-  caseLink: r.caseLink,
-  firstName: r.firstName,
-  lastName: r.lastName,
-  approvalDate: r.approvalDate,
-  levelWon: r.levelWon,
-  claimType: r.claimType,
-  claimTypeLabel: r.claimTypeLabel,
-  aljFirstName: r.aljFirstName,
-  aljLastName: r.aljLastName,
-  updatedAt: new Date(),
-});
-
-const toFeeUpdate = (r: ParsedCaseRow, existingWinSheetLink: string | null) => ({
-  assignedTo: r.assignedTo,
-  winSheetStatus: r.winSheetStatus,
-  winSheetLink: existingWinSheetLink ?? r.winSheetLink,
-  winSheetLinkText: r.winSheetLinkText,
-  caseStatus: r.caseStatus,
-  feesConfirmation: r.feesConfirmation,
-  dateAssignedToAgent: r.dateAssignedToAgent,
-  approvedBy: r.approvedBy,
-  t16Retro: r.t16Retro,
-  t16FeeDue: r.t16FeeDue,
-  t16FeeReceived: r.t16FeeReceived,
-  t16Pending: r.t16Pending,
-  t16FeeReceivedDate: r.t16FeeReceivedDate,
-  t2Retro: r.t2Retro,
-  t2FeeDue: r.t2FeeDue,
-  t2FeeReceived: r.t2FeeReceived,
-  t2Pending: r.t2Pending,
-  t2FeeReceivedDate: r.t2FeeReceivedDate,
-  auxRetro: r.auxRetro,
-  auxFeeDue: r.auxFeeDue,
-  auxFeeReceived: r.auxFeeReceived,
-  auxPending: r.auxPending,
-  auxFeeReceivedDate: r.auxFeeReceivedDate,
-  daysAfterApproval: r.daysAfterApproval,
-  approvalCategory: r.approvalCategory,
-  feesStatus: r.feesStatus,
-  weekAssignedToAgent: r.weekAssignedToAgent,
-  monthAssignedToAgent: r.monthAssignedToAgent,
-  updatedAt: new Date(),
-});
-
 const toClosedAt = (closedDate: string | null): Date | null => {
   if (!closedDate) return null;
   const parsed = new Date(`${closedDate}T12:00:00`);

--- a/src/components/modals/SheetSyncModal.tsx
+++ b/src/components/modals/SheetSyncModal.tsx
@@ -28,7 +28,8 @@ interface SheetPreviewRow {
   totalExpected: number;
   hasNotes: boolean;
   isSynthetic: boolean;
-  status: "new" | "existing";
+  status: "new" | "changed" | "unchanged";
+  changedFields: { field: string; sheet: string; db: string }[];
 }
 
 interface DbOnlyRow {
@@ -39,7 +40,7 @@ interface DbOnlyRow {
   status: "fees_closed" | "missing";
 }
 
-type Step4Filter = "all" | "new" | "existing" | "fees_closed" | "missing";
+type Step4Filter = "all" | "new" | "changed" | "unchanged" | "fees_closed" | "missing";
 
 type Step4PreviewRow =
   | (SheetPreviewRow & { syncable: true })
@@ -50,7 +51,8 @@ interface SyncPreviewResponse {
   summary: {
     fetched: number;
     new: number;
-    existing: number;
+    changed: number;
+    unchanged: number;
     feesClosed: number;
     missing: number;
     synthetic: number;
@@ -106,20 +108,23 @@ const STATUS_PILL: Record<string, string> = {
   closed: "bg-neutral-200 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-400",
 };
 
-const STATUS_BADGE = {
-  new: (dark: boolean) =>
+const STATUS_BADGE: Record<string, (dark: boolean) => string> = {
+  new: (dark) =>
     dark ? "bg-emerald-900/40 text-emerald-400" : "bg-emerald-100 text-emerald-700",
-  existing: (dark: boolean) =>
+  changed: (dark) =>
     dark ? "bg-blue-900/40 text-blue-400" : "bg-blue-100 text-blue-700",
-  fees_closed: (dark: boolean) =>
+  unchanged: (dark) =>
+    dark ? "bg-neutral-800 text-neutral-400" : "bg-neutral-100 text-neutral-600",
+  fees_closed: (dark) =>
     dark ? "bg-violet-900/40 text-violet-400" : "bg-violet-100 text-violet-700",
-  missing: (dark: boolean) =>
+  missing: (dark) =>
     dark ? "bg-amber-900/40 text-amber-400" : "bg-amber-100 text-amber-700",
 };
 
-const STATUS_LABEL = {
+const STATUS_LABEL: Record<string, string> = {
   new: "NEW",
-  existing: "TO UPDATE",
+  changed: "CHANGED",
+  unchanged: "UP TO DATE",
   fees_closed: "FEES CLOSED",
   missing: "MISSING",
 };
@@ -166,14 +171,12 @@ export default function SheetSyncModal({
       setPreview(data);
       setAllowSynthetic(false);
       setSelected(
-        new Set(
-          [
-            ...data.rows.sheet
-              .filter((r) => !r.isSynthetic)
-              .map((r) => r.clientId),
-            ...data.rows.feesClosed.map((r) => r.clientId),
-          ],
-        ),
+        new Set([
+          ...data.rows.sheet
+            .filter((r) => (r.status === "new" || r.status === "changed") && !r.isSynthetic)
+            .map((r) => r.clientId),
+          ...data.rows.feesClosed.map((r) => r.clientId),
+        ]),
       );
     } catch (e) {
       const err = e as Error;
@@ -192,8 +195,12 @@ export default function SheetSyncModal({
     () => preview?.rows.sheet.filter((r) => r.status === "new") ?? [],
     [preview],
   );
-  const existingRows = useMemo(
-    () => preview?.rows.sheet.filter((r) => r.status === "existing") ?? [],
+  const changedRows = useMemo(
+    () => preview?.rows.sheet.filter((r) => r.status === "changed") ?? [],
+    [preview],
+  );
+  const unchangedRows = useMemo(
+    () => preview?.rows.sheet.filter((r) => r.status === "unchanged") ?? [],
     [preview],
   );
   const syntheticRows = useMemo(
@@ -413,13 +420,23 @@ export default function SheetSyncModal({
                       connect a real sheet
                     </div>
                   )}
-                  <div className="grid grid-cols-2 sm:grid-cols-5 gap-3">
+                  <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-3">
                     <Stat t={t} label="Rows fetched" value={preview.summary.fetched.toLocaleString()} />
                     <Stat
                       t={t}
                       label="New cases"
                       value={preview.summary.new.toLocaleString()}
                       accent={dark ? "text-emerald-400" : "text-emerald-600"}
+                    />
+                    <Stat
+                      t={t}
+                      label="Changed"
+                      value={preview.summary.changed.toLocaleString()}
+                      accent={
+                        preview.summary.changed > 0
+                          ? dark ? "text-blue-400" : "text-blue-600"
+                          : undefined
+                      }
                     />
                     <Stat
                       t={t}
@@ -523,9 +540,10 @@ export default function SheetSyncModal({
               <p className={`text-[11px] ${t.textMuted} mb-4`}>
                 Four categories based on where each record exists.
               </p>
-              <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-5">
+              <div className="grid grid-cols-2 sm:grid-cols-5 gap-3 mb-5">
                 <Stat t={t} label="New" value={preview.summary.new.toLocaleString()} accent={dark ? "text-emerald-400" : "text-emerald-600"} />
-                <Stat t={t} label="Existing" value={preview.summary.existing.toLocaleString()} accent={dark ? "text-blue-400" : "text-blue-600"} />
+                <Stat t={t} label="Changed" value={preview.summary.changed.toLocaleString()} accent={preview.summary.changed > 0 ? (dark ? "text-blue-400" : "text-blue-600") : undefined} />
+                <Stat t={t} label="Up to date" value={preview.summary.unchanged.toLocaleString()} />
                 <Stat t={t} label="Fees Closed" value={preview.summary.feesClosed.toLocaleString()} accent={dark ? "text-violet-400" : "text-violet-600"} />
                 <Stat
                   t={t}
@@ -551,18 +569,34 @@ export default function SheetSyncModal({
                   />
                 </CategorySection>
                 <CategorySection
-                  status="existing"
-                  count={preview.summary.existing}
-                  description="In sheet · already in database — values will be updated on sync"
+                  status="changed"
+                  count={preview.summary.changed}
+                  description="In sheet · already in database · values have changed — will be updated on sync"
                   dark={dark}
                   t={t}
                 >
                   <SheetRowsTable
                     t={t}
                     dark={dark}
-                    rows={existingRows.slice(0, 100)}
-                    truncated={existingRows.length > 100}
-                    total={existingRows.length}
+                    rows={changedRows.slice(0, 100)}
+                    truncated={changedRows.length > 100}
+                    total={changedRows.length}
+                    showChangedFields
+                  />
+                </CategorySection>
+                <CategorySection
+                  status="unchanged"
+                  count={preview.summary.unchanged}
+                  description="In sheet · already in database · no changes detected — skipped by default"
+                  dark={dark}
+                  t={t}
+                >
+                  <SheetRowsTable
+                    t={t}
+                    dark={dark}
+                    rows={unchangedRows.slice(0, 100)}
+                    truncated={unchangedRows.length > 100}
+                    total={unchangedRows.length}
                   />
                 </CategorySection>
                 <CategorySection
@@ -618,7 +652,8 @@ export default function SheetSyncModal({
                 >
                   <option value="all">All rows</option>
                   <option value="new">New only</option>
-                  <option value="existing">To update only</option>
+                  <option value="changed">Changed only</option>
+                  <option value="unchanged">Up to date only</option>
                   <option value="fees_closed">Fees Closed only</option>
                   <option value="missing">Missing only</option>
                 </select>
@@ -790,7 +825,7 @@ const CategorySection = ({
   t,
   children,
 }: {
-  status: "new" | "existing" | "fees_closed" | "missing";
+  status: "new" | "changed" | "unchanged" | "fees_closed" | "missing";
   count: number;
   description: string;
   dark: boolean;
@@ -823,12 +858,14 @@ const SheetRowsTable = ({
   rows,
   truncated,
   total,
+  showChangedFields,
 }: {
   t: ReturnType<typeof themeClasses>;
   dark: boolean;
   rows: SheetPreviewRow[];
   truncated: boolean;
   total: number;
+  showChangedFields?: boolean;
 }) => (
   <div className={`rounded-lg border ${t.borderLight} overflow-hidden`}>
     <div className="overflow-x-auto">
@@ -836,6 +873,7 @@ const SheetRowsTable = ({
         <thead>
           <tr className={`border-b ${t.borderLight} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"}`}>
             <Th>Case</Th>
+            {showChangedFields && <Th>Changed (sheet → db)</Th>}
             <Th>Approved</Th>
             <Th>Assigned</Th>
             <Th>Win Sheet</Th>
@@ -860,6 +898,25 @@ const SheetRowsTable = ({
                   </a>
                 )}
               </td>
+              {showChangedFields && (
+                <td className="px-3 py-1.5 max-w-64">
+                  <div className={`text-[10px] font-mono space-y-0.5 ${dark ? "text-blue-300" : "text-blue-700"}`}>
+                    {r.changedFields.slice(0, 3).map((f) => (
+                      <div key={f.field} className="leading-tight">
+                        <span className="font-semibold">{f.field}</span>
+                        <span className={`ml-1 ${dark ? "text-neutral-400" : "text-neutral-500"}`}>
+                          {f.sheet || "∅"} → {f.db || "∅"}
+                        </span>
+                      </div>
+                    ))}
+                    {r.changedFields.length > 3 && (
+                      <div className={`${dark ? "text-neutral-500" : "text-neutral-400"}`}>
+                        +{r.changedFields.length - 3} more
+                      </div>
+                    )}
+                  </div>
+                </td>
+              )}
               <td className={`${t.textSub} px-3 py-1.5 tabular-nums`}>{fmtDate(r.approvalDate)}</td>
               <td className={`${t.textSub} px-3 py-1.5`}>{r.assignedTo ?? "—"}</td>
               <td className="px-3 py-1.5">

--- a/src/components/modals/SheetSyncModal.tsx
+++ b/src/components/modals/SheetSyncModal.tsx
@@ -169,7 +169,7 @@ export default function SheetSyncModal({
         new Set(
           [
             ...data.rows.sheet
-              .filter((r) => r.status === "new" && !r.isSynthetic)
+              .filter((r) => !r.isSynthetic)
               .map((r) => r.clientId),
             ...data.rows.feesClosed.map((r) => r.clientId),
           ],

--- a/src/lib/import/__tests__/sheets-mapper.test.ts
+++ b/src/lib/import/__tests__/sheets-mapper.test.ts
@@ -149,9 +149,9 @@ describe("CASE LINK name parsing", () => {
     expect(ws.some((w) => w.message.includes("Could not parse name"))).toBe(true);
   });
 
-  it("emits warning when there is no v. separator", () => {
+  it("emits warning when there is no v separator", () => {
     const ws = warnings([row({ "CASE LINK": "2024.01.15 Smith John" })]);
-    expect(ws.some((w) => w.message.includes("Could not parse name"))).toBe(true);
+    expect(ws.some((w) => w.message.includes('No "v" separator found'))).toBe(true);
   });
 
   it("falls back to Unknown when name cannot be parsed", () => {

--- a/src/lib/import/sheets-mapper.ts
+++ b/src/lib/import/sheets-mapper.ts
@@ -28,18 +28,25 @@ const dateOnly = (v: unknown): string | null => {
 const parseCaseLink = (link: string) => {
   let s = link.trim();
   s = s.replace(/^\d{4}[.\-/]\d{1,2}[.\-/]\d{1,2}\s+/, "");
-  const parts = s.split(/\s+v(?:s|\.)\s+/i);
+  const parts = s.split(/\s+vs?\.?\s+/i);
   const left = parts[0] || "";
   const right = parts[1] || "";
-  const leftClean = left.replace(/\s*\([^)]*\)\s*$/, "").trim();
-  const [lastRaw, firstRaw] = leftClean.split(/,\s*/);
+  const leftClean = left.replace(/\s*\([^)]*\)?$/, "").trim();
+  let lastRaw: string, firstRaw: string;
+  if (leftClean.includes(",")) {
+    [lastRaw, firstRaw] = leftClean.split(/,\s*/);
+  } else {
+    const tokens = leftClean.split(/\s+/);
+    lastRaw = tokens[0] ?? leftClean;
+    firstRaw = tokens.slice(1).join(" ");
+  }
   const lastName = (lastRaw || leftClean).trim();
   const firstName = (firstRaw || "").trim();
   let aljFirstName: string | null = null;
   let aljLastName: string | null = null;
   const aljClean = right
     .replace(/^ALJ\s+/i, "")
-    .replace(/\s*\([^)]*\)\s*$/, "")
+    .replace(/\s*\([^)]*\)?$/, "")
     .trim();
   if (aljClean && !/^SSA$/i.test(aljClean)) {
     const tokens = aljClean.split(/\s+/);
@@ -50,7 +57,8 @@ const parseCaseLink = (link: string) => {
       aljLastName = tokens[0] ?? null;
     }
   }
-  return { firstName, lastName, aljFirstName, aljLastName };
+  const missingVSeparator = parts.length === 1;
+  return { firstName, lastName, aljFirstName, aljLastName, missingVSeparator };
 };
 
 const mapClaimType = (raw: unknown) => {
@@ -139,11 +147,16 @@ export const mapSheetRows = (
     }
     seenIds.add(clientId);
 
-    const { firstName, lastName, aljFirstName, aljLastName } = parseCaseLink(linkText);
+    const { firstName, lastName, aljFirstName, aljLastName, missingVSeparator } = parseCaseLink(linkText);
     if (!firstName || !lastName) {
       warnings.push({
         row: i + 2,
         message: `Could not parse name from CASE LINK "${linkText.slice(0, 50)}" — stored as Unknown`,
+      });
+    } else if (missingVSeparator) {
+      warnings.push({
+        row: i + 2,
+        message: `No "v" separator found in CASE LINK "${linkText.slice(0, 50)}" — ALJ data not captured`,
       });
     }
 

--- a/src/lib/import/sheets-mapper.ts
+++ b/src/lib/import/sheets-mapper.ts
@@ -16,11 +16,15 @@ const dateOnly = (v: unknown): string | null => {
   const s = String(v).trim();
   if (!s) return null;
   const m = s.match(/^(\d{4})[-/.](\d{1,2})[-/.](\d{1,2})$/);
-  if (m) return `${m[1]}-${m[2].padStart(2, "0")}-${m[3].padStart(2, "0")}`;
+  if (m) {
+    const iso = `${m[1]}-${m[2].padStart(2, "0")}-${m[3].padStart(2, "0")}`;
+    return Number.isNaN(new Date(iso).getTime()) ? null : iso;
+  }
   const m2 = s.match(/^(\d{1,2})\/(\d{1,2})\/(\d{2,4})$/);
   if (m2) {
     const yy = m2[3].length === 2 ? `20${m2[3]}` : m2[3];
-    return `${yy}-${m2[1].padStart(2, "0")}-${m2[2].padStart(2, "0")}`;
+    const iso = `${yy}-${m2[1].padStart(2, "0")}-${m2[2].padStart(2, "0")}`;
+    return Number.isNaN(new Date(iso).getTime()) ? null : iso;
   }
   return null;
 };
@@ -100,8 +104,8 @@ const mapWinSheetStatus = (raw: unknown): ParsedCaseRow["winSheetStatus"] => {
     .toLowerCase();
   if (!s) return "not_started";
   if (s === "finished") return "closed";
-  if (s.includes("started")) return "started";
   if (s === "not started" || s === "not_started") return "not_started";
+  if (s.includes("started")) return "started";
   if (s === "in progress" || s === "in_progress") return "in_progress";
   if (s === "pending payment") return "pending_payment";
   if (s === "partially paid") return "partially_paid";

--- a/src/lib/import/sheets-mapper.ts
+++ b/src/lib/import/sheets-mapper.ts
@@ -32,7 +32,7 @@ const dateOnly = (v: unknown): string | null => {
 const parseCaseLink = (link: string) => {
   let s = link.trim();
   s = s.replace(/^\d{4}[.\-/]\d{1,2}[.\-/]\d{1,2}\s+/, "");
-  const parts = s.split(/\s+vs?\.?\s+/i);
+  const parts = s.split(/\s+vs?\.?\s*/i);
   const left = parts[0] || "";
   const right = parts[1] || "";
   const leftClean = left.replace(/\s*\([^)]*\)?$/, "").trim();

--- a/src/lib/import/sheets-mapper.ts
+++ b/src/lib/import/sheets-mapper.ts
@@ -32,7 +32,7 @@ const dateOnly = (v: unknown): string | null => {
 const parseCaseLink = (link: string) => {
   let s = link.trim();
   s = s.replace(/^\d{4}[.\-/]\d{1,2}[.\-/]\d{1,2}\s+/, "");
-  const parts = s.split(/\s+vs?(?:\.\s*|\s+)/i);
+  const parts = s.split(/\s+vs?(?:[.,]\s*|\s+)/i);
   const left = parts[0] || "";
   const right = parts[1] || "";
   const leftClean = left.replace(/\s*\([^)]*\)?$/, "").trim();

--- a/src/lib/import/sheets-mapper.ts
+++ b/src/lib/import/sheets-mapper.ts
@@ -32,7 +32,7 @@ const dateOnly = (v: unknown): string | null => {
 const parseCaseLink = (link: string) => {
   let s = link.trim();
   s = s.replace(/^\d{4}[.\-/]\d{1,2}[.\-/]\d{1,2}\s+/, "");
-  const parts = s.split(/\s+vs?\.?\s*/i);
+  const parts = s.split(/\s+vs?(?:\.\s*|\s+)/i);
   const left = parts[0] || "";
   const right = parts[1] || "";
   const leftClean = left.replace(/\s*\([^)]*\)?$/, "").trim();

--- a/src/lib/import/xlsx-mapper.ts
+++ b/src/lib/import/xlsx-mapper.ts
@@ -184,8 +184,8 @@ const mapWinSheetStatus = (raw: unknown): ParsedCaseRow["winSheetStatus"] => {
     .toLowerCase();
   if (!s) return "not_started";
   if (s === "finished") return "closed";
-  if (s.includes("started")) return "started";
   if (s === "not started" || s === "not_started") return "not_started";
+  if (s.includes("started")) return "started";
   if (s === "in progress" || s === "in_progress") return "in_progress";
   if (s === "pending payment") return "pending_payment";
   if (s === "partially paid") return "partially_paid";


### PR DESCRIPTION
## Summary

- Broadens the `v` separator regex from `/\s+v(?:s|\.)\s+/i` to `/\s+vs?\.?\s+/i` so bare ` v ` (no period, no trailing s) splits correctly
- Adds a no-comma fallback for claimant names: when the CASE LINK has no comma, splits on whitespace assuming `Last First` order (matching the sheet's `Last, First` convention)
- Fixes parse warnings on rows like `Horst Amanda v ALJ BRENDA ROSTEN (SSDI` and `Schomberg Matthieu v. SSA`