### PR TITLE
feat: mycase sync, win sheet quick look, and case tagging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,48 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Database
+# ──────────────────────────────────────────────────────────────────────────────
+
+# Main app database (Neon PostgreSQL — session pooler URL)
+DATABASE_URL=postgresql://user:password@host/dbname?sslmode=require&channel_binding=require
+
+# MyCase mirror database (Neon PostgreSQL — read-only replica)
+MYCASE_DB_URL=postgresql://user:password@host/dbname?sslmode=require&channel_binding=require
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Auth (NextAuth v5)
+# ──────────────────────────────────────────────────────────────────────────────
+
+AUTH_SECRET=your-nextauth-secret
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Chronicle API
+# ──────────────────────────────────────────────────────────────────────────────
+
+CHRONICLE_API_URL=https://api.chroniclelegal.com
+CHRONICLE_API_KEY=your-chronicle-api-key
+
+# ──────────────────────────────────────────────────────────────────────────────
+# n8n Webhooks
+# ──────────────────────────────────────────────────────────────────────────────
+
+# Google Sheets sync (pull from Sheets into app DB)
+SHEETS_SYNC_WEBHOOK_URL=https://your-n8n-instance/webhook/hsl-sheets-sync
+
+# Google Sheets push (push from app DB to Sheets)
+SHEETS_PUSH_WEBHOOK_URL=https://your-n8n-instance/webhook/hsl-sheets-push
+
+# Fees closed sync
+FEES_CLOSED_SYNC_WEBHOOK_URL=https://your-n8n-instance/webhook/hsl-fees-closed-sync
+
+# New user welcome email
+N8N_NEW_USER_EMAIL_WEBHOOK_URL=https://your-n8n-instance/webhook/hsl-new-user-email
+
+# MyCase — document list for a case (protected with token header)
+N8N_MYCASE_DOCS_WEBHOOK_URL=https://your-n8n-instance/webhook/your-docs-webhook-id
+N8N_MYCASE_DOCS_WEBHOOK_TOKEN=your-docs-webhook-token
+
+# MyCase — single document file download
+N8N_MYCASE_DOC_FILE_WEBHOOK_URL=https://your-n8n-instance/webhook/your-doc-file-webhook-id
+
+# MyCase — case detail fields (approval date, fee amounts, decisions, etc.)
+N8N_MYCASE_CASE_DETAIL_WEBHOOK_URL=https://your-n8n-instance/webhook/mycase-case-details

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env*
 .env.local*
+!.env.example
 
 # Spreadsheets (may contain PHI/PII — keep out of git)
 *.xlsx

--- a/README.md
+++ b/README.md
@@ -14,35 +14,17 @@ This is a [Next.js](https://nextjs.org) dashboard for HSL Fee Collection, using 
 
 2. **Configure environment variables:**
 
-   Create a `.env.local` file in the project root with:
+   Copy `.env.example` to `.env.local` and fill in the values:
 
-   ```env
-   # Database (Neon / PostgreSQL)
-   DATABASE_URL=your_postgres_connection_string
-
-   # Auth (NextAuth v5)
-   AUTH_SECRET=your_auth_secret
-
-   # Chronicle API
-   CHRONICLE_API_URL=https://api.chroniclelegal.com
-   CHRONICLE_BASE_URL=https://app.chroniclelegal.com
-   CHRONICLE_API_KEY=your_chronicle_api_key
-
-   # MyCase
-   MYCASE_API_URL=your_mycase_api_url
-   MYCASE_API_KEY=your_mycase_api_key
-   MYCASE_DB_URL=your_mycase_db_connection_string
-
-   # Webhooks
-   SHEETS_SYNC_WEBHOOK_URL=your_sheets_sync_webhook_url
-   SHEETS_PUSH_WEBHOOK_URL=your_sheets_push_webhook_url
-   FEES_CLOSED_SYNC_WEBHOOK_URL=your_fees_closed_sync_webhook_url
-
-   # Misc
-   CALLTOOLS_API_KEY=your_calltools_api_key
+   ```bash
+   cp .env.example .env.local
    ```
 
-   _Do not commit secrets!_
+   Required vars: `DATABASE_URL`, `MYCASE_DB_URL`, `AUTH_SECRET`, `CHRONICLE_API_URL`, `CHRONICLE_API_KEY`, and the n8n webhook URLs. See `.env.example` for the full list with descriptions.
+
+   Optional (used by the settings/connections page): `CHRONICLE_BASE_URL`, `MYCASE_API_URL`, `MYCASE_API_KEY`, `CALLTOOLS_API_KEY`.
+
+   _Do not commit `.env.local`._
 
 3. **Run the development server:**
 

--- a/drizzle/0017_mycase_sync_tags.sql
+++ b/drizzle/0017_mycase_sync_tags.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "mycase_sync_tags" (
+	"mycase_case_id" integer PRIMARY KEY NOT NULL,
+	"tag" varchar(50) DEFAULT 'viewed' NOT NULL,
+	"tagged_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"tagged_by" varchar(255)
+);

--- a/drizzle/meta/0017_snapshot.json
+++ b/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,2739 @@
+{
+  "id": "83c7c70c-681a-4f61-8b2d-d54be222e6c1",
+  "prevId": "e6e50f58-0fcf-48b2-a6af-6416f61ebb06",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_log": {
+      "name": "activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_record_id": {
+          "name": "fee_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_activity_log_case_id": {
+          "name": "idx_activity_log_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_log_created_at": {
+          "name": "idx_activity_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_log_case_id_cases_client_id_fk": {
+          "name": "activity_log_case_id_cases_client_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_log_fee_record_id_fee_records_id_fk": {
+          "name": "activity_log_fee_record_id_fee_records_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "fee_records",
+          "columnsFrom": [
+            "fee_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_settings": {
+      "name": "app_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approved_by_options": {
+      "name": "approved_by_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "approved_by_options_name_unique": {
+          "name": "approved_by_options_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cases": {
+      "name": "cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dob": {
+          "name": "dob",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last4_ssn": {
+          "name": "last4_ssn",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_type": {
+          "name": "claim_type",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "claim_type_label": {
+          "name": "claim_type_label",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level_won": {
+          "name": "level_won",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "t2_decision": {
+          "name": "t2_decision",
+          "type": "decision_outcome_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'unknown'"
+        },
+        "t16_decision": {
+          "name": "t16_decision",
+          "type": "decision_outcome_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'unknown'"
+        },
+        "application_date": {
+          "name": "application_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alleged_onset_date": {
+          "name": "alleged_onset_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_date": {
+          "name": "approval_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_date": {
+          "name": "closure_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_held_date": {
+          "name": "hearing_held_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_scheduled_date": {
+          "name": "hearing_scheduled_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_scheduled_datetime": {
+          "name": "hearing_scheduled_datetime",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_timezone": {
+          "name": "hearing_timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "office_with_jurisdiction": {
+          "name": "office_with_jurisdiction",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alj_first_name": {
+          "name": "alj_first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alj_last_name": {
+          "name": "alj_last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimant_location": {
+          "name": "claimant_location",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representative_location": {
+          "name": "representative_location",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_expert": {
+          "name": "medical_expert",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vocational_expert": {
+          "name": "vocational_expert",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_file_link": {
+          "name": "all_file_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exhibits_file_link": {
+          "name": "exhibits_file_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_file_updated_at": {
+          "name": "all_file_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exhibits_file_updated_at": {
+          "name": "exhibits_file_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_ssn": {
+          "name": "full_ssn",
+          "type": "varchar(11)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_diagnosis": {
+          "name": "primary_diagnosis",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_diagnosis_code": {
+          "name": "primary_diagnosis_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secondary_diagnosis": {
+          "name": "secondary_diagnosis",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secondary_diagnosis_code": {
+          "name": "secondary_diagnosis_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allegations": {
+          "name": "allegations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blind_dli": {
+          "name": "blind_dli",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firm_name": {
+          "name": "firm_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firm_ein": {
+          "name": "firm_ein",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_office": {
+          "name": "hearing_office",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representatives": {
+          "name": "representatives",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_history": {
+          "name": "decision_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_type": {
+          "name": "report_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expedited_case": {
+          "name": "expedited_case",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_of_case": {
+          "name": "status_of_case",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_date": {
+          "name": "status_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_date": {
+          "name": "request_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_date": {
+          "name": "receipt_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_date_assigned": {
+          "name": "first_date_assigned",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_fqr_starts": {
+          "name": "date_fqr_starts",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_insured": {
+          "name": "last_insured",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_created_at": {
+          "name": "source_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_updated_at": {
+          "name": "source_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ere_session_date": {
+          "name": "last_ere_session_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status_report_date": {
+          "name": "last_status_report_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documents_last_added_at": {
+          "name": "documents_last_added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invalid_ssn": {
+          "name": "invalid_ssn",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ssn_encrypted": {
+          "name": "ssn_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_link": {
+          "name": "case_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_pulled_at": {
+          "name": "last_pulled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_cases_client_id": {
+          "name": "idx_cases_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_external_id": {
+          "name": "idx_cases_external_id",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_claim_type_label": {
+          "name": "idx_cases_claim_type_label",
+          "columns": [
+            {
+              "expression": "claim_type_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_approval_date": {
+          "name": "idx_cases_approval_date",
+          "columns": [
+            {
+              "expression": "approval_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_last_name": {
+          "name": "idx_cases_last_name",
+          "columns": [
+            {
+              "expression": "last_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cases_client_id_unique": {
+          "name": "cases_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chronicle_documents": {
+      "name": "chronicle_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mycase_client_id": {
+          "name": "mycase_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chronicle_client_id": {
+          "name": "chronicle_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chronicle_document_id": {
+          "name": "chronicle_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_name": {
+          "name": "document_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_category": {
+          "name": "document_category",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_document": {
+          "name": "raw_document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chronicle_documents_case_id": {
+          "name": "idx_chronicle_documents_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chronicle_documents_case_id_cases_client_id_fk": {
+          "name": "chronicle_documents_case_id_cases_client_id_fk",
+          "tableFrom": "chronicle_documents",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chronicle_documents_case_id_chronicle_document_id_unique": {
+          "name": "chronicle_documents_case_id_chronicle_document_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id",
+            "chronicle_document_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_metrics": {
+      "name": "daily_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_date": {
+          "name": "metric_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ssa_calls": {
+          "name": "ssa_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "client_calls_ib": {
+          "name": "client_calls_ib",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "client_calls_ob": {
+          "name": "client_calls_ob",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_metrics_agent": {
+          "name": "idx_daily_metrics_agent",
+          "columns": [
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_metrics_date": {
+          "name": "idx_daily_metrics_date",
+          "columns": [
+            {
+              "expression": "metric_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_metrics_agent_name_team_members_name_fk": {
+          "name": "daily_metrics_agent_name_team_members_name_fk",
+          "tableFrom": "daily_metrics",
+          "tableTo": "team_members",
+          "columnsFrom": [
+            "agent_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dropdown_options": {
+      "name": "dropdown_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(150)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_dropdown_options_category_name": {
+          "name": "uq_dropdown_options_category_name",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dropdown_options_category": {
+          "name": "idx_dropdown_options_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_cap_history": {
+      "name": "fee_cap_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cap_amount": {
+          "name": "cap_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fee_cap_history_effective_date_unique": {
+          "name": "fee_cap_history_effective_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "effective_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_petitions": {
+      "name": "fee_petitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "noa": {
+          "name": "noa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "time_delineation": {
+          "name": "time_delineation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "fee_petition_doc": {
+          "name": "fee_petition_doc",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ltr_to_clmt": {
+          "name": "ltr_to_clmt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ltr_to_clmt_with_signature": {
+          "name": "ltr_to_clmt_with_signature",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ltr_to_alj": {
+          "name": "ltr_to_alj",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "fax_conf_fee_pet": {
+          "name": "fax_conf_fee_pet",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "update_note": {
+          "name": "update_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fee_petitions_case_id": {
+          "name": "idx_fee_petitions_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fee_petitions_case_id_cases_client_id_fk": {
+          "name": "fee_petitions_case_id_cases_client_id_fk",
+          "tableFrom": "fee_petitions",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fee_petitions_case_id_unique": {
+          "name": "fee_petitions_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_records": {
+      "name": "fee_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "win_sheet_status": {
+          "name": "win_sheet_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'not_started'"
+        },
+        "win_sheet_link": {
+          "name": "win_sheet_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "win_sheet_link_text": {
+          "name": "win_sheet_link_text",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_status": {
+          "name": "case_status",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fees_confirmation": {
+          "name": "fees_confirmation",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_assigned_to_agent": {
+          "name": "date_assigned_to_agent",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "t16_retro": {
+          "name": "t16_retro",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_fee_due": {
+          "name": "t16_fee_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_fee_received": {
+          "name": "t16_fee_received",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_pending": {
+          "name": "t16_pending",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_fee_received_date": {
+          "name": "t16_fee_received_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "t2_retro": {
+          "name": "t2_retro",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_fee_due": {
+          "name": "t2_fee_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_fee_received": {
+          "name": "t2_fee_received",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_pending": {
+          "name": "t2_pending",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_fee_received_date": {
+          "name": "t2_fee_received_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aux_retro": {
+          "name": "aux_retro",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_fee_due": {
+          "name": "aux_fee_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_fee_received": {
+          "name": "aux_fee_received",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_pending": {
+          "name": "aux_pending",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_fee_received_date": {
+          "name": "aux_fee_received_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_retro_due": {
+          "name": "total_retro_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "total_fees_expected": {
+          "name": "total_fees_expected",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "total_fees_paid": {
+          "name": "total_fees_paid",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "pif_ready_to_close": {
+          "name": "pif_ready_to_close",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_closed": {
+          "name": "is_closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "marked_overpaid": {
+          "name": "marked_overpaid",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_method": {
+          "name": "fee_method",
+          "type": "fee_method_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'fee_agreement'"
+        },
+        "applicable_fee_cap": {
+          "name": "applicable_fee_cap",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'9200'"
+        },
+        "fee_cap_applied": {
+          "name": "fee_cap_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "fee_computed": {
+          "name": "fee_computed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "fee_computed_at": {
+          "name": "fee_computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "days_after_approval": {
+          "name": "days_after_approval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_category": {
+          "name": "approval_category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fees_status": {
+          "name": "fees_status",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "week_assigned_to_agent": {
+          "name": "week_assigned_to_agent",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "month_assigned_to_agent": {
+          "name": "month_assigned_to_agent",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "sync_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'not_synced'"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mycase_record_id": {
+          "name": "mycase_record_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fee_records_case_id": {
+          "name": "idx_fee_records_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_assigned_to": {
+          "name": "idx_fee_records_assigned_to",
+          "columns": [
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_win_sheet_status": {
+          "name": "idx_fee_records_win_sheet_status",
+          "columns": [
+            {
+              "expression": "win_sheet_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_sync_status": {
+          "name": "idx_fee_records_sync_status",
+          "columns": [
+            {
+              "expression": "sync_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_pif": {
+          "name": "idx_fee_records_pif",
+          "columns": [
+            {
+              "expression": "pif_ready_to_close",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_is_closed": {
+          "name": "idx_fee_records_is_closed",
+          "columns": [
+            {
+              "expression": "is_closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fee_records_case_id_cases_client_id_fk": {
+          "name": "fee_records_case_id_cases_client_id_fk",
+          "tableFrom": "fee_records",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fee_records_case_id_unique": {
+          "name": "fee_records_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mycase_sync_tags": {
+      "name": "mycase_sync_tags",
+      "schema": "",
+      "columns": {
+        "mycase_case_id": {
+          "name": "mycase_case_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewed'"
+        },
+        "tagged_at": {
+          "name": "tagged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "tagged_by": {
+          "name": "tagged_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mycase_notice_documents": {
+      "name": "mycase_notice_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mycase_client_id": {
+          "name": "mycase_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mycase_document_id": {
+          "name": "mycase_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_name": {
+          "name": "document_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_pattern": {
+          "name": "matched_pattern",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_document": {
+          "name": "raw_document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mycase_notice_documents_case_id": {
+          "name": "idx_mycase_notice_documents_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mycase_notice_documents_case_id_cases_client_id_fk": {
+          "name": "mycase_notice_documents_case_id_cases_client_id_fk",
+          "tableFrom": "mycase_notice_documents",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mycase_notice_documents_case_id_mycase_document_id_unique": {
+          "name": "mycase_notice_documents_case_id_mycase_document_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id",
+            "mycase_document_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "notification_severity_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notifications_type": {
+          "name": "idx_notifications_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_is_read": {
+          "name": "idx_notifications_is_read",
+          "columns": [
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_created_at": {
+          "name": "idx_notifications_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_agent": {
+          "name": "idx_notifications_agent",
+          "columns": [
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_case_id_cases_client_id_fk": {
+          "name": "notifications_case_id_cases_client_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.overpaid_cases": {
+      "name": "overpaid_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "op_ltr_date": {
+          "name": "op_ltr_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "op_ltr_received": {
+          "name": "op_ltr_received",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overpaid_amount": {
+          "name": "overpaid_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checks_cleared": {
+          "name": "checks_cleared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "checks_cleared_at": {
+          "name": "checks_cleared_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "update_note": {
+          "name": "update_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_overpaid_cases_case_id": {
+          "name": "idx_overpaid_cases_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "overpaid_cases_case_id_cases_client_id_fk": {
+          "name": "overpaid_cases_case_id_cases_client_id_fk",
+          "tableFrom": "overpaid_cases",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "overpaid_cases_case_id_unique": {
+          "name": "overpaid_cases_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pull_logs": {
+      "name": "pull_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_records_pulled": {
+          "name": "total_records_pulled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "new_cases": {
+          "name": "new_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_cases": {
+          "name": "updated_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "errors": {
+          "name": "errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_at": {
+          "name": "triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_logs": {
+      "name": "sync_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cases": {
+          "name": "total_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "case_ids": {
+          "name": "case_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_at": {
+          "name": "triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_sync_logs_triggered_at": {
+          "name": "idx_sync_logs_triggered_at",
+          "columns": [
+            {
+              "expression": "triggered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'collections_specialist'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_members_name_unique": {
+          "name": "team_members_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_details": {
+      "name": "user_details",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chronicle_id": {
+          "name": "chronicle_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line_1": {
+          "name": "address_line_1",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line_2": {
+          "name": "address_line_2",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip_code": {
+          "name": "zip_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cell_phone": {
+          "name": "cell_phone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssn": {
+          "name": "ssn",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssn_last4": {
+          "name": "ssn_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age_at_approval": {
+          "name": "age_at_approval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "place_of_birth": {
+          "name": "place_of_birth",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mothers_first_name_and_maiden_name": {
+          "name": "mothers_first_name_and_maiden_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fathers_first_and_last_name": {
+          "name": "fathers_first_and_last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_details_case_id": {
+          "name": "idx_user_details_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_details_case_id_cases_client_id_fk": {
+          "name": "user_details_case_id_cases_client_id_fk",
+          "tableFrom": "user_details",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_details_case_id_unique": {
+          "name": "user_details_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        },
+        "user_details_chronicle_id_unique": {
+          "name": "user_details_chronicle_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chronicle_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.claim_type_enum": {
+      "name": "claim_type_enum",
+      "schema": "public",
+      "values": [
+        "T2",
+        "T16",
+        "T2_T16"
+      ]
+    },
+    "public.decision_outcome_enum": {
+      "name": "decision_outcome_enum",
+      "schema": "public",
+      "values": [
+        "fully_favorable",
+        "partially_favorable",
+        "unfavorable",
+        "dismissed",
+        "remand",
+        "unknown"
+      ]
+    },
+    "public.fee_method_enum": {
+      "name": "fee_method_enum",
+      "schema": "public",
+      "values": [
+        "fee_agreement",
+        "fee_petition"
+      ]
+    },
+    "public.level_won_enum": {
+      "name": "level_won_enum",
+      "schema": "public",
+      "values": [
+        "INITIAL",
+        "RECON",
+        "HEARING",
+        "AC",
+        "FEDERAL_COURT",
+        "FEE_PETITION"
+      ]
+    },
+    "public.notification_severity_enum": {
+      "name": "notification_severity_enum",
+      "schema": "public",
+      "values": [
+        "info",
+        "warning",
+        "critical"
+      ]
+    },
+    "public.notification_type_enum": {
+      "name": "notification_type_enum",
+      "schema": "public",
+      "values": [
+        "case_aging",
+        "fee_payment",
+        "call_target_missed",
+        "case_assigned"
+      ]
+    },
+    "public.sync_status_enum": {
+      "name": "sync_status_enum",
+      "schema": "public",
+      "values": [
+        "not_synced",
+        "syncing",
+        "synced",
+        "error"
+      ]
+    },
+    "public.user_role_enum": {
+      "name": "user_role_enum",
+      "schema": "public",
+      "values": [
+        "admin",
+        "member",
+        "system_admin"
+      ]
+    },
+    "public.win_sheet_status_enum": {
+      "name": "win_sheet_status_enum",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "started",
+        "in_progress",
+        "pending_payment",
+        "partially_paid",
+        "paid_in_full",
+        "closed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1781022889619,
       "tag": "0016_backfill_overpaid_checks_cleared_at",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1781027880813,
+      "tag": "0017_mycase_sync_tags",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/cases/[id]/route.ts
+++ b/src/app/api/cases/[id]/route.ts
@@ -421,7 +421,12 @@ export const PATCH = async (
 
       if (updates.length > 0) {
         await db.execute(
-          sql`UPDATE user_details SET ${sql.raw(updates.join(", "))}, updated_at = NOW() WHERE case_id = ${caseId}`,
+          sql`
+            INSERT INTO user_details (case_id, updated_at)
+            VALUES (${caseId}, NOW())
+            ON CONFLICT (case_id) DO UPDATE
+              SET ${sql.raw(updates.join(", "))}, updated_at = NOW()
+          `,
         );
       }
     }

--- a/src/app/api/cases/[id]/route.ts
+++ b/src/app/api/cases/[id]/route.ts
@@ -315,7 +315,7 @@ export const PATCH = async (
     }
 
     const body = await req.json();
-    const { caseFields, feeFields, logMessage, logAuthor } = body;
+    const { caseFields, feeFields, userDetailsFields, logMessage, logAuthor } = body;
 
     // Update case fields if provided
     if (caseFields && Object.keys(caseFields).length > 0) {
@@ -399,6 +399,29 @@ export const PATCH = async (
       if (updates.length > 0) {
         await db.execute(
           sql`UPDATE fee_records SET ${sql.raw(updates.join(", "))}, updated_at = NOW() WHERE case_id = ${caseId}`,
+        );
+      }
+    }
+
+    // Update user_details fields if provided
+    if (userDetailsFields && Object.keys(userDetailsFields).length > 0) {
+      const UD_FIELD_MAP: Record<string, string> = {
+        ssnLast4: "ssn_last4",
+        chronicleId: "chronicle_id",
+      };
+
+      const updates = Object.entries(userDetailsFields)
+        .filter(([k]) => UD_FIELD_MAP[k])
+        .map(([k, v]) => {
+          const col = UD_FIELD_MAP[k];
+          if (v === null) return `${col} = NULL`;
+          if (typeof v === "number") return `${col} = ${v}`;
+          return `${col} = '${String(v).replace(/'/g, "''")}'`;
+        });
+
+      if (updates.length > 0) {
+        await db.execute(
+          sql`UPDATE user_details SET ${sql.raw(updates.join(", "))}, updated_at = NOW() WHERE case_id = ${caseId}`,
         );
       }
     }

--- a/src/app/api/cases/[id]/route.ts
+++ b/src/app/api/cases/[id]/route.ts
@@ -98,8 +98,6 @@ export const GET = async (
         feesStatus: feeRecords.feesStatus,
         weekAssignedToAgent: feeRecords.weekAssignedToAgent,
         monthAssignedToAgent: feeRecords.monthAssignedToAgent,
-        feeRecordUpdatedAt: feeRecords.updatedAt,
-
         // user_details fields
         udChronicleId: userDetails.chronicleId,
         udFullName: userDetails.fullName,
@@ -410,22 +408,27 @@ export const PATCH = async (
         chronicleId: "chronicle_id",
       };
 
-      const updates = Object.entries(userDetailsFields)
-        .filter(([k]) => UD_FIELD_MAP[k])
-        .map(([k, v]) => {
-          const col = UD_FIELD_MAP[k];
-          if (v === null) return `${col} = NULL`;
-          if (typeof v === "number") return `${col} = ${v}`;
-          return `${col} = '${String(v).replace(/'/g, "''")}'`;
-        });
+      const colDefs: { col: string; sqlVal: string }[] = [];
+      for (const [k, v] of Object.entries(userDetailsFields)) {
+        const col = UD_FIELD_MAP[k];
+        if (!col) continue;
+        let sqlVal: string;
+        if (v === null) sqlVal = "NULL";
+        else if (typeof v === "number") sqlVal = String(v);
+        else sqlVal = `'${String(v).replace(/'/g, "''")}'`;
+        colDefs.push({ col, sqlVal });
+      }
 
-      if (updates.length > 0) {
+      if (colDefs.length > 0) {
+        const insertCols = colDefs.map((d) => d.col).join(", ");
+        const insertVals = colDefs.map((d) => d.sqlVal).join(", ");
+        const conflictSet = colDefs.map((d) => `${d.col} = ${d.sqlVal}`).join(", ");
         await db.execute(
           sql`
-            INSERT INTO user_details (case_id, updated_at)
-            VALUES (${caseId}, NOW())
+            INSERT INTO user_details (case_id, ${sql.raw(insertCols)}, updated_at)
+            VALUES (${caseId}, ${sql.raw(insertVals)}, NOW())
             ON CONFLICT (case_id) DO UPDATE
-              SET ${sql.raw(updates.join(", "))}, updated_at = NOW()
+              SET ${sql.raw(conflictSet)}, updated_at = NOW()
           `,
         );
       }

--- a/src/app/api/mycase/cases/[id]/details/route.ts
+++ b/src/app/api/mycase/cases/[id]/details/route.ts
@@ -6,6 +6,7 @@ import { cases, userDetails } from "@/lib/db/schema";
 import { myCaseDb } from "@/lib/db/mycase";
 import { mapMyCaseRows, type MyCaseDbRow } from "@/lib/import/mycase-mapper";
 import { fetchCaseDetails } from "@/lib/mycase-proxy";
+import { auth } from "@/auth";
 
 const CHRONICLE_LINK_FIELD_ID = 1101112;
 
@@ -26,6 +27,11 @@ export const GET = async (
   context: { params: { id: string } | Promise<{ id: string }> },
 ) => {
   try {
+    const session = await auth();
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+    }
+
     const caseId = await resolveId(context);
     if (!Number.isFinite(caseId)) {
       return NextResponse.json({ error: "Invalid case ID" }, { status: 400 });

--- a/src/app/api/mycase/cases/[id]/details/route.ts
+++ b/src/app/api/mycase/cases/[id]/details/route.ts
@@ -1,0 +1,139 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { cases, userDetails } from "@/lib/db/schema";
+import { myCaseDb } from "@/lib/db/mycase";
+import { mapMyCaseRows, type MyCaseDbRow } from "@/lib/import/mycase-mapper";
+import { fetchCaseDetails } from "@/lib/mycase-proxy";
+
+const CHRONICLE_LINK_FIELD_ID = 1101112;
+
+const resolveId = async (context: {
+  params: { id: string } | Promise<{ id: string }>;
+}) => {
+  const p = context.params instanceof Promise ? await context.params : context.params;
+  return parseInt(p.id);
+};
+
+// GET /api/mycase/cases/[id]/details
+// Resolution order for each field:
+//   1. MyCase mirror DB (custom_fields_named)
+//   2. Live MyCase API via n8n webhook (only for chronicleLink)
+//   3. Local app DB (cases + user_details) — fills whatever is still null
+export const GET = async (
+  _req: NextRequest,
+  context: { params: { id: string } | Promise<{ id: string }> },
+) => {
+  try {
+    const caseId = await resolveId(context);
+    if (!Number.isFinite(caseId)) {
+      return NextResponse.json({ error: "Invalid case ID" }, { status: 400 });
+    }
+
+    // Fire mirror DB and local DB in parallel.
+    const [rows, localRows] = await Promise.all([
+      myCaseDb<MyCaseDbRow[]>`
+        SELECT c.id, c.name, c.case_stage, c.status, c.opened_date, c.closed_date,
+               c.custom_fields_named,
+               cl.first_name AS client_first_name,
+               cl.last_name  AS client_last_name
+        FROM cases c
+        LEFT JOIN LATERAL (
+          SELECT first_name, last_name
+          FROM clients
+          WHERE id = ANY(c.clients) AND archived = false
+          ORDER BY id
+          LIMIT 1
+        ) cl ON true
+        WHERE c.id = ${caseId}
+        LIMIT 1
+      `,
+      db
+        .select({
+          approvalDate: cases.approvalDate,
+          claimTypeLabel: cases.claimTypeLabel,
+          levelWon: cases.levelWon,
+          t2Decision: cases.t2Decision,
+          t16Decision: cases.t16Decision,
+          chronicleId: userDetails.chronicleId,
+        })
+        .from(cases)
+        .leftJoin(userDetails, eq(userDetails.caseId, cases.clientId))
+        .where(eq(cases.clientId, caseId))
+        .limit(1),
+    ]);
+
+    if (rows.length === 0) {
+      return NextResponse.json({ error: "Case not found in MyCase" }, { status: 404 });
+    }
+
+    const { rows: mapped, warnings } = mapMyCaseRows(rows);
+    if (mapped.length === 0) {
+      return NextResponse.json({ error: "Case could not be mapped", warnings }, { status: 422 });
+    }
+
+    const r = mapped[0];
+    const local = localRows[0] ?? null;
+
+    // --- Chronicle link (3-step) ---
+    const rawMirrorLink = rows[0].custom_fields_named?.["CHRONICLE LINK"];
+    let chronicleLink =
+      typeof rawMirrorLink === "string" && rawMirrorLink.includes("chroniclelegal.com")
+        ? rawMirrorLink.trim()
+        : null;
+
+    if (!chronicleLink) {
+      const liveDetail = await fetchCaseDetails(caseId).catch(() => null);
+      const liveField = liveDetail?.custom_field_values?.find(
+        (f) => f.custom_field.id === CHRONICLE_LINK_FIELD_ID,
+      );
+      if (typeof liveField?.value === "string" && liveField.value.includes("chroniclelegal.com")) {
+        chronicleLink = liveField.value.trim();
+      }
+    }
+
+    if (!chronicleLink && local?.chronicleId != null) {
+      chronicleLink = `https://app.chroniclelegal.com/dashboard/clients/${local.chronicleId}`;
+    }
+
+    // --- Fill remaining nulls from local DB ---
+    const approvalDate = r.approvalDate ?? local?.approvalDate ?? null;
+    const claimTypeLabel = r.claimTypeLabel ?? local?.claimTypeLabel ?? null;
+    const levelWon = r.levelWon ?? local?.levelWon ?? null;
+    const t2Decision = r.t2Decision !== "unknown" ? r.t2Decision : (local?.t2Decision ?? "unknown");
+    const t16Decision = r.t16Decision !== "unknown" ? r.t16Decision : (local?.t16Decision ?? "unknown");
+
+    return NextResponse.json({
+      data: {
+        caseStage: rows[0].case_stage,
+        approvalDate,
+        assignedTo: r.assignedTo,
+        winSheetStatus: r.winSheetStatus,
+        claimTypeLabel,
+        levelWon,
+        chronicleLink,
+        t16Retro: r.t16Retro,
+        t16FeeDue: r.t16FeeDue,
+        t16FeeReceived: r.t16FeeReceived,
+        t16Pending: r.t16Pending,
+        t16FeeReceivedDate: r.t16FeeReceivedDate,
+        t2Retro: r.t2Retro,
+        t2FeeDue: r.t2FeeDue,
+        t2FeeReceived: r.t2FeeReceived,
+        t2Pending: r.t2Pending,
+        t2FeeReceivedDate: r.t2FeeReceivedDate,
+        feesConfirmation: r.feesConfirmation,
+        t2Decision,
+        t16Decision,
+        notes: r.notes,
+      },
+      warnings,
+    });
+  } catch (err) {
+    console.error("GET /api/mycase/cases/[id]/details error:", err);
+    return NextResponse.json(
+      { error: (err as Error).message },
+      { status: 500 },
+    );
+  }
+};

--- a/src/app/api/mycase/cases/[id]/details/route.ts
+++ b/src/app/api/mycase/cases/[id]/details/route.ts
@@ -6,6 +6,7 @@ import { cases, userDetails } from "@/lib/db/schema";
 import { myCaseDb } from "@/lib/db/mycase";
 import { mapMyCaseRows, type MyCaseDbRow } from "@/lib/import/mycase-mapper";
 import { fetchCaseDetails } from "@/lib/mycase-proxy";
+import { fetchChronicleClient, parseChronicleResponse } from "@/lib/chronicle-client";
 import { auth } from "@/auth";
 
 const CHRONICLE_LINK_FIELD_ID = 1101112;
@@ -21,7 +22,8 @@ const resolveId = async (context: {
 // Resolution order for each field:
 //   1. MyCase mirror DB (custom_fields_named)
 //   2. Live MyCase API via n8n webhook (only for chronicleLink)
-//   3. Local app DB (cases + user_details) — fills whatever is still null
+//   3. Chronicle API (only for t2/t16 decisions when mirror returns "unknown")
+//   4. Local app DB (cases + user_details) — fills whatever is still null
 export const GET = async (
   _req: NextRequest,
   context: { params: { id: string } | Promise<{ id: string }> },
@@ -107,8 +109,26 @@ export const GET = async (
     const approvalDate = r.approvalDate ?? local?.approvalDate ?? null;
     const claimTypeLabel = r.claimTypeLabel ?? local?.claimTypeLabel ?? null;
     const levelWon = r.levelWon ?? local?.levelWon ?? null;
-    const t2Decision = r.t2Decision !== "unknown" ? r.t2Decision : (local?.t2Decision ?? "unknown");
-    const t16Decision = r.t16Decision !== "unknown" ? r.t16Decision : (local?.t16Decision ?? "unknown");
+
+    // --- Decisions (mirror → Chronicle → local DB) ---
+    let t2Decision: string = r.t2Decision !== "unknown" ? r.t2Decision : "unknown";
+    let t16Decision: string = r.t16Decision !== "unknown" ? r.t16Decision : "unknown";
+
+    if ((t2Decision === "unknown" || t16Decision === "unknown") && local?.chronicleId != null) {
+      const apiUrl = process.env.CHRONICLE_API_URL ?? process.env.CHRONICLE_BASE_URL ?? "";
+      const apiKey = process.env.CHRONICLE_API_KEY ?? "";
+      if (apiUrl && apiKey) {
+        const raw = await fetchChronicleClient(local.chronicleId, apiUrl, apiKey).catch(() => null);
+        if (raw) {
+          const chr = parseChronicleResponse(raw);
+          if (t2Decision === "unknown" && chr.t2Decision) t2Decision = chr.t2Decision;
+          if (t16Decision === "unknown" && chr.t16Decision) t16Decision = chr.t16Decision;
+        }
+      }
+    }
+
+    if (t2Decision === "unknown") t2Decision = local?.t2Decision ?? "unknown";
+    if (t16Decision === "unknown") t16Decision = local?.t16Decision ?? "unknown";
 
     return NextResponse.json({
       data: {

--- a/src/app/api/mycase/cases/[id]/details/route.ts
+++ b/src/app/api/mycase/cases/[id]/details/route.ts
@@ -43,7 +43,7 @@ export const GET = async (
     const [rows, localRows] = await Promise.all([
       myCaseDb<MyCaseDbRow[]>`
         SELECT c.id, c.name, c.case_stage, c.status, c.opened_date, c.closed_date,
-               c.custom_fields_named,
+               c.custom_fields_named, c.case_number,
                cl.first_name AS client_first_name,
                cl.last_name  AS client_last_name
         FROM cases c
@@ -65,6 +65,7 @@ export const GET = async (
           t2Decision: cases.t2Decision,
           t16Decision: cases.t16Decision,
           chronicleId: userDetails.chronicleId,
+          ssnLast4: userDetails.ssnLast4,
         })
         .from(cases)
         .leftJoin(userDetails, eq(userDetails.caseId, cases.clientId))
@@ -110,19 +111,31 @@ export const GET = async (
     const claimTypeLabel = r.claimTypeLabel ?? local?.claimTypeLabel ?? null;
     const levelWon = r.levelWon ?? local?.levelWon ?? null;
 
+    // --- SSN last 4 (local DB → mirror → Chronicle) ---
+    let ssnLast4: string | null = local?.ssnLast4 ?? null;
+    if (!ssnLast4 && rows[0].case_number) {
+      const digits = rows[0].case_number.replace(/\D/g, "");
+      if (digits.length >= 4) ssnLast4 = digits.slice(-4);
+    }
+
     // --- Decisions (mirror → Chronicle → local DB) ---
     let t2Decision: string = r.t2Decision !== "unknown" ? r.t2Decision : "unknown";
     let t16Decision: string = r.t16Decision !== "unknown" ? r.t16Decision : "unknown";
 
-    if ((t2Decision === "unknown" || t16Decision === "unknown") && local?.chronicleId != null) {
+    const needsChronicle =
+      (t2Decision === "unknown" || t16Decision === "unknown" || !ssnLast4) &&
+      local?.chronicleId != null;
+
+    if (needsChronicle) {
       const apiUrl = process.env.CHRONICLE_API_URL ?? process.env.CHRONICLE_BASE_URL ?? "";
       const apiKey = process.env.CHRONICLE_API_KEY ?? "";
       if (apiUrl && apiKey) {
-        const raw = await fetchChronicleClient(local.chronicleId, apiUrl, apiKey).catch(() => null);
+        const raw = await fetchChronicleClient(local!.chronicleId!, apiUrl, apiKey).catch(() => null);
         if (raw) {
           const chr = parseChronicleResponse(raw);
           if (t2Decision === "unknown" && chr.t2Decision) t2Decision = chr.t2Decision;
           if (t16Decision === "unknown" && chr.t16Decision) t16Decision = chr.t16Decision;
+          if (!ssnLast4 && chr.last4Ssn) ssnLast4 = chr.last4Ssn;
         }
       }
     }
@@ -139,6 +152,7 @@ export const GET = async (
         claimTypeLabel,
         levelWon,
         chronicleLink,
+        ssnLast4,
         t16Retro: r.t16Retro,
         t16FeeDue: r.t16FeeDue,
         t16FeeReceived: r.t16FeeReceived,

--- a/src/app/api/mycase/cases/[id]/details/route.ts
+++ b/src/app/api/mycase/cases/[id]/details/route.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { NextRequest, NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
 import { db } from "@/lib/db";

--- a/src/app/api/mycase/sync/route.ts
+++ b/src/app/api/mycase/sync/route.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { inArray, eq, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { myCaseDb } from "@/lib/db/mycase";
-import { cases, feeRecords, activityLog } from "@/lib/db/schema";
+import { cases, feeRecords, activityLog, myCaseSyncTags } from "@/lib/db/schema";
 import { requireAdmin } from "@/lib/auth-helpers";
 import { mapMyCaseRows, type MyCaseDbRow } from "@/lib/import/mycase-mapper";
 import type { ParsedCaseRow } from "@/lib/import/xlsx-mapper";
@@ -216,13 +216,22 @@ export const POST = async (req: NextRequest) => {
         return f;
       };
 
+      const [tagRows] = await Promise.all([
+        db.select({ myCaseCaseId: myCaseSyncTags.myCaseCaseId, tag: myCaseSyncTags.tag })
+          .from(myCaseSyncTags),
+      ]);
+      const tagMap = new Map(tagRows.map((t) => [t.myCaseCaseId, t.tag]));
+
       const dbMap = new Map(allDbCases.map((c) => [c.clientId, c]));
       const myCaseIdSet = new Set(parsed.map((r) => r.clientId));
 
       const sourceRows = parsed.map((r) => {
         const dbEntry = dbMap.get(r.clientId);
         const changedFields = dbEntry ? getChangedFields(r, dbEntry) : [];
-        const status = !dbEntry ? "new" : changedFields.length > 0 ? "changed" : "unchanged";
+        const isTagged = tagMap.has(r.clientId);
+        const status = !dbEntry
+          ? (isTagged ? "viewed" : "new")
+          : changedFields.length > 0 ? "changed" : "unchanged";
         return {
           clientId: r.clientId,
           caseName: `${r.lastName}, ${r.firstName}`,
@@ -250,6 +259,7 @@ export const POST = async (req: NextRequest) => {
 
       const newCount = sourceRows.filter((r) => r.status === "new").length;
       const changedCount = sourceRows.filter((r) => r.status === "changed").length;
+      const viewedCount = sourceRows.filter((r) => r.status === "viewed").length;
 
       return NextResponse.json({
         mode,
@@ -257,7 +267,8 @@ export const POST = async (req: NextRequest) => {
           fetched: parsed.length,
           new: newCount,
           changed: changedCount,
-          unchanged: parsed.length - newCount - changedCount,
+          unchanged: parsed.length - newCount - changedCount - viewedCount,
+          viewed: viewedCount,
           missing: missingRows.length,
           warnings,
         },

--- a/src/app/api/mycase/sync/route.ts
+++ b/src/app/api/mycase/sync/route.ts
@@ -1,0 +1,482 @@
+import "server-only";
+import { NextRequest, NextResponse } from "next/server";
+import { inArray, eq, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { myCaseDb } from "@/lib/db/mycase";
+import { cases, feeRecords, activityLog } from "@/lib/db/schema";
+import { requireAdmin } from "@/lib/auth-helpers";
+import { mapMyCaseRows, type MyCaseDbRow } from "@/lib/import/mycase-mapper";
+import type { ParsedCaseRow } from "@/lib/import/xlsx-mapper";
+
+export const runtime = "nodejs";
+export const maxDuration = 120;
+
+const CHUNK = 500;
+
+const chunked = <T>(arr: T[], size: number): T[][] => {
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+};
+
+const fetchAllMyCaseRows = async (): Promise<MyCaseDbRow[]> =>
+  myCaseDb<MyCaseDbRow[]>`
+    SELECT c.id, c.name, c.case_stage, c.status, c.opened_date, c.closed_date,
+           c.custom_fields_named,
+           cl.first_name AS client_first_name,
+           cl.last_name  AS client_last_name
+    FROM cases c
+    LEFT JOIN LATERAL (
+      SELECT first_name, last_name
+      FROM clients
+      WHERE id = ANY(c.clients) AND archived = false
+      ORDER BY id
+      LIMIT 1
+    ) cl ON true
+    WHERE (
+      c.case_stage ILIKE '10 %'
+      OR c.case_stage ILIKE '10A %'
+      OR c.case_stage ILIKE '10B %'
+      OR c.case_stage ILIKE '10C %'
+    )
+    ORDER BY c.id
+  `;
+
+const fetchMyCaseRowsByIds = async (ids: number[]): Promise<MyCaseDbRow[]> =>
+  myCaseDb<MyCaseDbRow[]>`
+    SELECT c.id, c.name, c.case_stage, c.status, c.opened_date, c.closed_date,
+           c.custom_fields_named,
+           cl.first_name AS client_first_name,
+           cl.last_name  AS client_last_name
+    FROM cases c
+    LEFT JOIN LATERAL (
+      SELECT first_name, last_name
+      FROM clients
+      WHERE id = ANY(c.clients) AND archived = false
+      ORDER BY id
+      LIMIT 1
+    ) cl ON true
+    WHERE c.id = ANY(${ids}::int[])
+      AND (
+        c.case_stage ILIKE '10 %'
+        OR c.case_stage ILIKE '10A %'
+        OR c.case_stage ILIKE '10B %'
+        OR c.case_stage ILIKE '10C %'
+      )
+  `;
+
+const toCaseInsert = (r: ParsedCaseRow) => ({
+  clientId: r.clientId,
+  externalId: r.externalId,
+  caseLink: r.caseLink,
+  firstName: r.firstName,
+  lastName: r.lastName,
+  approvalDate: r.approvalDate,
+  levelWon: r.levelWon,
+  claimType: r.claimType,
+  claimTypeLabel: r.claimTypeLabel,
+  aljFirstName: r.aljFirstName,
+  aljLastName: r.aljLastName,
+  t2Decision: r.t2Decision,
+  t16Decision: r.t16Decision,
+});
+
+const toFeeInsert = (r: ParsedCaseRow) => ({
+  caseId: r.clientId,
+  assignedTo: r.assignedTo,
+  winSheetStatus: r.winSheetStatus,
+  winSheetLink: r.winSheetLink,
+  winSheetLinkText: r.winSheetLinkText,
+  caseStatus: r.caseStatus,
+  feesConfirmation: r.feesConfirmation,
+  dateAssignedToAgent: r.dateAssignedToAgent,
+  approvedBy: r.approvedBy,
+  t16Retro: r.t16Retro,
+  t16FeeDue: r.t16FeeDue,
+  t16FeeReceived: r.t16FeeReceived,
+  t16Pending: r.t16Pending,
+  t16FeeReceivedDate: r.t16FeeReceivedDate,
+  t2Retro: r.t2Retro,
+  t2FeeDue: r.t2FeeDue,
+  t2FeeReceived: r.t2FeeReceived,
+  t2Pending: r.t2Pending,
+  t2FeeReceivedDate: r.t2FeeReceivedDate,
+  auxRetro: r.auxRetro,
+  auxFeeDue: r.auxFeeDue,
+  auxFeeReceived: r.auxFeeReceived,
+  auxPending: r.auxPending,
+  auxFeeReceivedDate: r.auxFeeReceivedDate,
+  daysAfterApproval: r.daysAfterApproval,
+  approvalCategory: r.approvalCategory,
+  feesStatus: r.feesStatus,
+  weekAssignedToAgent: r.weekAssignedToAgent,
+  monthAssignedToAgent: r.monthAssignedToAgent,
+});
+
+// POST /api/mycase/sync
+//   mode=preview → diff MyCase DB against local fee collections DB
+//   mode=upsert  → body: { selectedClientIds: number[] }
+export const POST = async (req: NextRequest) => {
+  try {
+    const guard = await requireAdmin();
+    if (!guard.ok) {
+      return NextResponse.json(
+        { error: guard.error },
+        { status: guard.error === "Unauthenticated" ? 401 : 403 },
+      );
+    }
+
+    const { searchParams } = new URL(req.url);
+    const modeParam = searchParams.get("mode") ?? "preview";
+    if (modeParam !== "preview" && modeParam !== "upsert") {
+      return NextResponse.json({ error: `Invalid mode: ${modeParam}` }, { status: 400 });
+    }
+    const mode = modeParam;
+
+    if (mode === "preview") {
+      const rawRows = await fetchAllMyCaseRows();
+      const { rows: parsed, warnings } = mapMyCaseRows(rawRows);
+
+      const allDbCases = await db
+        .select({
+          clientId: cases.clientId,
+          caseLink: cases.caseLink,
+          firstName: cases.firstName,
+          lastName: cases.lastName,
+          approvalDate: cases.approvalDate,
+          levelWon: cases.levelWon,
+          claimType: cases.claimType,
+          claimTypeLabel: cases.claimTypeLabel,
+          aljFirstName: cases.aljFirstName,
+          aljLastName: cases.aljLastName,
+          assignedTo: feeRecords.assignedTo,
+          winSheetStatus: feeRecords.winSheetStatus,
+          caseStatus: feeRecords.caseStatus,
+          feesConfirmation: feeRecords.feesConfirmation,
+          t16Retro: feeRecords.t16Retro,
+          t16FeeDue: feeRecords.t16FeeDue,
+          t16FeeReceived: feeRecords.t16FeeReceived,
+          t16Pending: feeRecords.t16Pending,
+          t16FeeReceivedDate: feeRecords.t16FeeReceivedDate,
+          t2Retro: feeRecords.t2Retro,
+          t2FeeDue: feeRecords.t2FeeDue,
+          t2FeeReceived: feeRecords.t2FeeReceived,
+          t2Pending: feeRecords.t2Pending,
+          t2FeeReceivedDate: feeRecords.t2FeeReceivedDate,
+          auxRetro: feeRecords.auxRetro,
+          auxFeeDue: feeRecords.auxFeeDue,
+          auxFeeReceived: feeRecords.auxFeeReceived,
+          auxPending: feeRecords.auxPending,
+          auxFeeReceivedDate: feeRecords.auxFeeReceivedDate,
+          isClosed: feeRecords.isClosed,
+        })
+        .from(cases)
+        .leftJoin(feeRecords, eq(feeRecords.caseId, cases.clientId));
+
+      type DbRow = (typeof allDbCases)[number];
+      type ChangedField = { field: string; mycase: string; db: string };
+
+      const getChangedFields = (r: ParsedCaseRow, dbRow: DbRow): ChangedField[] => {
+        const f: ChangedField[] = [];
+        const s = (field: string, a: string | null | undefined, b: string | null | undefined) => {
+          if ((a ?? null) !== (b ?? null))
+            f.push({ field, mycase: String(a ?? ""), db: String(b ?? "") });
+        };
+        const n = (field: string, incoming: string, stored: string | null | undefined) => {
+          if (Math.abs(Number(incoming) - Number(stored ?? "0")) >= 0.01)
+            f.push({ field, mycase: incoming, db: stored ?? "" });
+        };
+        const ar = (field: string, arr: string[], dbArr: string[] | null | undefined) => {
+          if (
+            JSON.stringify([...(arr ?? [])].sort()) !==
+            JSON.stringify([...(dbArr ?? [])].sort())
+          )
+            f.push({ field, mycase: arr.join(","), db: (dbArr ?? []).join(",") });
+        };
+        s("caseLink", r.caseLink, dbRow.caseLink);
+        s("firstName", r.firstName, dbRow.firstName);
+        s("lastName", r.lastName, dbRow.lastName);
+        s("approvalDate", r.approvalDate, dbRow.approvalDate);
+        s("levelWon", r.levelWon, dbRow.levelWon);
+        ar("claimType", r.claimType, dbRow.claimType);
+        s("claimTypeLabel", r.claimTypeLabel, dbRow.claimTypeLabel);
+        s("aljFirstName", r.aljFirstName, dbRow.aljFirstName);
+        s("aljLastName", r.aljLastName, dbRow.aljLastName);
+        s("assignedTo", r.assignedTo, dbRow.assignedTo);
+        s("winSheetStatus", r.winSheetStatus, dbRow.winSheetStatus ?? "not_started");
+        s("caseStatus", r.caseStatus, dbRow.caseStatus);
+        n("t16Retro", r.t16Retro, dbRow.t16Retro);
+        n("t16FeeDue", r.t16FeeDue, dbRow.t16FeeDue);
+        n("t16FeeReceived", r.t16FeeReceived, dbRow.t16FeeReceived);
+        s("t16FeeReceivedDate", r.t16FeeReceivedDate, dbRow.t16FeeReceivedDate);
+        n("t2Retro", r.t2Retro, dbRow.t2Retro);
+        n("t2FeeDue", r.t2FeeDue, dbRow.t2FeeDue);
+        n("t2FeeReceived", r.t2FeeReceived, dbRow.t2FeeReceived);
+        s("t2FeeReceivedDate", r.t2FeeReceivedDate, dbRow.t2FeeReceivedDate);
+        return f;
+      };
+
+      const dbMap = new Map(allDbCases.map((c) => [c.clientId, c]));
+      const myCaseIdSet = new Set(parsed.map((r) => r.clientId));
+
+      const sourceRows = parsed.map((r) => {
+        const dbEntry = dbMap.get(r.clientId);
+        const changedFields = dbEntry ? getChangedFields(r, dbEntry) : [];
+        const status = !dbEntry ? "new" : changedFields.length > 0 ? "changed" : "unchanged";
+        return {
+          clientId: r.clientId,
+          caseName: `${r.lastName}, ${r.firstName}`,
+          caseLink: r.caseLink,
+          externalUrl: r.externalId,
+          approvalDate: r.approvalDate,
+          assignedTo: r.assignedTo,
+          winSheetStatus: r.winSheetStatus,
+          totalExpected: (Number(r.t16FeeDue) || 0) + (Number(r.t2FeeDue) || 0),
+          hasNotes: !!r.notes,
+          status,
+          changedFields,
+        };
+      });
+
+      const missingRows = allDbCases
+        .filter((c) => !c.isClosed && !myCaseIdSet.has(c.clientId))
+        .map((c) => ({
+          clientId: c.clientId,
+          caseName: `${c.lastName}, ${c.firstName}`,
+          caseLink: c.caseLink ?? "",
+          approvalDate: c.approvalDate,
+          status: "missing" as const,
+        }));
+
+      const newCount = sourceRows.filter((r) => r.status === "new").length;
+      const changedCount = sourceRows.filter((r) => r.status === "changed").length;
+
+      return NextResponse.json({
+        mode,
+        summary: {
+          fetched: parsed.length,
+          new: newCount,
+          changed: changedCount,
+          unchanged: parsed.length - newCount - changedCount,
+          missing: missingRows.length,
+          warnings,
+        },
+        rows: {
+          source: sourceRows,
+          missing: missingRows,
+        },
+      });
+    }
+
+    // upsert mode
+    let body: { selectedClientIds: unknown };
+    try {
+      body = (await req.json()) as { selectedClientIds: unknown };
+    } catch {
+      return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+    }
+    if (!Array.isArray(body.selectedClientIds)) {
+      return NextResponse.json(
+        { error: "selectedClientIds must be an array" },
+        { status: 400 },
+      );
+    }
+    if (body.selectedClientIds.length > 1000) {
+      return NextResponse.json(
+        { error: "selectedClientIds exceeds maximum of 1000" },
+        { status: 400 },
+      );
+    }
+    const ids = Array.from(new Set((body.selectedClientIds as unknown[]).map(Number)));
+    if (ids.some((n) => !Number.isInteger(n))) {
+      return NextResponse.json(
+        { error: "selectedClientIds must contain only integers" },
+        { status: 400 },
+      );
+    }
+
+    const rawRows = await fetchMyCaseRowsByIds(ids);
+    const { rows: parsed } = mapMyCaseRows(rawRows);
+
+    const selectedSet = new Set(ids);
+    const candidates = parsed.filter((r) => selectedSet.has(r.clientId));
+
+    if (candidates.length === 0) {
+      return NextResponse.json({ inserted: 0, updated: 0 });
+    }
+
+    const incomingIds = candidates.map((r) => r.clientId);
+    const existing = await db
+      .select({ clientId: cases.clientId })
+      .from(cases)
+      .where(inArray(cases.clientId, incomingIds));
+    const existingSet = new Set(existing.map((e) => e.clientId));
+
+    const newRows = candidates.filter((r) => !existingSet.has(r.clientId));
+    const updateRows = candidates.filter((r) => existingSet.has(r.clientId));
+
+    let inserted = 0;
+    let updated = 0;
+
+    await db.transaction(async (tx) => {
+      for (const batch of chunked(newRows, CHUNK)) {
+        const insertedCases = await tx
+          .insert(cases)
+          .values(batch.map(toCaseInsert))
+          .onConflictDoNothing({ target: cases.clientId })
+          .returning({ clientId: cases.clientId });
+
+        const insertedClientIds = new Set(insertedCases.map((r) => r.clientId));
+        const insertedRows = batch.filter((r) => insertedClientIds.has(r.clientId));
+        if (insertedRows.length === 0) continue;
+
+        await tx
+          .insert(feeRecords)
+          .values(insertedRows.map(toFeeInsert))
+          .onConflictDoNothing({ target: feeRecords.caseId });
+
+        const withNotes = insertedRows.filter((r) => r.notes);
+        if (withNotes.length > 0) {
+          await tx.insert(activityLog).values(
+            withNotes.map((r) => ({
+              caseId: r.clientId,
+              message: r.notes!,
+              createdBy: "MyCase Sync",
+            })),
+          );
+        }
+
+        inserted += insertedRows.length;
+      }
+    });
+
+    if (updateRows.length > 0) {
+      for (const batch of chunked(updateRows, CHUNK)) {
+        await Promise.all([
+          db.execute(sql`
+            UPDATE cases SET
+              external_id        = v.external_id,
+              case_link          = v.case_link,
+              first_name         = v.first_name,
+              last_name          = v.last_name,
+              approval_date      = v.approval_date::date,
+              level_won          = v.level_won,
+              claim_type         = v.claim_type::text[],
+              claim_type_label   = v.claim_type_label,
+              alj_first_name     = v.alj_first_name,
+              alj_last_name      = v.alj_last_name,
+              t2_decision        = v.t2_decision::decision_outcome_enum,
+              t16_decision       = v.t16_decision::decision_outcome_enum,
+              updated_at         = now()
+            FROM (VALUES ${sql.join(
+              batch.map(
+                (r) => sql`(
+                ${r.clientId},
+                ${r.externalId},
+                ${r.caseLink},
+                ${r.firstName},
+                ${r.lastName},
+                ${r.approvalDate},
+                ${r.levelWon},
+                ${"{" + r.claimType.join(",") + "}"},
+                ${r.claimTypeLabel},
+                ${r.aljFirstName},
+                ${r.aljLastName},
+                ${r.t2Decision},
+                ${r.t16Decision}
+              )`,
+              ),
+              sql`,`,
+            )}) AS v(client_id, external_id, case_link, first_name, last_name, approval_date, level_won, claim_type, claim_type_label, alj_first_name, alj_last_name, t2_decision, t16_decision)
+            WHERE cases.client_id = v.client_id::int
+          `,
+          ),
+          db.execute(sql`
+            INSERT INTO fee_records (
+              case_id, assigned_to, win_sheet_status, win_sheet_link, win_sheet_link_text,
+              case_status, fees_confirmation, date_assigned_to_agent, approved_by,
+              t16_retro, t16_fee_due, t16_fee_received, t16_pending, t16_fee_received_date,
+              t2_retro, t2_fee_due, t2_fee_received, t2_pending, t2_fee_received_date,
+              aux_retro, aux_fee_due, aux_fee_received, aux_pending, aux_fee_received_date,
+              days_after_approval, approval_category, fees_status,
+              week_assigned_to_agent, month_assigned_to_agent
+            )
+            VALUES ${sql.join(
+              batch.map(
+                (r) => sql`(
+                ${r.clientId},
+                ${r.assignedTo},
+                ${r.winSheetStatus},
+                ${r.winSheetLink},
+                ${r.winSheetLinkText},
+                ${r.caseStatus},
+                ${r.feesConfirmation},
+                ${r.dateAssignedToAgent}::date,
+                ${r.approvedBy},
+                ${r.t16Retro}::numeric,
+                ${r.t16FeeDue}::numeric,
+                ${r.t16FeeReceived}::numeric,
+                ${r.t16Pending}::numeric,
+                ${r.t16FeeReceivedDate}::date,
+                ${r.t2Retro}::numeric,
+                ${r.t2FeeDue}::numeric,
+                ${r.t2FeeReceived}::numeric,
+                ${r.t2Pending}::numeric,
+                ${r.t2FeeReceivedDate}::date,
+                ${r.auxRetro}::numeric,
+                ${r.auxFeeDue}::numeric,
+                ${r.auxFeeReceived}::numeric,
+                ${r.auxPending}::numeric,
+                ${r.auxFeeReceivedDate}::date,
+                ${r.daysAfterApproval}::int,
+                ${r.approvalCategory},
+                ${r.feesStatus},
+                ${r.weekAssignedToAgent},
+                ${r.monthAssignedToAgent}
+              )`,
+              ),
+              sql`,`,
+            )}
+            ON CONFLICT (case_id) DO UPDATE SET
+              assigned_to              = EXCLUDED.assigned_to,
+              win_sheet_status         = EXCLUDED.win_sheet_status,
+              win_sheet_link           = COALESCE(fee_records.win_sheet_link, EXCLUDED.win_sheet_link),
+              win_sheet_link_text      = COALESCE(fee_records.win_sheet_link_text, EXCLUDED.win_sheet_link_text),
+              case_status              = EXCLUDED.case_status,
+              fees_confirmation        = EXCLUDED.fees_confirmation,
+              date_assigned_to_agent   = COALESCE(fee_records.date_assigned_to_agent, EXCLUDED.date_assigned_to_agent),
+              approved_by              = COALESCE(fee_records.approved_by, EXCLUDED.approved_by),
+              t16_retro                = EXCLUDED.t16_retro,
+              t16_fee_due              = EXCLUDED.t16_fee_due,
+              t16_fee_received         = EXCLUDED.t16_fee_received,
+              t16_pending              = CASE WHEN EXCLUDED.t16_pending::numeric != 0 THEN EXCLUDED.t16_pending ELSE fee_records.t16_pending END,
+              t16_fee_received_date    = EXCLUDED.t16_fee_received_date,
+              t2_retro                 = EXCLUDED.t2_retro,
+              t2_fee_due               = EXCLUDED.t2_fee_due,
+              t2_fee_received          = EXCLUDED.t2_fee_received,
+              t2_pending               = CASE WHEN EXCLUDED.t2_pending::numeric != 0 THEN EXCLUDED.t2_pending ELSE fee_records.t2_pending END,
+              t2_fee_received_date     = EXCLUDED.t2_fee_received_date,
+              aux_retro                = EXCLUDED.aux_retro,
+              aux_fee_due              = EXCLUDED.aux_fee_due,
+              aux_fee_received         = EXCLUDED.aux_fee_received,
+              aux_pending              = CASE WHEN EXCLUDED.aux_pending::numeric != 0 THEN EXCLUDED.aux_pending ELSE fee_records.aux_pending END,
+              aux_fee_received_date    = EXCLUDED.aux_fee_received_date,
+              days_after_approval      = EXCLUDED.days_after_approval,
+              approval_category        = EXCLUDED.approval_category,
+              updated_at               = now()
+          `,
+          ),
+        ]);
+      }
+      updated = updateRows.length;
+    }
+
+    return NextResponse.json({ inserted, updated });
+  } catch (error) {
+    console.error("POST /api/mycase/sync error:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : String(error) },
+      { status: 500 },
+    );
+  }
+};

--- a/src/app/api/mycase/sync/tags/route.ts
+++ b/src/app/api/mycase/sync/tags/route.ts
@@ -1,0 +1,75 @@
+import "server-only";
+import { NextRequest, NextResponse } from "next/server";
+import { inArray } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { myCaseSyncTags } from "@/lib/db/schema";
+import { requireAdmin } from "@/lib/auth-helpers";
+import { auth } from "@/auth";
+
+// POST /api/mycase/sync/tags
+// body: { myCaseCaseIds: number[], tag?: string }
+// Tags one or more MyCase case IDs (default tag: "viewed").
+export const POST = async (req: NextRequest) => {
+  try {
+    const guard = await requireAdmin();
+    if (!guard.ok) {
+      return NextResponse.json(
+        { error: guard.error },
+        { status: guard.error === "Unauthenticated" ? 401 : 403 },
+      );
+    }
+
+    const session = await auth();
+    const taggedBy = session?.user?.email ?? null;
+
+    const body = (await req.json()) as { myCaseCaseIds: unknown; tag?: unknown };
+    if (!Array.isArray(body.myCaseCaseIds) || body.myCaseCaseIds.length === 0) {
+      return NextResponse.json({ error: "myCaseCaseIds must be a non-empty array" }, { status: 400 });
+    }
+
+    const ids = (body.myCaseCaseIds as unknown[]).map(Number).filter(Number.isFinite);
+    const tag = typeof body.tag === "string" && body.tag.trim() ? body.tag.trim() : "viewed";
+
+    await db
+      .insert(myCaseSyncTags)
+      .values(ids.map((id) => ({ myCaseCaseId: id, tag, taggedBy })))
+      .onConflictDoUpdate({
+        target: myCaseSyncTags.myCaseCaseId,
+        set: { tag, taggedBy, taggedAt: new Date() },
+      });
+
+    return NextResponse.json({ tagged: ids.length });
+  } catch (err) {
+    console.error("POST /api/mycase/sync/tags error:", err);
+    return NextResponse.json({ error: (err as Error).message }, { status: 500 });
+  }
+};
+
+// DELETE /api/mycase/sync/tags
+// body: { myCaseCaseIds: number[] }
+// Removes tags from the given MyCase case IDs.
+export const DELETE = async (req: NextRequest) => {
+  try {
+    const guard = await requireAdmin();
+    if (!guard.ok) {
+      return NextResponse.json(
+        { error: guard.error },
+        { status: guard.error === "Unauthenticated" ? 401 : 403 },
+      );
+    }
+
+    const body = (await req.json()) as { myCaseCaseIds: unknown };
+    if (!Array.isArray(body.myCaseCaseIds) || body.myCaseCaseIds.length === 0) {
+      return NextResponse.json({ error: "myCaseCaseIds must be a non-empty array" }, { status: 400 });
+    }
+
+    const ids = (body.myCaseCaseIds as unknown[]).map(Number).filter(Number.isFinite);
+
+    await db.delete(myCaseSyncTags).where(inArray(myCaseSyncTags.myCaseCaseId, ids));
+
+    return NextResponse.json({ untagged: ids.length });
+  } catch (err) {
+    console.error("DELETE /api/mycase/sync/tags error:", err);
+    return NextResponse.json({ error: (err as Error).message }, { status: 500 });
+  }
+};

--- a/src/app/api/sheets/sync/route.ts
+++ b/src/app/api/sheets/sync/route.ts
@@ -149,7 +149,7 @@ export const POST = async (req: NextRequest) => {
       ]);
       sheetCache = { masterRows: masterRaw, feesClosedRows: feesClosedRaw, ts: Date.now() };
 
-      const { rows: parsed, warnings } = mapSheetRows(masterRaw);
+      const { rows: parsed, warnings, needsLink } = mapSheetRows(masterRaw);
       const { rows: feesClosedParsed } = mapFeesClosedRows(feesClosedRaw);
 
       // Build lookup sets
@@ -321,12 +321,14 @@ export const POST = async (req: NextRequest) => {
           feesClosed: feesClosedRows.length,
           missing: missingRows.length,
           synthetic: sheetRows.filter((r) => r.isSynthetic).length,
+          needsLink: needsLink.length,
           warnings,
         },
         rows: {
           sheet: sheetRows,
           feesClosed: feesClosedRows,
           missing: missingRows,
+          needsLink,
         },
       });
     }

--- a/src/components/cases/CaseDetailSheet.tsx
+++ b/src/components/cases/CaseDetailSheet.tsx
@@ -199,6 +199,18 @@ export default function CaseDetailSheet({
     claimTypeLabel: "",
     ssnLast4: "",
     chronicleId: "",
+    t16Retro: "",
+    t16FeeDue: "",
+    t16FeeReceived: "",
+    t16FeeReceivedDate: "",
+    t2Retro: "",
+    t2FeeDue: "",
+    t2FeeReceived: "",
+    t2FeeReceivedDate: "",
+    auxRetro: "",
+    auxFeeDue: "",
+    auxFeeReceived: "",
+    auxFeeReceivedDate: "",
   });
   const [isSaving, setIsSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -290,6 +302,18 @@ export default function CaseDetailSheet({
         claimTypeLabel: data.claim ?? "",
         ssnLast4: myCaseData?.ssnLast4 ?? "",
         chronicleId: data.userDetails?.chronicleId != null ? String(data.userDetails.chronicleId) : "",
+        t16Retro: data.t16Retro > 0 ? String(data.t16Retro) : "",
+        t16FeeDue: data.t16FeeDue > 0 ? String(data.t16FeeDue) : "",
+        t16FeeReceived: data.t16FeeReceived > 0 ? String(data.t16FeeReceived) : "",
+        t16FeeReceivedDate: data.t16FeeReceivedDate ?? "",
+        t2Retro: data.t2Retro > 0 ? String(data.t2Retro) : "",
+        t2FeeDue: data.t2FeeDue > 0 ? String(data.t2FeeDue) : "",
+        t2FeeReceived: data.t2FeeReceived > 0 ? String(data.t2FeeReceived) : "",
+        t2FeeReceivedDate: data.t2FeeReceivedDate ?? "",
+        auxRetro: data.auxRetro > 0 ? String(data.auxRetro) : "",
+        auxFeeDue: data.auxFeeDue > 0 ? String(data.auxFeeDue) : "",
+        auxFeeReceived: data.auxFeeReceived > 0 ? String(data.auxFeeReceived) : "",
+        auxFeeReceivedDate: data.auxFeeReceivedDate ?? "",
       });
     }
   }, [data, myCaseData, isEditing]);
@@ -316,12 +340,39 @@ export default function CaseDetailSheet({
 
     const origChronicle = data.userDetails?.chronicleId != null ? String(data.userDetails.chronicleId) : "";
     if (editValues.chronicleId !== origChronicle) {
-      userDetailsFields.chronicleId = editValues.chronicleId
-        ? Number(editValues.chronicleId)
-        : null;
+      const n = Number(editValues.chronicleId);
+      userDetailsFields.chronicleId = editValues.chronicleId && Number.isFinite(n) ? n : null;
     }
 
-    if (!Object.keys(caseFields).length && !Object.keys(userDetailsFields).length) {
+    const feeFields: Record<string, number | string | null> = {};
+    const feeNumFields = [
+      ["t16Retro", data.t16Retro],
+      ["t16FeeDue", data.t16FeeDue],
+      ["t16FeeReceived", data.t16FeeReceived],
+      ["t2Retro", data.t2Retro],
+      ["t2FeeDue", data.t2FeeDue],
+      ["t2FeeReceived", data.t2FeeReceived],
+      ["auxRetro", data.auxRetro],
+      ["auxFeeDue", data.auxFeeDue],
+      ["auxFeeReceived", data.auxFeeReceived],
+    ] as const;
+    for (const [key, orig] of feeNumFields) {
+      const edited = editValues[key];
+      const editedNum = edited === "" ? 0 : Number(edited);
+      if (!Number.isFinite(editedNum)) continue;
+      if (editedNum !== orig) feeFields[key] = editedNum;
+    }
+    const feeDateFields = [
+      ["t16FeeReceivedDate", data.t16FeeReceivedDate],
+      ["t2FeeReceivedDate", data.t2FeeReceivedDate],
+      ["auxFeeReceivedDate", data.auxFeeReceivedDate],
+    ] as const;
+    for (const [key, orig] of feeDateFields) {
+      const edited = editValues[key];
+      if (edited !== (orig ?? "")) feeFields[key] = edited || null;
+    }
+
+    if (!Object.keys(caseFields).length && !Object.keys(userDetailsFields).length && !Object.keys(feeFields).length) {
       setIsEditing(false);
       return;
     }
@@ -332,7 +383,7 @@ export default function CaseDetailSheet({
       const res = await fetch(`/api/cases/${caseId}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ caseFields, userDetailsFields }),
+        body: JSON.stringify({ caseFields, feeFields, userDetailsFields }),
       });
       if (!res.ok) throw new Error(`Failed to save (${res.status})`);
       setIsEditing(false);
@@ -714,47 +765,69 @@ export default function CaseDetailSheet({
                 Fee Breakdown
               </h4>
               <div className="space-y-4">
-                {[
-                  {
-                    key: "t16",
-                    label: "T16 (SSI)",
-                    titleColor: "text-indigo-500",
-                    received: data.t16FeeReceived,
-                    retro: data.t16Retro,
-                    pending: data.t16Pending,
-                  },
-                  {
-                    key: "t2",
-                    label: "T2 (SSDI)",
-                    titleColor: "text-blue-500",
-                    received: data.t2FeeReceived,
-                    retro: data.t2Retro,
-                    pending: data.t2Pending,
-                  },
-                  {
-                    key: "aux",
-                    label: "AUX (Auxiliary)",
-                    titleColor: "text-violet-500",
-                    received: data.auxFeeReceived,
-                    retro: data.auxRetro,
-                    pending: data.auxPending,
-                  },
-                ].map((b) => (
+                {(
+                  [
+                    { key: "t16", label: "T16 (SSI)", titleColor: "text-indigo-500", received: data.t16FeeReceived, retro: data.t16Retro, pending: data.t16Pending, due: data.t16FeeDue, receivedDate: data.t16FeeReceivedDate },
+                    { key: "t2",  label: "T2 (SSDI)",  titleColor: "text-blue-500",    received: data.t2FeeReceived,  retro: data.t2Retro,  pending: data.t2Pending,  due: data.t2FeeDue,  receivedDate: data.t2FeeReceivedDate  },
+                    { key: "aux", label: "AUX",         titleColor: "text-violet-500",  received: data.auxFeeReceived, retro: data.auxRetro, pending: data.auxPending, due: data.auxFeeDue, receivedDate: data.auxFeeReceivedDate },
+                  ] as const
+                ).map((b) => (
                   <div key={b.key} className={`p-3 rounded-lg border ${t.borderLight} bg-neutral-50/30 dark:bg-neutral-900/20`}>
-                    <div className="flex items-center justify-between mb-2">
-                      <p className={`text-[11px] font-bold uppercase ${b.titleColor}`}>{b.label}</p>
-                      <p className="text-[10px] font-medium text-emerald-500">Rec: {currency(b.received)}</p>
-                    </div>
-                    <div className="grid grid-cols-2 gap-2">
-                      <div>
-                        <p className={lbl}>Retro</p>
-                        <p className="text-xs font-semibold">{currency(b.retro)}</p>
+                    <p className={`text-[11px] font-bold uppercase ${b.titleColor} mb-2`}>{b.label}</p>
+                    {isEditing ? (
+                      <div className="grid grid-cols-2 gap-x-3 gap-y-2">
+                        {(
+                          [
+                            { label: "Retro",     field: `${b.key}Retro`            as keyof typeof editValues },
+                            { label: "Fee Due",   field: `${b.key}FeeDue`           as keyof typeof editValues },
+                            { label: "Received",  field: `${b.key}FeeReceived`      as keyof typeof editValues },
+                          ] as const
+                        ).map(({ label, field }) => (
+                          <div key={field}>
+                            <p className={lbl}>{label}</p>
+                            <input
+                              type="number"
+                              min="0"
+                              step="0.01"
+                              value={editValues[field]}
+                              onChange={(e) => setEditValues((v) => ({ ...v, [field]: e.target.value }))}
+                              placeholder="0"
+                              className={inp}
+                            />
+                          </div>
+                        ))}
+                        <div>
+                          <p className={lbl}>Rec&apos;d Date</p>
+                          <input
+                            type="date"
+                            value={editValues[`${b.key}FeeReceivedDate` as keyof typeof editValues]}
+                            onChange={(e) => setEditValues((v) => ({ ...v, [`${b.key}FeeReceivedDate`]: e.target.value }))}
+                            className={inp}
+                          />
+                        </div>
                       </div>
-                      <div>
-                        <p className={lbl}>Pending</p>
-                        <p className={`text-xs font-semibold ${b.pending > 0 ? "text-amber-500" : ""}`}>{currency(b.pending)}</p>
+                    ) : (
+                      <div className="grid grid-cols-2 gap-2">
+                        <div>
+                          <p className={lbl}>Retro</p>
+                          <p className="text-xs font-semibold">{currency(b.retro)}</p>
+                        </div>
+                        <div>
+                          <p className={lbl}>Received</p>
+                          <p className="text-xs font-semibold text-emerald-500">{currency(b.received)}</p>
+                        </div>
+                        <div>
+                          <p className={lbl}>Pending</p>
+                          <p className={`text-xs font-semibold ${b.pending > 0 ? "text-amber-500" : ""}`}>{currency(b.pending)}</p>
+                        </div>
+                        {b.receivedDate && (
+                          <div>
+                            <p className={lbl}>Rec&apos;d Date</p>
+                            <p className="text-xs font-semibold">{dateStr(b.receivedDate)}</p>
+                          </div>
+                        )}
                       </div>
-                    </div>
+                    )}
                   </div>
                 ))}
               </div>

--- a/src/components/cases/CaseDetailSheet.tsx
+++ b/src/components/cases/CaseDetailSheet.tsx
@@ -319,6 +319,15 @@ export default function CaseDetailSheet({
     }
   }, [data, myCaseData, isEditing]);
 
+  // Backfill ssnLast4 if myCaseData arrives after the user already entered edit mode.
+  useEffect(() => {
+    if (!isEditing || !myCaseData?.ssnLast4) return;
+    setEditValues(prev => {
+      if (prev.ssnLast4 !== "") return prev;
+      return { ...prev, ssnLast4: myCaseData.ssnLast4! };
+    });
+  }, [isEditing, myCaseData]);
+
   const handleSave = useCallback(async () => {
     if (!data) return;
     const caseFields: Record<string, string | null> = {};
@@ -446,7 +455,7 @@ export default function CaseDetailSheet({
                   </button>
                   {data && (
                     <button
-                      onClick={() => setIsEditing(true)}
+                      onClick={() => { setIsEditing(true); setSaveError(null); }}
                       aria-label="Edit local details"
                       className={`h-7 w-7 rounded-md flex items-center justify-center ${t.hover} ${t.textSub}`}
                     >

--- a/src/components/cases/CaseDetailSheet.tsx
+++ b/src/components/cases/CaseDetailSheet.tsx
@@ -391,7 +391,7 @@ export default function CaseDetailSheet({
                 <div>
                   <p className={lbl}>Approval Date</p>
                   <p className={`${val} flex items-center gap-1`}>
-                    <CalendarDays aria-hidden="true" className="h-3 w-3 text-indigo-500" /> {dateStr(data.approvalDate ?? myCaseData?.approvalDate)}
+                    <CalendarDays aria-hidden="true" className="h-3 w-3 text-indigo-500" /> {dateStr(myCaseData?.approvalDate ?? data.approvalDate)}
                   </p>
                 </div>
                 <div>
@@ -551,7 +551,7 @@ export default function CaseDetailSheet({
                   <div className="grid grid-cols-2 gap-3">
                     <div>
                       <p className={lbl}>Approval Date</p>
-                      <p className={val}>{dateStr(myCaseData.approvalDate ?? data?.approvalDate)}</p>
+                      <p className={val}>{dateStr(myCaseData.approvalDate)}</p>
                     </div>
                     <div>
                       <p className={lbl}>Case Stage</p>

--- a/src/components/cases/CaseDetailSheet.tsx
+++ b/src/components/cases/CaseDetailSheet.tsx
@@ -347,6 +347,12 @@ export default function CaseDetailSheet({
                       {STATUS_LABELS_DETAIL[data.status] || data.status}
                     </span>
                   </div>
+                  {chronicleLink && (
+                    <div className="mt-2">
+                      <p className={lbl}>Chronicle ID</p>
+                      <p className={`${val} text-sky-500`}>{chronicleLink.split("/").pop() ?? "—"}</p>
+                    </div>
+                  )}
                 </div>
                 <div className="text-right shrink-0 flex flex-col items-end gap-3">
                   <div>

--- a/src/components/cases/CaseDetailSheet.tsx
+++ b/src/components/cases/CaseDetailSheet.tsx
@@ -46,6 +46,30 @@ interface CaseDetailSheetProps {
 const currency = (v: number) => (v > 0 ? fmtFull(v) : "—");
 const dateStr = (d: string | null | undefined) => (d ? fmtDate(d) : "—");
 
+type MyCaseData = {
+  caseStage: string | null;
+  approvalDate: string | null;
+  assignedTo: string | null;
+  winSheetStatus: string;
+  claimTypeLabel: string | null;
+  levelWon: string | null;
+  t16Retro: string;
+  t16FeeDue: string;
+  t16FeeReceived: string;
+  t16Pending: string;
+  t16FeeReceivedDate: string | null;
+  t2Retro: string;
+  t2FeeDue: string;
+  t2FeeReceived: string;
+  t2Pending: string;
+  t2FeeReceivedDate: string | null;
+  feesConfirmation: string | null;
+  t2Decision: string;
+  t16Decision: string;
+  notes: string | null;
+  chronicleLink: string | null;
+};
+
 function ClientDetailsSection({
   ud,
   textMuted,
@@ -156,30 +180,6 @@ export default function CaseDetailSheet({
   const t = themeClasses(dark);
   const router = useRouter();
 
-  type MyCaseData = {
-    caseStage: string | null;
-    approvalDate: string | null;
-    assignedTo: string | null;
-    winSheetStatus: string;
-    claimTypeLabel: string | null;
-    levelWon: string | null;
-    t16Retro: string;
-    t16FeeDue: string;
-    t16FeeReceived: string;
-    t16Pending: string;
-    t16FeeReceivedDate: string | null;
-    t2Retro: string;
-    t2FeeDue: string;
-    t2FeeReceived: string;
-    t2Pending: string;
-    t2FeeReceivedDate: string | null;
-    feesConfirmation: string | null;
-    t2Decision: string;
-    t16Decision: string;
-    notes: string | null;
-    chronicleLink: string | null;
-  };
-
   const [data, setData] = useState<CaseDetailData | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -266,6 +266,12 @@ export default function CaseDetailSheet({
   const lbl = `text-[10px] font-semibold uppercase tracking-wider ${t.textMuted}`;
   const val = `text-[13px] font-semibold ${t.text} mt-0.5`;
   const sectionCls = `p-4 border-b ${t.borderLight}`;
+
+  const chronicleLink = data
+    ? (myCaseData?.chronicleLink ?? (data.userDetails?.chronicleId != null
+        ? `https://app.chroniclelegal.com/dashboard/clients/${data.userDetails.chronicleId}`
+        : null))
+    : null;
 
   return (
     <>
@@ -362,9 +368,9 @@ export default function CaseDetailSheet({
                   >
                     Documents <FileText aria-hidden="true" className="h-3 w-3" />
                   </button>
-                  {(myCaseData?.chronicleLink ?? (data.userDetails?.chronicleId != null ? `https://app.chroniclelegal.com/dashboard/clients/${data.userDetails.chronicleId}` : null)) && (
+                  {chronicleLink && (
                     <a
-                      href={myCaseData?.chronicleLink ?? `https://app.chroniclelegal.com/dashboard/clients/${data.userDetails?.chronicleId}`}
+                      href={chronicleLink}
                       target="_blank"
                       rel="noopener noreferrer"
                       className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-[10px] font-bold uppercase transition-colors ${dark ? "bg-sky-900/30 text-sky-400 hover:bg-sky-900/50" : "bg-sky-50 text-sky-600 hover:bg-sky-100"}`}
@@ -410,11 +416,15 @@ export default function CaseDetailSheet({
               <div className="space-y-3">
                 <div className="flex items-center justify-between">
                   <p className={lbl}>T2 (SSDI) Decision</p>
-                  <p className={`${val} capitalize`}>{data.t2Decision?.replace(/_/g, " ") || "—"}</p>
+                  <p className={`${val} capitalize`}>
+                    {data.t2Decision && data.t2Decision !== "unknown" ? data.t2Decision.replace(/_/g, " ") : "—"}
+                  </p>
                 </div>
                 <div className="flex items-center justify-between">
                   <p className={lbl}>T16 (SSI) Decision</p>
-                  <p className={`${val} capitalize`}>{data.t16Decision?.replace(/_/g, " ") || "—"}</p>
+                  <p className={`${val} capitalize`}>
+                    {data.t16Decision && data.t16Decision !== "unknown" ? data.t16Decision.replace(/_/g, " ") : "—"}
+                  </p>
                 </div>
                 <div className="flex items-center justify-between">
                   <p className={lbl}>Win Sheet Status</p>
@@ -526,9 +536,15 @@ export default function CaseDetailSheet({
                   <span className={`text-[11px] ${t.textMuted}`}>Fetching from MyCase…</span>
                 </div>
               ) : myCaseError ? (
-                <div className={`flex items-start gap-2 rounded-md p-2 text-[11px] ${dark ? "bg-amber-900/20 text-amber-400" : "bg-amber-50 text-amber-700"}`}>
+                <div
+                  role="alert"
+                  className={`flex items-start gap-2 rounded-md p-2 text-[11px] ${dark ? "bg-amber-900/20 text-amber-400" : "bg-amber-50 text-amber-700"}`}
+                >
                   <AlertTriangle aria-hidden="true" className="h-3.5 w-3.5 shrink-0 mt-0.5" />
-                  <span>{myCaseError}</span>
+                  <span className="flex-1">{myCaseError}</span>
+                  <button onClick={fetchMyCaseData} className="shrink-0 underline font-semibold">
+                    Retry
+                  </button>
                 </div>
               ) : myCaseData ? (
                 <div className="space-y-3">

--- a/src/components/cases/CaseDetailSheet.tsx
+++ b/src/components/cases/CaseDetailSheet.tsx
@@ -18,6 +18,8 @@ import {
   Phone,
   Database,
   AlertTriangle,
+  Pencil,
+  Check,
 } from "lucide-react";
 import {
   Sheet,
@@ -188,6 +190,18 @@ export default function CaseDetailSheet({
   const [myCaseLoading, setMyCaseLoading] = useState(false);
   const [myCaseError, setMyCaseError] = useState<string | null>(null);
   const [docsOpen, setDocsOpen] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValues, setEditValues] = useState({
+    approvalDate: "",
+    t2Decision: "",
+    t16Decision: "",
+    levelWon: "",
+    claimTypeLabel: "",
+    ssnLast4: "",
+    chronicleId: "",
+  });
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const myCaseAbortRef = useRef<AbortController | null>(null);
 
@@ -257,6 +271,8 @@ export default function CaseDetailSheet({
       setData(null);
       setMyCaseData(null);
       setMyCaseError(null);
+      setIsEditing(false);
+      setSaveError(null);
     }
     return () => {
       abortRef.current?.abort();
@@ -264,8 +280,79 @@ export default function CaseDetailSheet({
     };
   }, [isOpen, fetchCase, fetchMyCaseData]);
 
+  useEffect(() => {
+    if (data && !isEditing) {
+      setEditValues({
+        approvalDate: data.approvalDate ?? "",
+        t2Decision: data.t2Decision ?? "",
+        t16Decision: data.t16Decision ?? "",
+        levelWon: data.level === "—" ? "" : (data.level ?? ""),
+        claimTypeLabel: data.claim ?? "",
+        ssnLast4: myCaseData?.ssnLast4 ?? "",
+        chronicleId: data.userDetails?.chronicleId != null ? String(data.userDetails.chronicleId) : "",
+      });
+    }
+  }, [data, myCaseData, isEditing]);
+
+  const handleSave = useCallback(async () => {
+    if (!data) return;
+    const caseFields: Record<string, string | null> = {};
+    const userDetailsFields: Record<string, string | number | null> = {};
+
+    if (editValues.approvalDate !== (data.approvalDate ?? ""))
+      caseFields.approvalDate = editValues.approvalDate || null;
+    if (editValues.t2Decision !== (data.t2Decision ?? ""))
+      caseFields.t2Decision = editValues.t2Decision || null;
+    if (editValues.t16Decision !== (data.t16Decision ?? ""))
+      caseFields.t16Decision = editValues.t16Decision || null;
+    if (editValues.levelWon !== (data.level === "—" ? "" : (data.level ?? "")))
+      caseFields.levelWon = editValues.levelWon || null;
+    if (editValues.claimTypeLabel !== (data.claim ?? ""))
+      caseFields.claimTypeLabel = editValues.claimTypeLabel || null;
+
+    const origSsn = myCaseData?.ssnLast4 ?? "";
+    if (editValues.ssnLast4 !== origSsn)
+      userDetailsFields.ssnLast4 = editValues.ssnLast4 || null;
+
+    const origChronicle = data.userDetails?.chronicleId != null ? String(data.userDetails.chronicleId) : "";
+    if (editValues.chronicleId !== origChronicle) {
+      userDetailsFields.chronicleId = editValues.chronicleId
+        ? Number(editValues.chronicleId)
+        : null;
+    }
+
+    if (!Object.keys(caseFields).length && !Object.keys(userDetailsFields).length) {
+      setIsEditing(false);
+      return;
+    }
+
+    setIsSaving(true);
+    setSaveError(null);
+    try {
+      const res = await fetch(`/api/cases/${caseId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ caseFields, userDetailsFields }),
+      });
+      if (!res.ok) throw new Error(`Failed to save (${res.status})`);
+      setIsEditing(false);
+      fetchCase();
+      fetchMyCaseData();
+    } catch (err) {
+      setSaveError((err as Error).message);
+    } finally {
+      setIsSaving(false);
+    }
+  }, [data, myCaseData, editValues, caseId, fetchCase, fetchMyCaseData]);
+
+  const handleCancelEdit = useCallback(() => {
+    setIsEditing(false);
+    setSaveError(null);
+  }, []);
+
   const lbl = `text-[10px] font-semibold uppercase tracking-wider ${t.textMuted}`;
   const val = `text-[13px] font-semibold ${t.text} mt-0.5`;
+  const inp = `mt-1 h-7 px-2 rounded border text-[12px] w-full outline-none ${t.inputBg}`;
   const sectionCls = `p-4 border-b ${t.borderLight}`;
 
   const chronicleLink = data
@@ -289,26 +376,63 @@ export default function CaseDetailSheet({
               Win Sheet Quick Look
             </SheetTitle>
             <div className="flex items-center gap-1">
-              <button
-                onClick={handleRefresh}
-                disabled={loading || myCaseLoading}
-                aria-label="Refresh"
-                className={`h-7 w-7 rounded-md flex items-center justify-center ${t.hover} ${t.textSub} disabled:opacity-40`}
-              >
-                <RefreshCw aria-hidden="true" className={`h-3.5 w-3.5 ${(loading || myCaseLoading) ? "animate-spin" : ""}`} />
-              </button>
-              <button
-                onClick={onClose}
-                aria-label="Close"
-                className={`h-7 w-7 rounded-md flex items-center justify-center ${t.hover} ${t.textSub}`}
-              >
-                <X aria-hidden="true" className="h-4 w-4" />
-              </button>
+              {!isEditing ? (
+                <>
+                  <button
+                    onClick={handleRefresh}
+                    disabled={loading || myCaseLoading}
+                    aria-label="Refresh"
+                    className={`h-7 w-7 rounded-md flex items-center justify-center ${t.hover} ${t.textSub} disabled:opacity-40`}
+                  >
+                    <RefreshCw aria-hidden="true" className={`h-3.5 w-3.5 ${(loading || myCaseLoading) ? "animate-spin" : ""}`} />
+                  </button>
+                  {data && (
+                    <button
+                      onClick={() => setIsEditing(true)}
+                      aria-label="Edit local details"
+                      className={`h-7 w-7 rounded-md flex items-center justify-center ${t.hover} ${t.textSub}`}
+                    >
+                      <Pencil aria-hidden="true" className="h-3.5 w-3.5" />
+                    </button>
+                  )}
+                </>
+              ) : (
+                <>
+                  <button
+                    onClick={handleSave}
+                    disabled={isSaving}
+                    aria-label="Save changes"
+                    className={`h-7 px-2 rounded-md flex items-center gap-1 text-[11px] font-semibold ${dark ? "bg-indigo-600 hover:bg-indigo-500 text-white" : "bg-indigo-600 hover:bg-indigo-700 text-white"} disabled:opacity-50`}
+                  >
+                    <Check aria-hidden="true" className="h-3 w-3" />
+                    {isSaving ? "Saving…" : "Save"}
+                  </button>
+                  <button
+                    onClick={handleCancelEdit}
+                    aria-label="Cancel edit"
+                    className={`h-7 w-7 rounded-md flex items-center justify-center ${t.hover} ${t.textSub}`}
+                  >
+                    <X aria-hidden="true" className="h-4 w-4" />
+                  </button>
+                </>
+              )}
+              {!isEditing && (
+                <button
+                  onClick={onClose}
+                  aria-label="Close"
+                  className={`h-7 w-7 rounded-md flex items-center justify-center ${t.hover} ${t.textSub}`}
+                >
+                  <X aria-hidden="true" className="h-4 w-4" />
+                </button>
+              )}
             </div>
           </div>
           <SheetDescription className={`text-[11px] ${t.textMuted}`}>
-            Details needed for processing the win sheet for this case.
+            {isEditing ? "Edit local DB fields — changes write to the app database." : "Details needed for processing the win sheet for this case."}
           </SheetDescription>
+          {saveError && (
+            <p role="alert" className="text-[11px] text-red-500 mt-1">{saveError}</p>
+          )}
         </SheetHeader>
 
         {loading ? (
@@ -348,16 +472,37 @@ export default function CaseDetailSheet({
                       {STATUS_LABELS_DETAIL[data.status] || data.status}
                     </span>
                   </div>
-                  {chronicleLink && (
+                  {(chronicleLink || isEditing) && (
                     <div className="mt-2">
                       <p className={lbl}>Chronicle ID</p>
-                      <p className={`${val} text-sky-500`}>{chronicleLink.split("/").pop() ?? "—"}</p>
+                      {isEditing ? (
+                        <input
+                          type="number"
+                          value={editValues.chronicleId}
+                          onChange={(e) => setEditValues((v) => ({ ...v, chronicleId: e.target.value }))}
+                          placeholder="e.g. 12345"
+                          className={inp}
+                        />
+                      ) : (
+                        <p className={`${val} text-sky-500`}>{chronicleLink!.split("/").pop() ?? "—"}</p>
+                      )}
                     </div>
                   )}
-                  {myCaseData?.ssnLast4 && (
+                  {(myCaseData?.ssnLast4 || isEditing) && (
                     <div className="mt-2">
                       <p className={lbl}>SSN (last 4)</p>
-                      <p className={val}>***-**-{myCaseData.ssnLast4}</p>
+                      {isEditing ? (
+                        <input
+                          type="text"
+                          maxLength={4}
+                          value={editValues.ssnLast4}
+                          onChange={(e) => setEditValues((v) => ({ ...v, ssnLast4: e.target.value.replace(/\D/g, "") }))}
+                          placeholder="e.g. 1234"
+                          className={inp}
+                        />
+                      ) : (
+                        <p className={val}>***-**-{myCaseData!.ssnLast4}</p>
+                      )}
                     </div>
                   )}
                 </div>
@@ -403,9 +548,18 @@ export default function CaseDetailSheet({
               <div className="grid grid-cols-2 gap-4">
                 <div>
                   <p className={lbl}>Approval Date</p>
-                  <p className={`${val} flex items-center gap-1`}>
-                    <CalendarDays aria-hidden="true" className="h-3 w-3 text-indigo-500" /> {dateStr(myCaseData?.approvalDate ?? data.approvalDate)}
-                  </p>
+                  {isEditing ? (
+                    <input
+                      type="date"
+                      value={editValues.approvalDate}
+                      onChange={(e) => setEditValues((v) => ({ ...v, approvalDate: e.target.value }))}
+                      className={inp}
+                    />
+                  ) : (
+                    <p className={`${val} flex items-center gap-1`}>
+                      <CalendarDays aria-hidden="true" className="h-3 w-3 text-indigo-500" /> {dateStr(myCaseData?.approvalDate ?? data.approvalDate)}
+                    </p>
+                  )}
                 </div>
                 <div>
                   <p className={lbl}>Aging</p>
@@ -427,18 +581,86 @@ export default function CaseDetailSheet({
                 <FileText aria-hidden="true" className="h-3 w-3" /> Decisions
               </h4>
               <div className="space-y-3">
-                <div className="flex items-center justify-between">
-                  <p className={lbl}>T2 (SSDI) Decision</p>
-                  <p className={`${val} capitalize`}>
-                    {data.t2Decision && data.t2Decision !== "unknown" ? data.t2Decision.replace(/_/g, " ") : "—"}
-                  </p>
-                </div>
-                <div className="flex items-center justify-between">
-                  <p className={lbl}>T16 (SSI) Decision</p>
-                  <p className={`${val} capitalize`}>
-                    {data.t16Decision && data.t16Decision !== "unknown" ? data.t16Decision.replace(/_/g, " ") : "—"}
-                  </p>
-                </div>
+                {isEditing ? (
+                  <div className="grid grid-cols-2 gap-3">
+                    <div>
+                      <p className={lbl}>Claim Type</p>
+                      <select
+                        value={editValues.claimTypeLabel}
+                        onChange={(e) => setEditValues((v) => ({ ...v, claimTypeLabel: e.target.value }))}
+                        className={inp}
+                      >
+                        <option value="">—</option>
+                        <option value="T2">T2 (SSDI)</option>
+                        <option value="T16">T16 (SSI)</option>
+                        <option value="T2_T16">T2 + T16</option>
+                      </select>
+                    </div>
+                    <div>
+                      <p className={lbl}>Level Won</p>
+                      <select
+                        value={editValues.levelWon}
+                        onChange={(e) => setEditValues((v) => ({ ...v, levelWon: e.target.value }))}
+                        className={inp}
+                      >
+                        <option value="">—</option>
+                        <option value="INITIAL">Initial</option>
+                        <option value="RECON">Reconsideration</option>
+                        <option value="HEARING">Hearing</option>
+                        <option value="AC">Appeals Council</option>
+                        <option value="FEDERAL_COURT">Federal Court</option>
+                        <option value="FEE_PETITION">Fee Petition</option>
+                      </select>
+                    </div>
+                    <div>
+                      <p className={lbl}>T2 Decision</p>
+                      <select
+                        value={editValues.t2Decision}
+                        onChange={(e) => setEditValues((v) => ({ ...v, t2Decision: e.target.value }))}
+                        className={inp}
+                      >
+                        <option value="">—</option>
+                        <option value="fully_favorable">Fully Favorable</option>
+                        <option value="partially_favorable">Partially Favorable</option>
+                        <option value="unfavorable">Unfavorable</option>
+                        <option value="dismissed">Dismissed</option>
+                        <option value="remand">Remand</option>
+                        <option value="unknown">Unknown</option>
+                      </select>
+                    </div>
+                    <div>
+                      <p className={lbl}>T16 Decision</p>
+                      <select
+                        value={editValues.t16Decision}
+                        onChange={(e) => setEditValues((v) => ({ ...v, t16Decision: e.target.value }))}
+                        className={inp}
+                      >
+                        <option value="">—</option>
+                        <option value="fully_favorable">Fully Favorable</option>
+                        <option value="partially_favorable">Partially Favorable</option>
+                        <option value="unfavorable">Unfavorable</option>
+                        <option value="dismissed">Dismissed</option>
+                        <option value="remand">Remand</option>
+                        <option value="unknown">Unknown</option>
+                      </select>
+                    </div>
+                  </div>
+                ) : (
+                  <>
+                    <div className="flex items-center justify-between">
+                      <p className={lbl}>T2 (SSDI) Decision</p>
+                      <p className={`${val} capitalize`}>
+                        {data.t2Decision && data.t2Decision !== "unknown" ? data.t2Decision.replace(/_/g, " ") : "—"}
+                      </p>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <p className={lbl}>T16 (SSI) Decision</p>
+                      <p className={`${val} capitalize`}>
+                        {data.t16Decision && data.t16Decision !== "unknown" ? data.t16Decision.replace(/_/g, " ") : "—"}
+                      </p>
+                    </div>
+                  </>
+                )}
                 <div className="flex items-center justify-between">
                   <p className={lbl}>Win Sheet Status</p>
                   <p className={val}>{STATUS_LABELS_DETAIL[data.status] || data.status}</p>

--- a/src/components/cases/CaseDetailSheet.tsx
+++ b/src/components/cases/CaseDetailSheet.tsx
@@ -16,6 +16,8 @@ import {
   User,
   MapPin,
   Phone,
+  Database,
+  AlertTriangle,
 } from "lucide-react";
 import {
   Sheet,
@@ -154,11 +156,39 @@ export default function CaseDetailSheet({
   const t = themeClasses(dark);
   const router = useRouter();
 
+  type MyCaseData = {
+    caseStage: string | null;
+    approvalDate: string | null;
+    assignedTo: string | null;
+    winSheetStatus: string;
+    claimTypeLabel: string | null;
+    levelWon: string | null;
+    t16Retro: string;
+    t16FeeDue: string;
+    t16FeeReceived: string;
+    t16Pending: string;
+    t16FeeReceivedDate: string | null;
+    t2Retro: string;
+    t2FeeDue: string;
+    t2FeeReceived: string;
+    t2Pending: string;
+    t2FeeReceivedDate: string | null;
+    feesConfirmation: string | null;
+    t2Decision: string;
+    t16Decision: string;
+    notes: string | null;
+    chronicleLink: string | null;
+  };
+
   const [data, setData] = useState<CaseDetailData | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [myCaseData, setMyCaseData] = useState<MyCaseData | null>(null);
+  const [myCaseLoading, setMyCaseLoading] = useState(false);
+  const [myCaseError, setMyCaseError] = useState<string | null>(null);
   const [docsOpen, setDocsOpen] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
+  const myCaseAbortRef = useRef<AbortController | null>(null);
 
   const fetchCase = useCallback(async () => {
     if (!caseId) return;
@@ -185,16 +215,53 @@ export default function CaseDetailSheet({
     }
   }, [caseId]);
 
+  const fetchMyCaseData = useCallback(async () => {
+    if (!caseId) return;
+    myCaseAbortRef.current?.abort();
+    const controller = new AbortController();
+    myCaseAbortRef.current = controller;
+
+    setMyCaseLoading(true);
+    setMyCaseError(null);
+    try {
+      const res = await fetch(`/api/mycase/cases/${caseId}/details`, {
+        signal: controller.signal,
+      });
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({}));
+        throw new Error((json.error as string) || `Failed to load MyCase data (${res.status})`);
+      }
+      const json = await res.json();
+      setMyCaseData(json.data);
+    } catch (err) {
+      if ((err as Error).name === "AbortError") return;
+      setMyCaseError((err as Error).message);
+    } finally {
+      if (myCaseAbortRef.current === controller) {
+        setMyCaseLoading(false);
+      }
+    }
+  }, [caseId]);
+
+  const handleRefresh = useCallback(() => {
+    fetchCase();
+    fetchMyCaseData();
+  }, [fetchCase, fetchMyCaseData]);
+
   useEffect(() => {
     if (isOpen) {
       fetchCase();
+      fetchMyCaseData();
     } else {
       setData(null);
+      setMyCaseData(null);
+      setMyCaseError(null);
     }
     return () => {
       abortRef.current?.abort();
+      myCaseAbortRef.current?.abort();
     };
-  }, [isOpen, fetchCase]);
+  }, [isOpen, fetchCase, fetchMyCaseData]);
 
   const lbl = `text-[10px] font-semibold uppercase tracking-wider ${t.textMuted}`;
   const val = `text-[13px] font-semibold ${t.text} mt-0.5`;
@@ -214,13 +281,23 @@ export default function CaseDetailSheet({
             <SheetTitle className={`text-sm font-bold ${t.text}`}>
               Win Sheet Quick Look
             </SheetTitle>
-            <button
-              onClick={onClose}
-              aria-label="Close"
-              className={`h-7 w-7 rounded-md flex items-center justify-center ${t.hover} ${t.textSub}`}
-            >
-              <X aria-hidden="true" className="h-4 w-4" />
-            </button>
+            <div className="flex items-center gap-1">
+              <button
+                onClick={handleRefresh}
+                disabled={loading || myCaseLoading}
+                aria-label="Refresh"
+                className={`h-7 w-7 rounded-md flex items-center justify-center ${t.hover} ${t.textSub} disabled:opacity-40`}
+              >
+                <RefreshCw aria-hidden="true" className={`h-3.5 w-3.5 ${(loading || myCaseLoading) ? "animate-spin" : ""}`} />
+              </button>
+              <button
+                onClick={onClose}
+                aria-label="Close"
+                className={`h-7 w-7 rounded-md flex items-center justify-center ${t.hover} ${t.textSub}`}
+              >
+                <X aria-hidden="true" className="h-4 w-4" />
+              </button>
+            </div>
           </div>
           <SheetDescription className={`text-[11px] ${t.textMuted}`}>
             Details needed for processing the win sheet for this case.
@@ -285,9 +362,9 @@ export default function CaseDetailSheet({
                   >
                     Documents <FileText aria-hidden="true" className="h-3 w-3" />
                   </button>
-                  {data.userDetails?.chronicleId != null && (
+                  {(myCaseData?.chronicleLink ?? (data.userDetails?.chronicleId != null ? `https://app.chroniclelegal.com/dashboard/clients/${data.userDetails.chronicleId}` : null)) && (
                     <a
-                      href={`https://app.chroniclelegal.com/dashboard/clients/${data.userDetails.chronicleId}`}
+                      href={myCaseData?.chronicleLink ?? `https://app.chroniclelegal.com/dashboard/clients/${data.userDetails?.chronicleId}`}
                       target="_blank"
                       rel="noopener noreferrer"
                       className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-[10px] font-bold uppercase transition-colors ${dark ? "bg-sky-900/30 text-sky-400 hover:bg-sky-900/50" : "bg-sky-50 text-sky-600 hover:bg-sky-100"}`}
@@ -308,7 +385,7 @@ export default function CaseDetailSheet({
                 <div>
                   <p className={lbl}>Approval Date</p>
                   <p className={`${val} flex items-center gap-1`}>
-                    <CalendarDays aria-hidden="true" className="h-3 w-3 text-indigo-500" /> {dateStr(data.approvalDate)}
+                    <CalendarDays aria-hidden="true" className="h-3 w-3 text-indigo-500" /> {dateStr(data.approvalDate ?? myCaseData?.approvalDate)}
                   </p>
                 </div>
                 <div>
@@ -436,6 +513,107 @@ export default function CaseDetailSheet({
                   </div>
                 ))}
               </div>
+            </div>
+
+            {/* Live from MyCase */}
+            <div className={sectionCls}>
+              <h4 className={`text-[10px] font-bold uppercase tracking-widest ${t.textMuted} mb-3 flex items-center gap-1.5`}>
+                <Database aria-hidden="true" className="h-3 w-3" /> Live from MyCase
+              </h4>
+              {myCaseLoading ? (
+                <div className="flex items-center gap-2 py-2">
+                  <RefreshCw aria-hidden="true" className={`h-3.5 w-3.5 animate-spin ${t.textMuted}`} />
+                  <span className={`text-[11px] ${t.textMuted}`}>Fetching from MyCase…</span>
+                </div>
+              ) : myCaseError ? (
+                <div className={`flex items-start gap-2 rounded-md p-2 text-[11px] ${dark ? "bg-amber-900/20 text-amber-400" : "bg-amber-50 text-amber-700"}`}>
+                  <AlertTriangle aria-hidden="true" className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+                  <span>{myCaseError}</span>
+                </div>
+              ) : myCaseData ? (
+                <div className="space-y-3">
+                  <div className="grid grid-cols-2 gap-3">
+                    <div>
+                      <p className={lbl}>Approval Date</p>
+                      <p className={val}>{dateStr(myCaseData.approvalDate ?? data?.approvalDate)}</p>
+                    </div>
+                    <div>
+                      <p className={lbl}>Case Stage</p>
+                      <p className={`${val} text-[11px] leading-tight`}>{myCaseData.caseStage ?? "—"}</p>
+                    </div>
+                    <div>
+                      <p className={lbl}>Assigned To</p>
+                      <p className={val}>{myCaseData.assignedTo ?? "—"}</p>
+                    </div>
+                    <div>
+                      <p className={lbl}>Win Sheet Status</p>
+                      <p className={val}>{myCaseData.winSheetStatus.replace(/_/g, " ")}</p>
+                    </div>
+                    {myCaseData.claimTypeLabel && (
+                      <div>
+                        <p className={lbl}>Claim Type</p>
+                        <p className={val}>{myCaseData.claimTypeLabel.replace(/_/g, " / ")}</p>
+                      </div>
+                    )}
+                    {myCaseData.levelWon && (
+                      <div>
+                        <p className={lbl}>Level Won</p>
+                        <p className={val}>{myCaseData.levelWon.replace(/_/g, " ")}</p>
+                      </div>
+                    )}
+                  </div>
+                  {[
+                    { key: "t16", label: "T16 (SSI)", color: "text-indigo-500", retro: myCaseData.t16Retro, due: myCaseData.t16FeeDue, received: myCaseData.t16FeeReceived, pending: myCaseData.t16Pending, receivedDate: myCaseData.t16FeeReceivedDate },
+                    { key: "t2", label: "T2 (SSDI)", color: "text-blue-500", retro: myCaseData.t2Retro, due: myCaseData.t2FeeDue, received: myCaseData.t2FeeReceived, pending: myCaseData.t2Pending, receivedDate: myCaseData.t2FeeReceivedDate },
+                  ].map((b) => (
+                    <div key={b.key} className={`p-3 rounded-lg border ${t.borderLight} bg-neutral-50/30 dark:bg-neutral-900/20`}>
+                      <p className={`text-[11px] font-bold uppercase ${b.color} mb-2`}>{b.label}</p>
+                      <div className="grid grid-cols-2 gap-2">
+                        {[
+                          { label: "Retro", val: b.retro },
+                          { label: "Fee Due", val: b.due },
+                          { label: "Received", val: b.received },
+                          { label: "Pending", val: b.pending },
+                        ].map((f) => (
+                          <div key={f.label}>
+                            <p className={lbl}>{f.label}</p>
+                            <p className="text-xs font-semibold">{Number(f.val) > 0 ? fmtFull(Number(f.val)) : "—"}</p>
+                          </div>
+                        ))}
+                        {b.receivedDate && (
+                          <div className="col-span-2">
+                            <p className={lbl}>Fee Received Date</p>
+                            <p className="text-xs font-semibold">{dateStr(b.receivedDate)}</p>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                  <div className="grid grid-cols-2 gap-3">
+                    {[
+                      { label: "T2 Decision", val: myCaseData.t2Decision },
+                      { label: "T16 Decision", val: myCaseData.t16Decision },
+                    ].map((f) => f.val && f.val !== "unknown" ? (
+                      <div key={f.label}>
+                        <p className={lbl}>{f.label}</p>
+                        <p className={val}>{f.val.replace(/_/g, " ")}</p>
+                      </div>
+                    ) : null)}
+                  </div>
+                  {myCaseData.feesConfirmation && (
+                    <div>
+                      <p className={lbl}>Fees Confirmation</p>
+                      <p className={`${val} text-[11px] leading-snug`}>{myCaseData.feesConfirmation}</p>
+                    </div>
+                  )}
+                  {myCaseData.notes && (
+                    <div>
+                      <p className={lbl}>Collection Notes</p>
+                      <p className={`${val} text-[11px] leading-snug whitespace-pre-wrap`}>{myCaseData.notes}</p>
+                    </div>
+                  )}
+                </div>
+              ) : null}
             </div>
 
             {/* Actions */}

--- a/src/components/cases/CaseDetailSheet.tsx
+++ b/src/components/cases/CaseDetailSheet.tsx
@@ -68,6 +68,7 @@ type MyCaseData = {
   t16Decision: string;
   notes: string | null;
   chronicleLink: string | null;
+  ssnLast4: string | null;
 };
 
 function ClientDetailsSection({
@@ -351,6 +352,12 @@ export default function CaseDetailSheet({
                     <div className="mt-2">
                       <p className={lbl}>Chronicle ID</p>
                       <p className={`${val} text-sky-500`}>{chronicleLink.split("/").pop() ?? "—"}</p>
+                    </div>
+                  )}
+                  {myCaseData?.ssnLast4 && (
+                    <div className="mt-2">
+                      <p className={lbl}>SSN (last 4)</p>
+                      <p className={val}>***-**-{myCaseData.ssnLast4}</p>
                     </div>
                   )}
                 </div>

--- a/src/components/cases/CaseDetailSheet.tsx
+++ b/src/components/cases/CaseDetailSheet.tsx
@@ -216,6 +216,7 @@ export default function CaseDetailSheet({
   const [saveError, setSaveError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const myCaseAbortRef = useRef<AbortController | null>(null);
+  const saveAbortRef = useRef<AbortController | null>(null);
 
   const fetchCase = useCallback(async () => {
     if (!caseId) return;
@@ -377,6 +378,10 @@ export default function CaseDetailSheet({
       return;
     }
 
+    saveAbortRef.current?.abort();
+    const controller = new AbortController();
+    saveAbortRef.current = controller;
+
     setIsSaving(true);
     setSaveError(null);
     try {
@@ -384,12 +389,14 @@ export default function CaseDetailSheet({
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ caseFields, feeFields, userDetailsFields }),
+        signal: controller.signal,
       });
       if (!res.ok) throw new Error(`Failed to save (${res.status})`);
       setIsEditing(false);
       fetchCase();
       fetchMyCaseData();
     } catch (err) {
+      if ((err as Error).name === "AbortError") return;
       setSaveError((err as Error).message);
     } finally {
       setIsSaving(false);

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -10,6 +10,7 @@ import {
   MessageSquare,
   FileSpreadsheet,
   CloudUpload,
+  Database,
   RotateCcw,
   Loader2,
   ExternalLink,
@@ -31,6 +32,7 @@ import CaseDetailSheet from "./CaseDetailSheet";
 import ImportCasesModal from "@/components/modals/ImportCasesModal";
 import SheetSyncModal from "@/components/modals/SheetSyncModal";
 import SheetPushModal from "@/components/modals/SheetPushModal";
+import MyCaseSyncModal from "@/components/modals/MyCaseSyncModal";
 import NotesModal from "@/components/modals/NotesModal";
 import { AcknowledgeAndCloseDialog } from "./AcknowledgeAndCloseDialog";
 
@@ -174,6 +176,7 @@ export const FeeRecordsTable = ({
   const [selectedCaseId, setSelectedCaseId] = useState<number | null>(null);
   const [importOpen, setImportOpen] = useState(false);
   const [syncOpen, setSyncOpen] = useState(false);
+  const [myCaseSyncOpen, setMyCaseSyncOpen] = useState(false);
   const [pushOpen, setPushOpen] = useState(false);
   const [notesFor, setNotesFor] = useState<{ id: number; name: string } | null>(
     null,
@@ -563,6 +566,12 @@ export const FeeRecordsTable = ({
                 className={`h-8 px-3 rounded-md text-xs font-semibold flex items-center gap-1.5 ${dark ? "bg-emerald-700 hover:bg-emerald-600 text-white" : "bg-emerald-600 hover:bg-emerald-700 text-white"} transition-colors`}
               >
                 <FileSpreadsheet className="h-3.5 w-3.5" aria-hidden="true" /> Sync from Sheets
+              </button>
+              <button
+                onClick={() => setMyCaseSyncOpen(true)}
+                className={`h-8 px-3 rounded-md text-xs font-semibold flex items-center gap-1.5 ${dark ? "bg-indigo-700 hover:bg-indigo-600 text-white" : "bg-indigo-600 hover:bg-indigo-700 text-white"} transition-colors`}
+              >
+                <Database className="h-3.5 w-3.5" aria-hidden="true" /> Sync from MyCase
               </button>
               <button
                 onClick={() => setPushOpen(true)}
@@ -1445,6 +1454,16 @@ export const FeeRecordsTable = ({
         <SheetSyncModal
           dark={dark}
           onClose={() => setSyncOpen(false)}
+          onSynced={async () => {
+            if (onImported) await onImported();
+          }}
+        />
+      )}
+
+      {myCaseSyncOpen && (
+        <MyCaseSyncModal
+          dark={dark}
+          onClose={() => setMyCaseSyncOpen(false)}
           onSynced={async () => {
             if (onImported) await onImported();
           }}

--- a/src/components/modals/MyCaseSyncModal.tsx
+++ b/src/components/modals/MyCaseSyncModal.tsx
@@ -314,7 +314,7 @@ export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncM
         .filter((r) => !selected.has(r.clientId))
         .map((r) => r.clientId);
       if (unselectedNewIds.length > 0) {
-        void handleTag(unselectedNewIds);
+        await handleTag(unselectedNewIds);
       }
       setResult(syncResult);
       try { await onSynced(); } catch { /* refresh failed; sync succeeded */ }

--- a/src/components/modals/MyCaseSyncModal.tsx
+++ b/src/components/modals/MyCaseSyncModal.tsx
@@ -130,9 +130,11 @@ export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncM
 
   const fetchControllerRef = useRef<AbortController | null>(null);
   const syncControllerRef = useRef<AbortController | null>(null);
+  const tagControllerRef = useRef<AbortController | null>(null);
   useEffect(() => () => {
     fetchControllerRef.current?.abort();
     syncControllerRef.current?.abort();
+    tagControllerRef.current?.abort();
   }, []);
 
   const handleFetch = async () => {
@@ -188,23 +190,29 @@ export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncM
       clientIds.forEach((id) => next.delete(id));
       return next;
     });
+    tagControllerRef.current?.abort();
+    const tagController = new AbortController();
+    tagControllerRef.current = tagController;
     try {
       const res = await fetch("/api/mycase/sync/tags", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ myCaseCaseIds: clientIds }),
+        signal: tagController.signal,
       });
       if (!res.ok) {
         const json: Record<string, unknown> = await res.json().catch(() => ({}));
         throw new Error((json.error as string) ?? `Tag failed (${res.status})`);
       }
     } catch (e) {
+      const err = e as Error;
+      if (err.name === "AbortError") return;
       setViewedIds((prev) => {
         const next = new Set(prev);
         clientIds.forEach((id) => next.delete(id));
         return next;
       });
-      setError((e as Error).message);
+      setError(err.message);
     }
   };
 
@@ -214,19 +222,25 @@ export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncM
       clientIds.forEach((id) => next.delete(id));
       return next;
     });
+    tagControllerRef.current?.abort();
+    const tagController = new AbortController();
+    tagControllerRef.current = tagController;
     try {
       const res = await fetch("/api/mycase/sync/tags", {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ myCaseCaseIds: clientIds }),
+        signal: tagController.signal,
       });
       if (!res.ok) {
         const json: Record<string, unknown> = await res.json().catch(() => ({}));
         throw new Error((json.error as string) ?? `Untag failed (${res.status})`);
       }
     } catch (e) {
+      const err = e as Error;
+      if (err.name === "AbortError") return;
       setViewedIds((prev) => new Set([...prev, ...clientIds]));
-      setError((e as Error).message);
+      setError(err.message);
     }
   };
 

--- a/src/components/modals/MyCaseSyncModal.tsx
+++ b/src/components/modals/MyCaseSyncModal.tsx
@@ -697,9 +697,26 @@ export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncM
               {syncing ? "Syncing…" : `Sync Selected (${selected.size.toLocaleString()})`}
             </button>
           ) : (
-            <button onClick={onClose} className={`h-8 px-4 rounded-md text-xs font-semibold ${t.ctaBtn} transition-colors`}>
-              Done
-            </button>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => {
+                  setResult(null);
+                  setPreview(null);
+                  setSelected(new Set());
+                  setViewedIds(new Set());
+                  setSearch("");
+                  setFilter("all");
+                  setError(null);
+                  setStep(1);
+                }}
+                className={`h-8 px-4 rounded-md border text-xs font-semibold ${t.outlineBtn} transition-colors`}
+              >
+                Sync Again
+              </button>
+              <button onClick={onClose} className={`h-8 px-4 rounded-md text-xs font-semibold ${t.ctaBtn} transition-colors`}>
+                Done
+              </button>
+            </div>
           )}
         </div>
       </div>

--- a/src/components/modals/MyCaseSyncModal.tsx
+++ b/src/components/modals/MyCaseSyncModal.tsx
@@ -329,10 +329,7 @@ export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncM
     return false;
   };
 
-  const syncableCount = useMemo(
-    () => effectiveRows.filter((r) => r.status !== "viewed").length,
-    [effectiveRows],
-  );
+  const syncableCount = effectiveRows.length;
 
   const lblCls = `text-[10px] font-semibold uppercase tracking-wider ${t.textMuted}`;
 
@@ -559,7 +556,7 @@ export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncM
                 <CategorySection status="missing" count={preview.summary.missing} description="In fee collections database · not found in MyCase with an approval date" dark={dark} t={t}>
                   <MissingRowsTable t={t} dark={dark} rows={preview.rows.missing} />
                 </CategorySection>
-                <CategorySection status="viewed" count={viewedRows.length} description="In MyCase · not yet in database · previously marked as viewed — skipped on sync" dark={dark} t={t}>
+                <CategorySection status="viewed" count={viewedRows.length} description="In MyCase · not yet in database · previously seen — can still be selected for sync" dark={dark} t={t}>
                   <SourceRowsTable t={t} dark={dark} rows={viewedRows.slice(0, 100)} truncated={viewedRows.length > 100} total={viewedRows.length} />
                 </CategorySection>
               </div>
@@ -606,7 +603,7 @@ export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncM
                     setSelected(new Set([
                       ...selected,
                       ...filteredRows
-                        .filter((r) => r.status !== "missing" && r.status !== "viewed")
+                        .filter((r) => r.status !== "missing")
                         .map((r) => r.clientId),
                     ]))
                   }
@@ -618,7 +615,7 @@ export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncM
                   onClick={() => {
                     const next = new Set(selected);
                     filteredRows
-                      .filter((r) => r.status !== "missing" && r.status !== "viewed")
+                      .filter((r) => r.status !== "missing")
                       .forEach((r) => next.delete(r.clientId));
                     setSelected(next);
                   }}
@@ -635,7 +632,7 @@ export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncM
                 selected={selected}
                 onToggle={(id) => {
                   const row = allRows.find((r) => r.clientId === id);
-                  if (!row || row.status === "missing" || row.status === "viewed") return;
+                  if (!row || row.status === "missing") return;
                   const next = new Set(selected);
                   if (next.has(id)) next.delete(id); else next.add(id);
                   setSelected(next);
@@ -924,19 +921,18 @@ const SelectionTable = ({
             const isMissing = r.status === "missing";
             const isViewed = r.status === "viewed";
             const isNew = r.status === "new";
-            const isSelectable = !isMissing && !isViewed;
             const checked = selected.has(r.clientId);
             return (
               <tr
                 key={r.clientId}
-                onClick={() => isSelectable && onToggle(r.clientId)}
-                className={`border-b ${t.borderLight} ${!isSelectable ? "cursor-default opacity-60" : "cursor-pointer"} ${dark ? "hover:bg-neutral-800/40" : "hover:bg-neutral-50"}`}
+                onClick={() => !isMissing && onToggle(r.clientId)}
+                className={`border-b ${t.borderLight} ${isMissing ? "cursor-default opacity-60" : "cursor-pointer"} ${dark ? "hover:bg-neutral-800/40" : "hover:bg-neutral-50"}`}
               >
                 <td className="px-3 py-1.5">
                   <input
                     type="checkbox"
                     checked={checked}
-                    disabled={!isSelectable}
+                    disabled={isMissing}
                     onChange={() => onToggle(r.clientId)}
                     onClick={(e) => e.stopPropagation()}
                     className="h-3.5 w-3.5 cursor-pointer disabled:cursor-not-allowed"

--- a/src/components/modals/MyCaseSyncModal.tsx
+++ b/src/components/modals/MyCaseSyncModal.tsx
@@ -11,6 +11,8 @@ import {
   ArrowLeft,
   ArrowRight,
   CloudDownload,
+  Eye,
+  EyeOff,
 } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
 import { fmtFull, fmtDate } from "@/lib/formatters";
@@ -25,7 +27,7 @@ interface SourceRow {
   winSheetStatus: string;
   totalExpected: number;
   hasNotes: boolean;
-  status: "new" | "changed" | "unchanged";
+  status: "new" | "changed" | "unchanged" | "viewed";
   changedFields: { field: string; mycase: string; db: string }[];
 }
 
@@ -44,6 +46,7 @@ interface SyncPreviewResponse {
     changed: number;
     unchanged: number;
     missing: number;
+    viewed: number;
     warnings: { row: number; message: string }[];
   };
   rows: {
@@ -59,7 +62,7 @@ interface MyCaseSyncModalProps {
 }
 
 type Step = 1 | 2 | 3 | 4;
-type RowFilter = "all" | "new" | "changed" | "unchanged" | "missing";
+type RowFilter = "all" | "new" | "changed" | "unchanged" | "missing" | "viewed";
 
 const STEPS: { n: Step; title: string; subtitle: string }[] = [
   { n: 1, title: "Step 1", subtitle: "Fetch from MyCase" },
@@ -101,6 +104,7 @@ const STATUS_BADGE: Record<string, (dark: boolean) => string> = {
   changed: (dark) => (dark ? "bg-blue-900/40 text-blue-400" : "bg-blue-100 text-blue-700"),
   unchanged: (dark) => (dark ? "bg-neutral-800 text-neutral-400" : "bg-neutral-100 text-neutral-600"),
   missing: (dark) => (dark ? "bg-amber-900/40 text-amber-400" : "bg-amber-100 text-amber-700"),
+  viewed: (dark) => (dark ? "bg-violet-900/40 text-violet-400" : "bg-violet-100 text-violet-700"),
 };
 
 const STATUS_LABEL: Record<string, string> = {
@@ -108,6 +112,7 @@ const STATUS_LABEL: Record<string, string> = {
   changed: "CHANGED",
   unchanged: "UP TO DATE",
   missing: "MISSING",
+  viewed: "VIEWED",
 };
 
 export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncModalProps) {
@@ -116,6 +121,7 @@ export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncM
   const [fetching, setFetching] = useState(false);
   const [preview, setPreview] = useState<SyncPreviewResponse | null>(null);
   const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [viewedIds, setViewedIds] = useState<Set<number>>(new Set());
   const [syncing, setSyncing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<{ inserted: number; updated: number } | null>(null);
@@ -152,6 +158,9 @@ export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncM
         throw new Error((json.error as string) || `Fetch failed (${res.status})`);
       const data = json as unknown as SyncPreviewResponse;
       setPreview(data);
+      setViewedIds(
+        new Set(data.rows.source.filter((r) => r.status === "viewed").map((r) => r.clientId)),
+      );
       setSelected(
         new Set(
           data.rows.source
@@ -172,17 +181,78 @@ export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncM
     }
   };
 
-  const newRows = useMemo(() => preview?.rows.source.filter((r) => r.status === "new") ?? [], [preview]);
-  const changedRows = useMemo(() => preview?.rows.source.filter((r) => r.status === "changed") ?? [], [preview]);
-  const unchangedRows = useMemo(() => preview?.rows.source.filter((r) => r.status === "unchanged") ?? [], [preview]);
+  const handleTag = async (clientIds: number[]) => {
+    setViewedIds((prev) => new Set([...prev, ...clientIds]));
+    setSelected((prev) => {
+      const next = new Set(prev);
+      clientIds.forEach((id) => next.delete(id));
+      return next;
+    });
+    try {
+      const res = await fetch("/api/mycase/sync/tags", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ myCaseCaseIds: clientIds }),
+      });
+      if (!res.ok) {
+        const json: Record<string, unknown> = await res.json().catch(() => ({}));
+        throw new Error((json.error as string) ?? `Tag failed (${res.status})`);
+      }
+    } catch (e) {
+      setViewedIds((prev) => {
+        const next = new Set(prev);
+        clientIds.forEach((id) => next.delete(id));
+        return next;
+      });
+      setError((e as Error).message);
+    }
+  };
+
+  const handleUntag = async (clientIds: number[]) => {
+    setViewedIds((prev) => {
+      const next = new Set(prev);
+      clientIds.forEach((id) => next.delete(id));
+      return next;
+    });
+    try {
+      const res = await fetch("/api/mycase/sync/tags", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ myCaseCaseIds: clientIds }),
+      });
+      if (!res.ok) {
+        const json: Record<string, unknown> = await res.json().catch(() => ({}));
+        throw new Error((json.error as string) ?? `Untag failed (${res.status})`);
+      }
+    } catch (e) {
+      setViewedIds((prev) => new Set([...prev, ...clientIds]));
+      setError((e as Error).message);
+    }
+  };
+
+  // Apply local tag overrides on top of server response
+  const effectiveRows = useMemo(
+    () =>
+      preview?.rows.source.map((r): SourceRow => ({
+        ...r,
+        status: viewedIds.has(r.clientId)
+          ? "viewed"
+          : r.status === "viewed"
+          ? "new"
+          : r.status,
+      })) ?? [],
+    [preview, viewedIds],
+  );
+
+  const newRows = useMemo(() => effectiveRows.filter((r) => r.status === "new"), [effectiveRows]);
+  const changedRows = useMemo(() => effectiveRows.filter((r) => r.status === "changed"), [effectiveRows]);
+  const unchangedRows = useMemo(() => effectiveRows.filter((r) => r.status === "unchanged"), [effectiveRows]);
+  const viewedRows = useMemo(() => effectiveRows.filter((r) => r.status === "viewed"), [effectiveRows]);
 
   const allRows = useMemo(() => {
     if (!preview) return [];
-    return [
-      ...preview.rows.source,
-      ...preview.rows.missing,
-    ];
-  }, [preview]);
+    return [...effectiveRows, ...preview.rows.missing];
+  }, [effectiveRows, preview]);
 
   const filteredRows = useMemo(() => {
     let r = allRows;
@@ -225,6 +295,13 @@ export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncM
       setSyncing(false);
     }
     if (syncResult) {
+      // Auto-tag new cases that were not selected — they won't appear as "new" on the next fetch
+      const unselectedNewIds = newRows
+        .filter((r) => !selected.has(r.clientId))
+        .map((r) => r.clientId);
+      if (unselectedNewIds.length > 0) {
+        void handleTag(unselectedNewIds);
+      }
       setResult(syncResult);
       try { await onSynced(); } catch { /* refresh failed; sync succeeded */ }
     }
@@ -237,6 +314,11 @@ export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncM
     if (s === 4) return selected.size > 0;
     return false;
   };
+
+  const syncableCount = useMemo(
+    () => effectiveRows.filter((r) => r.status !== "viewed").length,
+    [effectiveRows],
+  );
 
   const lblCls = `text-[10px] font-semibold uppercase tracking-wider ${t.textMuted}`;
 
@@ -341,26 +423,32 @@ export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncM
 
               {preview && !fetching && (
                 <div className="space-y-4">
-                  <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-3">
+                  <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-3">
                     <Stat t={t} label="Rows fetched" value={preview.summary.fetched.toLocaleString()} />
                     <Stat
                       t={t}
                       label="New cases"
-                      value={preview.summary.new.toLocaleString()}
+                      value={newRows.length.toLocaleString()}
                       accent={dark ? "text-emerald-400" : "text-emerald-600"}
                     />
                     <Stat
                       t={t}
                       label="Changed"
-                      value={preview.summary.changed.toLocaleString()}
-                      accent={preview.summary.changed > 0 ? (dark ? "text-blue-400" : "text-blue-600") : undefined}
+                      value={changedRows.length.toLocaleString()}
+                      accent={changedRows.length > 0 ? (dark ? "text-blue-400" : "text-blue-600") : undefined}
                     />
-                    <Stat t={t} label="Up to date" value={preview.summary.unchanged.toLocaleString()} />
+                    <Stat t={t} label="Up to date" value={unchangedRows.length.toLocaleString()} />
                     <Stat
                       t={t}
                       label="Missing"
                       value={preview.summary.missing.toLocaleString()}
                       accent={preview.summary.missing > 0 ? (dark ? "text-amber-400" : "text-amber-600") : undefined}
+                    />
+                    <Stat
+                      t={t}
+                      label="Viewed"
+                      value={viewedRows.length.toLocaleString()}
+                      accent={viewedRows.length > 0 ? (dark ? "text-violet-400" : "text-violet-600") : undefined}
                     />
                   </div>
                   {preview.summary.warnings.length > 0 && (
@@ -437,24 +525,28 @@ export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncM
               <p className={`text-[11px] ${t.textMuted} mb-4`}>
                 Categories based on how each record compares between MyCase and the fee collections database.
               </p>
-              <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-5">
-                <Stat t={t} label="New" value={preview.summary.new.toLocaleString()} accent={dark ? "text-emerald-400" : "text-emerald-600"} />
-                <Stat t={t} label="Changed" value={preview.summary.changed.toLocaleString()} accent={preview.summary.changed > 0 ? (dark ? "text-blue-400" : "text-blue-600") : undefined} />
-                <Stat t={t} label="Up to date" value={preview.summary.unchanged.toLocaleString()} />
+              <div className="grid grid-cols-2 sm:grid-cols-5 gap-3 mb-5">
+                <Stat t={t} label="New" value={newRows.length.toLocaleString()} accent={dark ? "text-emerald-400" : "text-emerald-600"} />
+                <Stat t={t} label="Changed" value={changedRows.length.toLocaleString()} accent={changedRows.length > 0 ? (dark ? "text-blue-400" : "text-blue-600") : undefined} />
+                <Stat t={t} label="Up to date" value={unchangedRows.length.toLocaleString()} />
                 <Stat t={t} label="Missing" value={preview.summary.missing.toLocaleString()} accent={preview.summary.missing > 0 ? (dark ? "text-amber-400" : "text-amber-600") : undefined} />
+                <Stat t={t} label="Viewed" value={viewedRows.length.toLocaleString()} accent={viewedRows.length > 0 ? (dark ? "text-violet-400" : "text-violet-600") : undefined} />
               </div>
               <div className="space-y-5">
-                <CategorySection status="new" count={preview.summary.new} description="In MyCase · not yet in database — will be inserted on sync" dark={dark} t={t}>
+                <CategorySection status="new" count={newRows.length} description="In MyCase · not yet in database — will be inserted on sync" dark={dark} t={t}>
                   <SourceRowsTable t={t} dark={dark} rows={newRows.slice(0, 100)} truncated={newRows.length > 100} total={newRows.length} />
                 </CategorySection>
-                <CategorySection status="changed" count={preview.summary.changed} description="In MyCase · already in database · values have changed — will be updated on sync" dark={dark} t={t}>
+                <CategorySection status="changed" count={changedRows.length} description="In MyCase · already in database · values have changed — will be updated on sync" dark={dark} t={t}>
                   <SourceRowsTable t={t} dark={dark} rows={changedRows.slice(0, 100)} truncated={changedRows.length > 100} total={changedRows.length} showChangedFields />
                 </CategorySection>
-                <CategorySection status="unchanged" count={preview.summary.unchanged} description="In MyCase · already in database · no changes detected — skipped by default" dark={dark} t={t}>
+                <CategorySection status="unchanged" count={unchangedRows.length} description="In MyCase · already in database · no changes detected — skipped by default" dark={dark} t={t}>
                   <SourceRowsTable t={t} dark={dark} rows={unchangedRows.slice(0, 100)} truncated={unchangedRows.length > 100} total={unchangedRows.length} />
                 </CategorySection>
                 <CategorySection status="missing" count={preview.summary.missing} description="In fee collections database · not found in MyCase with an approval date" dark={dark} t={t}>
                   <MissingRowsTable t={t} dark={dark} rows={preview.rows.missing} />
+                </CategorySection>
+                <CategorySection status="viewed" count={viewedRows.length} description="In MyCase · not yet in database · previously marked as viewed — skipped on sync" dark={dark} t={t}>
+                  <SourceRowsTable t={t} dark={dark} rows={viewedRows.slice(0, 100)} truncated={viewedRows.length > 100} total={viewedRows.length} />
                 </CategorySection>
               </div>
             </div>
@@ -472,7 +564,7 @@ export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncM
                 </div>
                 <div className={`text-[11px] ${t.textSub}`}>
                   <span className={`font-bold ${t.text}`}>{selected.size.toLocaleString()}</span>
-                  {" "}/ {preview.rows.source.length.toLocaleString()} syncable selected
+                  {" "}/ {syncableCount.toLocaleString()} syncable selected
                 </div>
               </div>
 
@@ -493,12 +585,15 @@ export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncM
                   <option value="changed">Changed only</option>
                   <option value="unchanged">Up to date only</option>
                   <option value="missing">Missing only</option>
+                  <option value="viewed">Viewed only</option>
                 </select>
                 <button
                   onClick={() =>
                     setSelected(new Set([
                       ...selected,
-                      ...filteredRows.filter((r) => r.status !== "missing").map((r) => r.clientId),
+                      ...filteredRows
+                        .filter((r) => r.status !== "missing" && r.status !== "viewed")
+                        .map((r) => r.clientId),
                     ]))
                   }
                   className={`h-8 px-3 rounded-md border text-xs font-medium ${t.outlineBtn} transition-colors`}
@@ -508,7 +603,9 @@ export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncM
                 <button
                   onClick={() => {
                     const next = new Set(selected);
-                    filteredRows.filter((r) => r.status !== "missing").forEach((r) => next.delete(r.clientId));
+                    filteredRows
+                      .filter((r) => r.status !== "missing" && r.status !== "viewed")
+                      .forEach((r) => next.delete(r.clientId));
                     setSelected(next);
                   }}
                   className={`h-8 px-3 rounded-md border text-xs font-medium ${t.outlineBtn} transition-colors`}
@@ -524,11 +621,13 @@ export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncM
                 selected={selected}
                 onToggle={(id) => {
                   const row = allRows.find((r) => r.clientId === id);
-                  if (!row || row.status === "missing") return;
+                  if (!row || row.status === "missing" || row.status === "viewed") return;
                   const next = new Set(selected);
                   if (next.has(id)) next.delete(id); else next.add(id);
                   setSelected(next);
                 }}
+                onTag={(id) => handleTag([id])}
+                onUntag={(id) => handleUntag([id])}
               />
             </div>
           )}
@@ -622,7 +721,7 @@ const CategorySection = ({
   t,
   children,
 }: {
-  status: "new" | "changed" | "unchanged" | "missing";
+  status: "new" | "changed" | "unchanged" | "missing" | "viewed";
   count: number;
   description: string;
   dark: boolean;
@@ -781,12 +880,16 @@ const SelectionTable = ({
   rows,
   selected,
   onToggle,
+  onTag,
+  onUntag,
 }: {
   t: ReturnType<typeof themeClasses>;
   dark: boolean;
   rows: (SourceRow | MissingRow)[];
   selected: Set<number>;
   onToggle: (id: number) => void;
+  onTag: (id: number) => void;
+  onUntag: (id: number) => void;
 }) => (
   <div className={`rounded-lg border ${t.borderLight} overflow-hidden`}>
     <div className="overflow-x-auto">
@@ -799,23 +902,27 @@ const SelectionTable = ({
             <Th>Approved</Th>
             <Th>Assigned</Th>
             <Th>Win Sheet Status</Th>
+            <Th>{""}</Th>
           </tr>
         </thead>
         <tbody>
           {rows.map((r) => {
             const isMissing = r.status === "missing";
+            const isViewed = r.status === "viewed";
+            const isNew = r.status === "new";
+            const isSelectable = !isMissing && !isViewed;
             const checked = selected.has(r.clientId);
             return (
               <tr
                 key={r.clientId}
-                onClick={() => !isMissing && onToggle(r.clientId)}
-                className={`border-b ${t.borderLight} ${isMissing ? "cursor-not-allowed opacity-60" : "cursor-pointer"} ${dark ? "hover:bg-neutral-800/40" : "hover:bg-neutral-50"}`}
+                onClick={() => isSelectable && onToggle(r.clientId)}
+                className={`border-b ${t.borderLight} ${!isSelectable ? "cursor-default opacity-60" : "cursor-pointer"} ${dark ? "hover:bg-neutral-800/40" : "hover:bg-neutral-50"}`}
               >
                 <td className="px-3 py-1.5">
                   <input
                     type="checkbox"
                     checked={checked}
-                    disabled={isMissing}
+                    disabled={!isSelectable}
                     onChange={() => onToggle(r.clientId)}
                     onClick={(e) => e.stopPropagation()}
                     className="h-3.5 w-3.5 cursor-pointer disabled:cursor-not-allowed"
@@ -840,6 +947,28 @@ const SelectionTable = ({
                     </span>
                   ) : (
                     <span className={`text-[10px] ${t.textMuted}`}>—</span>
+                  )}
+                </td>
+                <td className="px-3 py-1.5 text-right">
+                  {isNew && (
+                    <button
+                      onClick={(e) => { e.stopPropagation(); onTag(r.clientId); }}
+                      title="Mark as viewed — hide from future new cases"
+                      className={`h-6 px-2 rounded text-[10px] font-medium flex items-center gap-1 ml-auto transition-colors ${dark ? "text-violet-400 hover:bg-violet-900/40" : "text-violet-600 hover:bg-violet-100"}`}
+                    >
+                      <Eye className="h-3 w-3" aria-hidden="true" />
+                      Mark Viewed
+                    </button>
+                  )}
+                  {isViewed && (
+                    <button
+                      onClick={(e) => { e.stopPropagation(); onUntag(r.clientId); }}
+                      title="Unmark — restore to new"
+                      className={`h-6 px-2 rounded text-[10px] font-medium flex items-center gap-1 ml-auto transition-colors ${dark ? "text-neutral-400 hover:bg-neutral-700" : "text-neutral-500 hover:bg-neutral-200"}`}
+                    >
+                      <EyeOff className="h-3 w-3" aria-hidden="true" />
+                      Unmark
+                    </button>
                   )}
                 </td>
               </tr>

--- a/src/components/modals/MyCaseSyncModal.tsx
+++ b/src/components/modals/MyCaseSyncModal.tsx
@@ -1,0 +1,858 @@
+"use client";
+
+import { useMemo, useRef, useState, useEffect } from "react";
+import {
+  X,
+  RefreshCw,
+  Database,
+  CheckCircle2,
+  AlertTriangle,
+  ExternalLink,
+  ArrowLeft,
+  ArrowRight,
+  CloudDownload,
+} from "lucide-react";
+import { themeClasses } from "@/lib/theme-classes";
+import { fmtFull, fmtDate } from "@/lib/formatters";
+
+interface SourceRow {
+  clientId: number;
+  caseName: string;
+  caseLink: string;
+  externalUrl: string | null;
+  approvalDate: string | null;
+  assignedTo: string | null;
+  winSheetStatus: string;
+  totalExpected: number;
+  hasNotes: boolean;
+  status: "new" | "changed" | "unchanged";
+  changedFields: { field: string; mycase: string; db: string }[];
+}
+
+interface MissingRow {
+  clientId: number;
+  caseName: string;
+  caseLink: string;
+  approvalDate: string | null;
+  status: "missing";
+}
+
+interface SyncPreviewResponse {
+  summary: {
+    fetched: number;
+    new: number;
+    changed: number;
+    unchanged: number;
+    missing: number;
+    warnings: { row: number; message: string }[];
+  };
+  rows: {
+    source: SourceRow[];
+    missing: MissingRow[];
+  };
+}
+
+interface MyCaseSyncModalProps {
+  dark: boolean;
+  onClose: () => void;
+  onSynced: () => Promise<void> | void;
+}
+
+type Step = 1 | 2 | 3 | 4;
+type RowFilter = "all" | "new" | "changed" | "unchanged" | "missing";
+
+const STEPS: { n: Step; title: string; subtitle: string }[] = [
+  { n: 1, title: "Step 1", subtitle: "Fetch from MyCase" },
+  { n: 2, title: "Step 2", subtitle: "Field Map" },
+  { n: 3, title: "Step 3", subtitle: "Compare & Preview" },
+  { n: 4, title: "Step 4", subtitle: "Select & Sync" },
+];
+
+const FIELD_MAP = [
+  { source: "cases.name", db: "cases.case_link + first_name + last_name", required: true },
+  { source: "custom_fields['APPROVAL DATE']", db: "cases.approval_date", required: true },
+  { source: "custom_fields['CLAIM TYPE'] / 'What TYPE of CLAIM?'", db: "cases.claim_type_label", required: false },
+  { source: "custom_fields['Level of Win'] / 'STAGE PAID'", db: "cases.level_won", required: false },
+  { source: "custom_fields['CHRONICLE LINK']", db: "cases.external_id", required: false },
+  { source: "custom_fields['FEE ASSIGNMENT']", db: "fee_records.assigned_to", required: false },
+  { source: "custom_fields['T2 RETRO']", db: "fee_records.t2_retro", required: false },
+  { source: "custom_fields['T2 FEE DUE']", db: "fee_records.t2_fee_due", required: false },
+  { source: "custom_fields['T2 FEE PAID']", db: "fee_records.t2_fee_received", required: false },
+  { source: "custom_fields['DATE T2 FEE PAID']", db: "fee_records.t2_fee_received_date", required: false },
+  { source: "custom_fields['T16 RETRO']", db: "fee_records.t16_retro", required: false },
+  { source: "custom_fields['T16 FEE DUE']", db: "fee_records.t16_fee_due", required: false },
+  { source: "custom_fields['T16 FEE PAID']", db: "fee_records.t16_fee_received", required: false },
+  { source: "custom_fields['PAID IN FULL'] / case_stage", db: "fee_records.win_sheet_status", required: false },
+  { source: "custom_fields['COLLECTION NOTES']", db: "activity_log.message (new cases only)", required: false },
+];
+
+const STATUS_PILL: Record<string, string> = {
+  not_started: "bg-neutral-200 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-400",
+  started: "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-400",
+  in_progress: "bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-400",
+  pending_payment: "bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-400",
+  partially_paid: "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400",
+  paid_in_full: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-400",
+  closed: "bg-neutral-200 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-400",
+};
+
+const STATUS_BADGE: Record<string, (dark: boolean) => string> = {
+  new: (dark) => (dark ? "bg-emerald-900/40 text-emerald-400" : "bg-emerald-100 text-emerald-700"),
+  changed: (dark) => (dark ? "bg-blue-900/40 text-blue-400" : "bg-blue-100 text-blue-700"),
+  unchanged: (dark) => (dark ? "bg-neutral-800 text-neutral-400" : "bg-neutral-100 text-neutral-600"),
+  missing: (dark) => (dark ? "bg-amber-900/40 text-amber-400" : "bg-amber-100 text-amber-700"),
+};
+
+const STATUS_LABEL: Record<string, string> = {
+  new: "NEW",
+  changed: "CHANGED",
+  unchanged: "UP TO DATE",
+  missing: "MISSING",
+};
+
+export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncModalProps) {
+  const t = themeClasses(dark);
+  const [step, setStep] = useState<Step>(1);
+  const [fetching, setFetching] = useState(false);
+  const [preview, setPreview] = useState<SyncPreviewResponse | null>(null);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [syncing, setSyncing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<{ inserted: number; updated: number } | null>(null);
+  const [search, setSearch] = useState("");
+  const [filter, setFilter] = useState<RowFilter>("all");
+
+  const fetchControllerRef = useRef<AbortController | null>(null);
+  const syncControllerRef = useRef<AbortController | null>(null);
+  useEffect(() => () => {
+    fetchControllerRef.current?.abort();
+    syncControllerRef.current?.abort();
+  }, []);
+
+  const handleFetch = async () => {
+    if (preview != null && selected.size > 0) {
+      if (!window.confirm("Re-fetching will reset your current selection. Continue?")) return;
+    }
+    setFetching(true);
+    setError(null);
+    setPreview(null);
+
+    const controller = new AbortController();
+    fetchControllerRef.current = controller;
+    let timedOut = false;
+    const timer = setTimeout(() => { timedOut = true; controller.abort(); }, 30_000);
+    try {
+      const res = await fetch("/api/mycase/sync?mode=preview", {
+        method: "POST",
+        signal: controller.signal,
+      });
+      let json: Record<string, unknown> = {};
+      try { json = await res.json(); } catch { /* non-JSON body */ }
+      if (!res.ok)
+        throw new Error((json.error as string) || `Fetch failed (${res.status})`);
+      const data = json as unknown as SyncPreviewResponse;
+      setPreview(data);
+      setSelected(
+        new Set(
+          data.rows.source
+            .filter((r) => r.status === "new" || r.status === "changed")
+            .map((r) => r.clientId),
+        ),
+      );
+    } catch (e) {
+      const err = e as Error;
+      if (err.name === "AbortError") {
+        if (timedOut) setError("Fetch timed out — please try again.");
+      } else {
+        setError(err.message);
+      }
+    } finally {
+      clearTimeout(timer);
+      setFetching(false);
+    }
+  };
+
+  const newRows = useMemo(() => preview?.rows.source.filter((r) => r.status === "new") ?? [], [preview]);
+  const changedRows = useMemo(() => preview?.rows.source.filter((r) => r.status === "changed") ?? [], [preview]);
+  const unchangedRows = useMemo(() => preview?.rows.source.filter((r) => r.status === "unchanged") ?? [], [preview]);
+
+  const allRows = useMemo(() => {
+    if (!preview) return [];
+    return [
+      ...preview.rows.source,
+      ...preview.rows.missing,
+    ];
+  }, [preview]);
+
+  const filteredRows = useMemo(() => {
+    let r = allRows;
+    if (filter !== "all") r = r.filter((x) => x.status === filter);
+    if (search) {
+      const q = search.toLowerCase();
+      r = r.filter(
+        (x) =>
+          x.caseName.toLowerCase().includes(q) ||
+          String(x.clientId).includes(q) ||
+          ("assignedTo" in x ? (x.assignedTo ?? "").toLowerCase().includes(q) : false),
+      );
+    }
+    return r;
+  }, [allRows, filter, search]);
+
+  const runSync = async () => {
+    if (!preview) return;
+    const controller = new AbortController();
+    syncControllerRef.current = controller;
+    setSyncing(true);
+    setError(null);
+    let syncResult: { inserted: number; updated: number } | null = null;
+    try {
+      const res = await fetch("/api/mycase/sync?mode=upsert", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ selectedClientIds: [...selected] }),
+        signal: controller.signal,
+      });
+      let json: Record<string, unknown> = {};
+      try { json = await res.json(); } catch { /* non-JSON body */ }
+      if (!res.ok)
+        throw new Error((json.error as string) || `Sync failed (${res.status})`);
+      syncResult = { inserted: json.inserted as number, updated: json.updated as number };
+    } catch (e) {
+      const err = e as Error;
+      if (err.name !== "AbortError") setError(err.message);
+    } finally {
+      setSyncing(false);
+    }
+    if (syncResult) {
+      setResult(syncResult);
+      try { await onSynced(); } catch { /* refresh failed; sync succeeded */ }
+    }
+  };
+
+  const canAdvanceFromStep = (s: Step): boolean => {
+    if (s === 1) return !!preview;
+    if (s === 2) return !!preview;
+    if (s === 3) return !!preview;
+    if (s === 4) return selected.size > 0;
+    return false;
+  };
+
+  const lblCls = `text-[10px] font-semibold uppercase tracking-wider ${t.textMuted}`;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center" onClick={onClose}>
+      <div className="absolute inset-0 bg-black/50" />
+      <div
+        className={`relative w-full max-w-5xl max-h-[92vh] overflow-hidden flex flex-col rounded-xl border ${t.card} mx-4`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className={`flex items-center justify-between px-5 py-3 border-b ${t.borderLight}`}>
+          <div className="flex items-center gap-2">
+            <Database
+              className={`h-4 w-4 ${dark ? "text-indigo-400" : "text-indigo-600"}`}
+              aria-hidden="true"
+            />
+            <h3 className={`text-sm font-bold ${t.text}`}>MyCase Sync</h3>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className={`h-7 w-7 rounded-md flex items-center justify-center ${t.hover} ${t.textSub}`}
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+
+        {/* Stepper */}
+        <div className={`grid grid-cols-4 gap-1 p-1 ${dark ? "bg-neutral-900/50" : "bg-neutral-50"}`}>
+          {STEPS.map((s) => {
+            const active = s.n === step;
+            const completed = s.n < step;
+            return (
+              <button
+                key={s.n}
+                onClick={() => { if (s.n <= step || canAdvanceFromStep(step)) setStep(s.n); }}
+                className={`text-left px-3 py-2 rounded-md transition-colors ${
+                  active
+                    ? dark ? "bg-neutral-100 text-neutral-900" : "bg-neutral-900 text-white"
+                    : completed
+                      ? dark ? "text-neutral-200 hover:bg-neutral-800" : "text-neutral-700 hover:bg-neutral-200"
+                      : dark ? "text-neutral-500" : "text-neutral-400"
+                }`}
+              >
+                <div className="text-[10px] font-bold uppercase tracking-wider">{s.title}</div>
+                <div className="text-[12px] font-medium">{s.subtitle}</div>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto p-5">
+          {error && (step === 1 || step === 4) && (
+            <div
+              role="alert"
+              className={`mb-4 rounded-md border p-3 text-xs flex items-start justify-between gap-3 ${dark ? "bg-red-900/20 border-red-800 text-red-300" : "bg-red-50 border-red-200 text-red-700"}`}
+            >
+              <span>{error}</span>
+              <button onClick={step === 1 ? handleFetch : runSync} className="shrink-0 underline font-semibold">
+                Retry
+              </button>
+            </div>
+          )}
+
+          {/* STEP 1: Fetch */}
+          {step === 1 && (
+            <div>
+              <div className="flex items-center gap-2 mb-1">
+                <CloudDownload className={`h-4 w-4 ${t.textSub}`} aria-hidden="true" />
+                <h4 className={`text-sm font-semibold ${t.text}`}>Fetch from MyCase</h4>
+              </div>
+              <p className={`text-[11px] ${t.textMuted} mb-6`}>
+                Queries the MyCase mirror database for all cases with an approval date and compares
+                them against the fee collections database.
+              </p>
+
+              {!preview && !fetching && (
+                <div className={`rounded-lg border-2 border-dashed p-12 text-center ${dark ? "border-neutral-700" : "border-neutral-300"}`}>
+                  <Database className={`h-10 w-10 mx-auto mb-3 ${t.textMuted}`} aria-hidden="true" />
+                  <p className={`text-sm font-semibold ${t.text} mb-1`}>Ready to sync</p>
+                  <p className={`text-[11px] ${t.textMuted} mb-5`}>
+                    Click the button below to pull the latest data from the MyCase mirror database
+                  </p>
+                  <button
+                    onClick={handleFetch}
+                    className={`h-9 px-5 rounded-lg text-xs font-semibold flex items-center gap-2 mx-auto ${t.ctaBtn} transition-colors`}
+                  >
+                    <CloudDownload className="h-3.5 w-3.5" aria-hidden="true" />
+                    Fetch from MyCase
+                  </button>
+                </div>
+              )}
+
+              {fetching && (
+                <div className="flex items-center justify-center py-16">
+                  <RefreshCw className={`h-5 w-5 animate-spin ${t.textMuted}`} aria-hidden="true" />
+                  <span className={`ml-2 text-sm ${t.textSub}`}>Fetching from MyCase…</span>
+                </div>
+              )}
+
+              {preview && !fetching && (
+                <div className="space-y-4">
+                  <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-3">
+                    <Stat t={t} label="Rows fetched" value={preview.summary.fetched.toLocaleString()} />
+                    <Stat
+                      t={t}
+                      label="New cases"
+                      value={preview.summary.new.toLocaleString()}
+                      accent={dark ? "text-emerald-400" : "text-emerald-600"}
+                    />
+                    <Stat
+                      t={t}
+                      label="Changed"
+                      value={preview.summary.changed.toLocaleString()}
+                      accent={preview.summary.changed > 0 ? (dark ? "text-blue-400" : "text-blue-600") : undefined}
+                    />
+                    <Stat t={t} label="Up to date" value={preview.summary.unchanged.toLocaleString()} />
+                    <Stat
+                      t={t}
+                      label="Missing"
+                      value={preview.summary.missing.toLocaleString()}
+                      accent={preview.summary.missing > 0 ? (dark ? "text-amber-400" : "text-amber-600") : undefined}
+                    />
+                  </div>
+                  {preview.summary.warnings.length > 0 && (
+                    <div className={`rounded-md border p-3 text-[11px] ${dark ? "bg-amber-900/20 border-amber-800 text-amber-300" : "bg-amber-50 border-amber-200 text-amber-800"}`}>
+                      <div className="flex items-center gap-1.5 font-semibold mb-1">
+                        <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
+                        {preview.summary.warnings.length} warning{preview.summary.warnings.length === 1 ? "" : "s"}
+                      </div>
+                      <ul className="space-y-0.5 max-h-36 overflow-y-auto">
+                        {preview.summary.warnings.slice(0, 25).map((w, i) => (
+                          <li key={i}>Row {w.row}: {w.message}</li>
+                        ))}
+                      </ul>
+                      {preview.summary.warnings.length > 25 && (
+                        <p className="mt-1 opacity-70">…and {preview.summary.warnings.length - 25} more</p>
+                      )}
+                    </div>
+                  )}
+                  <button
+                    onClick={handleFetch}
+                    className={`h-8 px-3 rounded-md border text-xs font-medium flex items-center gap-1.5 ${t.outlineBtn} transition-colors`}
+                  >
+                    <RefreshCw className="h-3 w-3" aria-hidden="true" />
+                    Re-fetch
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* STEP 2: Field Map */}
+          {step === 2 && (
+            <div>
+              <h4 className={`text-sm font-semibold ${t.text} mb-1`}>Field Map</h4>
+              <p className={`text-[11px] ${t.textMuted} mb-4`}>
+                How MyCase custom fields map to the fee collections database. All mappings are
+                automatic — no action needed.
+              </p>
+              <div className={`rounded-lg border ${t.borderLight} overflow-hidden`}>
+                <table className="w-full text-[12px]">
+                  <thead>
+                    <tr className={`border-b ${t.borderLight} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"}`}>
+                      <th className={`${lblCls} text-left px-3 py-2`}>MyCase field</th>
+                      <th className={`${lblCls} text-left px-3 py-2`}>Maps to</th>
+                      <th className={`${lblCls} text-center px-3 py-2 w-24`}>Required</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {FIELD_MAP.map((m) => (
+                      <tr key={m.source} className={`border-b ${t.borderLight}`}>
+                        <td className={`${t.text} px-3 py-2 font-medium font-mono text-[11px]`}>{m.source}</td>
+                        <td className={`${t.textSub} px-3 py-2 font-mono text-[11px]`}>{m.db}</td>
+                        <td className="px-3 py-2 text-center">
+                          {m.required ? (
+                            <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${dark ? "bg-red-900/40 text-red-400" : "bg-red-50 text-red-600"}`}>
+                              REQUIRED
+                            </span>
+                          ) : (
+                            <span className={`text-[10px] ${t.textMuted}`}>optional</span>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          {/* STEP 3: Compare & Preview */}
+          {step === 3 && preview && (
+            <div>
+              <h4 className={`text-sm font-semibold ${t.text} mb-1`}>Compare & Preview</h4>
+              <p className={`text-[11px] ${t.textMuted} mb-4`}>
+                Categories based on how each record compares between MyCase and the fee collections database.
+              </p>
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-5">
+                <Stat t={t} label="New" value={preview.summary.new.toLocaleString()} accent={dark ? "text-emerald-400" : "text-emerald-600"} />
+                <Stat t={t} label="Changed" value={preview.summary.changed.toLocaleString()} accent={preview.summary.changed > 0 ? (dark ? "text-blue-400" : "text-blue-600") : undefined} />
+                <Stat t={t} label="Up to date" value={preview.summary.unchanged.toLocaleString()} />
+                <Stat t={t} label="Missing" value={preview.summary.missing.toLocaleString()} accent={preview.summary.missing > 0 ? (dark ? "text-amber-400" : "text-amber-600") : undefined} />
+              </div>
+              <div className="space-y-5">
+                <CategorySection status="new" count={preview.summary.new} description="In MyCase · not yet in database — will be inserted on sync" dark={dark} t={t}>
+                  <SourceRowsTable t={t} dark={dark} rows={newRows.slice(0, 100)} truncated={newRows.length > 100} total={newRows.length} />
+                </CategorySection>
+                <CategorySection status="changed" count={preview.summary.changed} description="In MyCase · already in database · values have changed — will be updated on sync" dark={dark} t={t}>
+                  <SourceRowsTable t={t} dark={dark} rows={changedRows.slice(0, 100)} truncated={changedRows.length > 100} total={changedRows.length} showChangedFields />
+                </CategorySection>
+                <CategorySection status="unchanged" count={preview.summary.unchanged} description="In MyCase · already in database · no changes detected — skipped by default" dark={dark} t={t}>
+                  <SourceRowsTable t={t} dark={dark} rows={unchangedRows.slice(0, 100)} truncated={unchangedRows.length > 100} total={unchangedRows.length} />
+                </CategorySection>
+                <CategorySection status="missing" count={preview.summary.missing} description="In fee collections database · not found in MyCase with an approval date" dark={dark} t={t}>
+                  <MissingRowsTable t={t} dark={dark} rows={preview.rows.missing} />
+                </CategorySection>
+              </div>
+            </div>
+          )}
+
+          {/* STEP 4: Select & Sync */}
+          {step === 4 && preview && !result && (
+            <div>
+              <div className="flex items-center justify-between mb-2">
+                <div>
+                  <h4 className={`text-sm font-semibold ${t.text}`}>Select & Sync</h4>
+                  <p className={`text-[11px] ${t.textMuted}`}>
+                    Choose which rows to import. New cases are inserted; existing cases are updated.
+                  </p>
+                </div>
+                <div className={`text-[11px] ${t.textSub}`}>
+                  <span className={`font-bold ${t.text}`}>{selected.size.toLocaleString()}</span>
+                  {" "}/ {preview.rows.source.length.toLocaleString()} syncable selected
+                </div>
+              </div>
+
+              <div className="flex items-center gap-2 mb-3 flex-wrap">
+                <input
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder="Search name, id, agent…"
+                  className={`h-8 px-3 rounded-md border text-xs outline-none flex-1 min-w-40 ${t.inputBg}`}
+                />
+                <select
+                  value={filter}
+                  onChange={(e) => setFilter(e.target.value as typeof filter)}
+                  className={`h-8 px-2 rounded-md border text-xs outline-none cursor-pointer ${t.inputBg}`}
+                >
+                  <option value="all">All rows</option>
+                  <option value="new">New only</option>
+                  <option value="changed">Changed only</option>
+                  <option value="unchanged">Up to date only</option>
+                  <option value="missing">Missing only</option>
+                </select>
+                <button
+                  onClick={() =>
+                    setSelected(new Set([
+                      ...selected,
+                      ...filteredRows.filter((r) => r.status !== "missing").map((r) => r.clientId),
+                    ]))
+                  }
+                  className={`h-8 px-3 rounded-md border text-xs font-medium ${t.outlineBtn} transition-colors`}
+                >
+                  Select shown
+                </button>
+                <button
+                  onClick={() => {
+                    const next = new Set(selected);
+                    filteredRows.filter((r) => r.status !== "missing").forEach((r) => next.delete(r.clientId));
+                    setSelected(next);
+                  }}
+                  className={`h-8 px-3 rounded-md border text-xs font-medium ${t.outlineBtn} transition-colors`}
+                >
+                  Deselect shown
+                </button>
+              </div>
+
+              <SelectionTable
+                t={t}
+                dark={dark}
+                rows={filteredRows}
+                selected={selected}
+                onToggle={(id) => {
+                  const row = allRows.find((r) => r.clientId === id);
+                  if (!row || row.status === "missing") return;
+                  const next = new Set(selected);
+                  if (next.has(id)) next.delete(id); else next.add(id);
+                  setSelected(next);
+                }}
+              />
+            </div>
+          )}
+
+          {/* STEP 4: result */}
+          {step === 4 && result && (
+            <div className="py-12">
+              <div className={`max-w-md mx-auto rounded-lg border p-5 ${dark ? "bg-emerald-900/20 border-emerald-800 text-emerald-300" : "bg-emerald-50 border-emerald-200 text-emerald-800"}`}>
+                <div className="flex items-start gap-3">
+                  <CheckCircle2 className="h-5 w-5 mt-0.5 shrink-0" aria-hidden="true" />
+                  <div className="text-[13px]">
+                    <p className="font-bold">Sync complete.</p>
+                    <p className="opacity-90 mt-1">
+                      <span className="font-semibold">{result.inserted.toLocaleString()}</span> new
+                      case{result.inserted === 1 ? "" : "s"} inserted ·{" "}
+                      <span className="font-semibold">{result.updated.toLocaleString()}</span>{" "}
+                      existing record{result.updated === 1 ? "" : "s"} updated.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className={`flex items-center justify-between px-5 py-3 border-t ${t.borderLight}`}>
+          <button
+            onClick={() => { if (step === 1) onClose(); else setStep((step - 1) as Step); }}
+            className={`h-8 px-3 text-xs font-medium ${t.textSub} hover:underline flex items-center gap-1`}
+          >
+            <ArrowLeft className="h-3 w-3" aria-hidden="true" />
+            {step === 1 ? "Cancel" : "Back"}
+          </button>
+
+          {step < 4 ? (
+            <button
+              onClick={() => canAdvanceFromStep(step) && setStep((step + 1) as Step)}
+              disabled={!canAdvanceFromStep(step)}
+              className={`h-8 px-4 rounded-md text-xs font-semibold flex items-center gap-1.5 ${t.ctaBtn} transition-colors disabled:opacity-50`}
+            >
+              Next: {STEPS[step].subtitle}
+              <ArrowRight className="h-3 w-3" aria-hidden="true" />
+            </button>
+          ) : !result ? (
+            <button
+              onClick={runSync}
+              disabled={syncing || selected.size === 0}
+              className={`h-8 px-4 rounded-md text-xs font-semibold flex items-center gap-1.5 ${t.ctaBtn} transition-colors disabled:opacity-50`}
+            >
+              {syncing ? (
+                <RefreshCw className="h-3 w-3 animate-spin" aria-hidden="true" />
+              ) : (
+                <Database className="h-3 w-3" aria-hidden="true" />
+              )}
+              {syncing ? "Syncing…" : `Sync Selected (${selected.size.toLocaleString()})`}
+            </button>
+          ) : (
+            <button onClick={onClose} className={`h-8 px-4 rounded-md text-xs font-semibold ${t.ctaBtn} transition-colors`}>
+              Done
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const Stat = ({
+  t,
+  label,
+  value,
+  accent,
+}: {
+  t: ReturnType<typeof themeClasses>;
+  label: string;
+  value: string;
+  accent?: string;
+}) => (
+  <div className={`rounded-lg border ${t.borderLight} p-3`}>
+    <p className={`text-[10px] font-semibold uppercase tracking-wider ${t.textMuted}`}>{label}</p>
+    <p className={`text-[18px] font-bold mt-0.5 tabular-nums ${accent ?? t.text}`}>{value}</p>
+  </div>
+);
+
+const CategorySection = ({
+  status,
+  count,
+  description,
+  dark,
+  t,
+  children,
+}: {
+  status: "new" | "changed" | "unchanged" | "missing";
+  count: number;
+  description: string;
+  dark: boolean;
+  t: ReturnType<typeof themeClasses>;
+  children: React.ReactNode;
+}) => (
+  <div>
+    <div className="flex items-center gap-2 mb-2">
+      <span className={`text-[10px] font-semibold px-2 py-0.5 rounded ${STATUS_BADGE[status](dark)}`}>
+        {STATUS_LABEL[status]}
+      </span>
+      <span className={`text-[11px] font-semibold tabular-nums ${t.text}`}>{count.toLocaleString()}</span>
+      <span className={`text-[11px] ${t.textMuted}`}>{description}</span>
+    </div>
+    {count === 0 ? (
+      <div className={`rounded-lg border ${t.borderLight} px-3 py-4 text-center text-[11px] ${t.textMuted}`}>None</div>
+    ) : (
+      children
+    )}
+  </div>
+);
+
+const SourceRowsTable = ({
+  t,
+  dark,
+  rows,
+  truncated,
+  total,
+  showChangedFields,
+}: {
+  t: ReturnType<typeof themeClasses>;
+  dark: boolean;
+  rows: SourceRow[];
+  truncated: boolean;
+  total: number;
+  showChangedFields?: boolean;
+}) => (
+  <div className={`rounded-lg border ${t.borderLight} overflow-hidden`}>
+    <div className="overflow-x-auto">
+      <table className="w-full text-[12px]">
+        <thead>
+          <tr className={`border-b ${t.borderLight} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"}`}>
+            <Th>Case</Th>
+            {showChangedFields && <Th>Changed (MyCase → db)</Th>}
+            <Th>Approved</Th>
+            <Th>Assigned</Th>
+            <Th>Win Sheet Status</Th>
+            <Th alignRight>Expected</Th>
+            <Th>Notes</Th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.clientId} className={`border-b ${t.borderLight}`}>
+              <td className={`${t.text} px-3 py-1.5 font-medium max-w-72 truncate`} title={r.caseLink}>
+                {r.caseName}
+                {r.externalUrl && (
+                  <a
+                    href={r.externalUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    onClick={(e) => e.stopPropagation()}
+                    className={`ml-1 inline-flex ${t.textMuted} hover:${t.text}`}
+                  >
+                    <ExternalLink className="h-3 w-3 inline" aria-hidden="true" />
+                  </a>
+                )}
+              </td>
+              {showChangedFields && (
+                <td className="px-3 py-1.5 max-w-64">
+                  <div className={`text-[10px] font-mono space-y-0.5 ${dark ? "text-blue-300" : "text-blue-700"}`}>
+                    {r.changedFields.slice(0, 3).map((f) => (
+                      <div key={f.field} className="leading-tight">
+                        <span className="font-semibold">{f.field}</span>
+                        <span className={`ml-1 ${dark ? "text-neutral-400" : "text-neutral-500"}`}>
+                          {f.mycase || "∅"} → {f.db || "∅"}
+                        </span>
+                      </div>
+                    ))}
+                    {r.changedFields.length > 3 && (
+                      <div className={`${dark ? "text-neutral-500" : "text-neutral-400"}`}>
+                        +{r.changedFields.length - 3} more
+                      </div>
+                    )}
+                  </div>
+                </td>
+              )}
+              <td className={`${t.textSub} px-3 py-1.5 tabular-nums`}>{fmtDate(r.approvalDate)}</td>
+              <td className={`${t.textSub} px-3 py-1.5`}>{r.assignedTo ?? "—"}</td>
+              <td className="px-3 py-1.5">
+                <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${STATUS_PILL[r.winSheetStatus] ?? STATUS_PILL.not_started}`}>
+                  {r.winSheetStatus.replace(/_/g, " ")}
+                </span>
+              </td>
+              <td className={`${t.text} px-3 py-1.5 text-right tabular-nums font-medium`}>
+                {r.totalExpected > 0 ? fmtFull(r.totalExpected) : "—"}
+              </td>
+              <td className="px-3 py-1.5 text-center">
+                {r.hasNotes ? (
+                  <span className={`text-[10px] font-semibold ${dark ? "text-blue-400" : "text-blue-600"}`}>YES</span>
+                ) : (
+                  <span className={`text-[10px] ${t.textMuted}`}>—</span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+    {truncated && (
+      <div className={`text-[11px] px-3 py-2 ${t.textMuted} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"} border-t ${t.borderLight}`}>
+        Showing first 100 of {total.toLocaleString()} rows.
+      </div>
+    )}
+  </div>
+);
+
+const MissingRowsTable = ({
+  t,
+  dark,
+  rows,
+}: {
+  t: ReturnType<typeof themeClasses>;
+  dark: boolean;
+  rows: MissingRow[];
+}) => (
+  <div className={`rounded-lg border ${t.borderLight} overflow-hidden`}>
+    <div className="overflow-x-auto">
+      <table className="w-full text-[12px]">
+        <thead>
+          <tr className={`border-b ${t.borderLight} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"}`}>
+            <Th>Case</Th>
+            <Th>Approved</Th>
+            <Th>Case Link</Th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.clientId} className={`border-b ${t.borderLight}`}>
+              <td className={`${t.text} px-3 py-1.5 font-medium`}>{r.caseName}</td>
+              <td className={`${t.textSub} px-3 py-1.5 tabular-nums`}>{fmtDate(r.approvalDate)}</td>
+              <td className={`${t.textMuted} px-3 py-1.5 text-[11px] max-w-80 truncate`} title={r.caseLink}>
+                {r.caseLink || "—"}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  </div>
+);
+
+const SelectionTable = ({
+  t,
+  dark,
+  rows,
+  selected,
+  onToggle,
+}: {
+  t: ReturnType<typeof themeClasses>;
+  dark: boolean;
+  rows: (SourceRow | MissingRow)[];
+  selected: Set<number>;
+  onToggle: (id: number) => void;
+}) => (
+  <div className={`rounded-lg border ${t.borderLight} overflow-hidden`}>
+    <div className="overflow-x-auto">
+      <table className="w-full text-[12px]">
+        <thead>
+          <tr className={`border-b ${t.borderLight} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"} sticky top-0`}>
+            <Th>{""}</Th>
+            <Th>Case</Th>
+            <Th>Status</Th>
+            <Th>Approved</Th>
+            <Th>Assigned</Th>
+            <Th>Win Sheet Status</Th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => {
+            const isMissing = r.status === "missing";
+            const checked = selected.has(r.clientId);
+            return (
+              <tr
+                key={r.clientId}
+                onClick={() => !isMissing && onToggle(r.clientId)}
+                className={`border-b ${t.borderLight} ${isMissing ? "cursor-not-allowed opacity-60" : "cursor-pointer"} ${dark ? "hover:bg-neutral-800/40" : "hover:bg-neutral-50"}`}
+              >
+                <td className="px-3 py-1.5">
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    disabled={isMissing}
+                    onChange={() => onToggle(r.clientId)}
+                    onClick={(e) => e.stopPropagation()}
+                    className="h-3.5 w-3.5 cursor-pointer disabled:cursor-not-allowed"
+                  />
+                </td>
+                <td className={`${t.text} px-3 py-1.5 font-medium max-w-80 truncate`} title={r.caseLink}>
+                  {r.caseName}
+                </td>
+                <td className="px-3 py-1.5">
+                  <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${STATUS_BADGE[r.status](dark)}`}>
+                    {STATUS_LABEL[r.status]}
+                  </span>
+                </td>
+                <td className={`${t.textSub} px-3 py-1.5 tabular-nums`}>{fmtDate(r.approvalDate)}</td>
+                <td className={`${t.textSub} px-3 py-1.5`}>
+                  {"assignedTo" in r ? (r.assignedTo ?? "—") : "—"}
+                </td>
+                <td className="px-3 py-1.5">
+                  {"winSheetStatus" in r ? (
+                    <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${STATUS_PILL[r.winSheetStatus] ?? STATUS_PILL.not_started}`}>
+                      {r.winSheetStatus.replace(/_/g, " ")}
+                    </span>
+                  ) : (
+                    <span className={`text-[10px] ${t.textMuted}`}>—</span>
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  </div>
+);
+
+const Th = ({ children, alignRight }: { children: React.ReactNode; alignRight?: boolean }) => (
+  <th className={`text-[10px] font-semibold uppercase tracking-wider px-3 py-2 ${alignRight ? "text-right" : "text-left"}`}>
+    {children}
+  </th>
+);

--- a/src/components/modals/SheetSyncModal.tsx
+++ b/src/components/modals/SheetSyncModal.tsx
@@ -40,6 +40,11 @@ interface DbOnlyRow {
   status: "fees_closed" | "missing";
 }
 
+interface NeedsLinkRow {
+  row: number;
+  caseLink: string;
+}
+
 type Step4Filter = "all" | "new" | "changed" | "unchanged" | "fees_closed" | "missing";
 
 type Step4PreviewRow =
@@ -56,12 +61,14 @@ interface SyncPreviewResponse {
     feesClosed: number;
     missing: number;
     synthetic: number;
+    needsLink: number;
     warnings: { row: number; message: string }[];
   };
   rows: {
     sheet: SheetPreviewRow[];
     feesClosed: DbOnlyRow[];
     missing: DbOnlyRow[];
+    needsLink: NeedsLinkRow[];
   };
 }
 
@@ -205,6 +212,10 @@ export default function SheetSyncModal({
   );
   const syntheticRows = useMemo(
     () => preview?.rows.sheet.filter((r) => r.isSynthetic) ?? [],
+    [preview],
+  );
+  const needsLinkRows = useMemo(
+    () => preview?.rows.needsLink ?? [],
     [preview],
   );
 
@@ -456,10 +467,10 @@ export default function SheetSyncModal({
                     />
                     <Stat
                       t={t}
-                      label="No URL"
-                      value={preview.summary.synthetic.toLocaleString()}
+                      label="Needs Link"
+                      value={preview.summary.needsLink.toLocaleString()}
                       accent={
-                        preview.summary.synthetic > 0
+                        preview.summary.needsLink > 0
                           ? dark ? "text-red-400" : "text-red-600"
                           : undefined
                       }
@@ -479,6 +490,23 @@ export default function SheetSyncModal({
                       </ul>
                       {preview.summary.warnings.length > 25 && (
                         <p className="mt-1 opacity-70">…and {preview.summary.warnings.length - 25} more</p>
+                      )}
+                    </div>
+                  )}
+                  {needsLinkRows.length > 0 && (
+                    <div className={`rounded-md border p-3 text-[11px] ${dark ? "bg-red-900/20 border-red-800 text-red-300" : "bg-red-50 border-red-200 text-red-800"}`}>
+                      <div className="flex items-center gap-1.5 font-semibold mb-1">
+                        <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
+                        {needsLinkRows.length} row{needsLinkRows.length === 1 ? "" : "s"} {needsLinkRows.length === 1 ? "has" : "have"} no MyCase link — skipped
+                      </div>
+                      <p className="opacity-80 mb-2">These rows will not be synced until a valid MyCase URL is added to the sheet.</p>
+                      <ul className="space-y-0.5 max-h-36 overflow-y-auto">
+                        {needsLinkRows.slice(0, 25).map((r, i) => (
+                          <li key={i}>Row {r.row}: {r.caseLink}</li>
+                        ))}
+                      </ul>
+                      {needsLinkRows.length > 25 && (
+                        <p className="mt-1 opacity-70">…and {needsLinkRows.length - 25} more</p>
                       )}
                     </div>
                   )}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -776,3 +776,13 @@ export const activityLogRelations = relations(activityLog, ({ one }) => ({
     references: [feeRecords.id],
   }),
 }));
+
+// ============================================================================
+// MyCase sync tags — tracks cases that have been reviewed but not synced
+// ============================================================================
+export const myCaseSyncTags = pgTable("mycase_sync_tags", {
+  myCaseCaseId: integer("mycase_case_id").primaryKey(),
+  tag: varchar("tag", { length: 50 }).notNull().default("viewed"),
+  taggedAt: timestamp("tagged_at", { withTimezone: true }).notNull().defaultNow(),
+  taggedBy: varchar("tagged_by", { length: 255 }),
+});

--- a/src/lib/import/__tests__/sheets-mapper.test.ts
+++ b/src/lib/import/__tests__/sheets-mapper.test.ts
@@ -168,20 +168,20 @@ describe("CASE LINK name parsing", () => {
 // ─── Synthetic ID assignment ──────────────────────────────────────────────────
 
 describe("synthetic ID", () => {
-  it("emits warning when CASE LINK_url is absent", () => {
-    const ws = warnings([row({ "CASE LINK_url": null })]);
-    const w = ws.find((w) => w.message.includes("No valid MyCase URL"));
-    expect(w).toBeDefined();
+  it("adds to needsLink when CASE LINK_url is absent", () => {
+    const { needsLink } = mapSheetRows([row({ "CASE LINK_url": null })]);
+    expect(needsLink).toHaveLength(1);
+    expect(needsLink[0].row).toBe(2);
   });
 
-  it("emits warning when URL does not contain a mycase.com court_cases path", () => {
-    const ws = warnings([row({ "CASE LINK_url": "https://example.com/case/99" })]);
-    expect(ws.some((w) => w.message.includes("No valid MyCase URL"))).toBe(true);
+  it("adds to needsLink when URL does not contain a mycase.com court_cases path", () => {
+    const { needsLink } = mapSheetRows([row({ "CASE LINK_url": "https://example.com/case/99" })]);
+    expect(needsLink).toHaveLength(1);
   });
 
-  it("assigns a clientId >= SYNTHETIC_ID_BASE when no URL", () => {
-    const [r] = parsed([row({ "CASE LINK_url": null })]);
-    expect(r.clientId).toBeGreaterThanOrEqual(SYNTHETIC_ID_BASE);
+  it("does not include no-URL rows in parsed output", () => {
+    const { rows } = mapSheetRows([row({ "CASE LINK_url": null })]);
+    expect(rows).toHaveLength(0);
   });
 
   it("emits duplicate-ID warning and assigns synthetic for second row with same MyCase id", () => {
@@ -236,33 +236,30 @@ describe("monetary amounts", () => {
 
 describe("warning row numbers", () => {
   it("row number is 1-indexed with header offset (first data row = row 2)", () => {
-    const ws = warnings([row({ "CASE LINK_url": null })]);
-    expect(ws[0].row).toBe(2);
+    const { needsLink } = mapSheetRows([row({ "CASE LINK_url": null })]);
+    expect(needsLink[0].row).toBe(2);
   });
 
   it("row number increments correctly for later rows", () => {
-    const ws = warnings([
+    const { needsLink } = mapSheetRows([
       row(),
       row({ "CASE LINK_url": null, "CASE LINK": "2024.02.01 Jones, Mary v. ALJ Smith" }),
     ]);
-    const w = ws.find((w) => w.message.includes("No valid MyCase URL"));
-    expect(w!.row).toBe(3);
+    expect(needsLink[0].row).toBe(3);
   });
 });
 
 // ─── Multiple issues in one row ───────────────────────────────────────────────
 
 describe("multiple malformed fields", () => {
-  it("collects all warnings for a single bad row", () => {
+  it("collects all warnings for a single bad row (with valid URL)", () => {
     const ws = warnings([
       row({
-        "CASE LINK_url": null,
         "APPROVAL DATE": "March 15 2024",
         "CLAIM TYPE": "UNKNOWN_TYPE",
         "CASE LINK": "2024.01.15 SmithJohn v. ALJ Doe",
       }),
     ]);
-    expect(ws.some((w) => w.message.includes("No valid MyCase URL"))).toBe(true);
     expect(ws.some((w) => w.message.includes("Approval date"))).toBe(true);
     expect(ws.some((w) => w.message.includes("Unrecognized claim type"))).toBe(true);
     expect(ws.some((w) => w.message.includes("Could not parse name"))).toBe(true);

--- a/src/lib/import/mycase-mapper.ts
+++ b/src/lib/import/mycase-mapper.ts
@@ -10,6 +10,7 @@ export type MyCaseDbRow = {
   custom_fields_named: Record<string, unknown> | null;
   client_first_name: string | null;
   client_last_name: string | null;
+  case_number: string | null;
 };
 
 const cf = (row: MyCaseDbRow, key: string): string | null => {

--- a/src/lib/import/mycase-mapper.ts
+++ b/src/lib/import/mycase-mapper.ts
@@ -1,0 +1,238 @@
+import type { ParsedCaseRow } from "./xlsx-mapper";
+
+export type MyCaseDbRow = {
+  id: number | string; // postgres.js returns bigint columns as strings
+  name: string | null;
+  case_stage: string | null;
+  status: string | null;
+  opened_date: string | null;
+  closed_date: string | null;
+  custom_fields_named: Record<string, unknown> | null;
+  client_first_name: string | null;
+  client_last_name: string | null;
+};
+
+const cf = (row: MyCaseDbRow, key: string): string | null => {
+  const v = row.custom_fields_named?.[key];
+  if (v == null || v === "") return null;
+  return String(v).trim() || null;
+};
+
+const num = (v: string | null): string => {
+  if (!v) return "0";
+  const n = Number(String(v).replace(/[, $]/g, ""));
+  return Number.isFinite(n) ? String(n) : "0";
+};
+
+const dateOnly = (v: string | null): string | null => {
+  if (!v) return null;
+  const s = v.trim();
+  const iso = s.match(/^(\d{4})[-/.](\d{1,2})[-/.](\d{1,2})$/);
+  if (iso) {
+    const out = `${iso[1]}-${iso[2].padStart(2, "0")}-${iso[3].padStart(2, "0")}`;
+    return Number.isNaN(new Date(out).getTime()) ? null : out;
+  }
+  const mdy = s.match(/^(\d{1,2})\/(\d{1,2})\/(\d{2,4})$/);
+  if (mdy) {
+    const yy = mdy[3].length === 2 ? `20${mdy[3]}` : mdy[3];
+    const out = `${yy}-${mdy[1].padStart(2, "0")}-${mdy[2].padStart(2, "0")}`;
+    return Number.isNaN(new Date(out).getTime()) ? null : out;
+  }
+  return null;
+};
+
+const MYCASE_URL_RE = /mycase\.com\/court_cases\/(\d+)/i;
+
+const parseCaseLink = (name: string) => {
+  let s = name.trim();
+  s = s.replace(/^\d{4}[.\-/]\d{1,2}[.\-/]\d{1,2}\s+/, "");
+  const parts = s.split(/\s+vs?(?:[.,]\s*|\s+)/i);
+  const left = parts[0] || "";
+  const right = parts[1] || "";
+  const leftClean = left.replace(/\s*\([^)]*\)?$/, "").trim();
+  let lastRaw: string, firstRaw: string;
+  if (leftClean.includes(",")) {
+    [lastRaw, firstRaw] = leftClean.split(/,\s*/);
+  } else {
+    const tokens = leftClean.split(/\s+/);
+    lastRaw = tokens[0] ?? leftClean;
+    firstRaw = tokens.slice(1).join(" ");
+  }
+  const lastName = (lastRaw || leftClean).trim();
+  const firstName = (firstRaw || "").trim();
+  let aljFirstName: string | null = null;
+  let aljLastName: string | null = null;
+  const aljClean = right.replace(/^ALJ\s+/i, "").replace(/\s*\([^)]*\)?$/, "").trim();
+  if (aljClean && !/^SSA$/i.test(aljClean)) {
+    const tokens = aljClean.split(/\s+/);
+    if (tokens.length >= 2) {
+      aljFirstName = tokens[0];
+      aljLastName = tokens.slice(1).join(" ");
+    } else {
+      aljLastName = tokens[0] ?? null;
+    }
+  }
+  return { firstName, lastName, aljFirstName, aljLastName };
+};
+
+const mapClaimType = (raw: string | null) => {
+  const s = (raw ?? "").trim().toUpperCase();
+  if (!s) return { claimType: [] as string[], claimTypeLabel: null as "T2" | "T16" | "T2_T16" | null };
+  if (s.includes("CONC") || (s.includes("T2") && s.includes("T16")))
+    return { claimType: ["T2", "T16"], claimTypeLabel: "T2_T16" as const };
+  if (s.includes("T16") || s.includes("SSI"))
+    return { claimType: ["T16"], claimTypeLabel: "T16" as const };
+  if (s.includes("T2") || s.includes("SSDI"))
+    return { claimType: ["T2"], claimTypeLabel: "T2" as const };
+  return { claimType: [s], claimTypeLabel: null };
+};
+
+const mapLevelWon = (raw: string | null): ParsedCaseRow["levelWon"] => {
+  const s = (raw ?? "").trim().toUpperCase().replace(/\s+/g, "_");
+  if (s === "INITIAL") return "INITIAL";
+  if (s === "RECON" || s === "RECONSIDERATION") return "RECON";
+  if (s === "HEARING" || s === "ALJ" || s === "ALJ_HEARING") return "HEARING";
+  if (s === "AC" || s === "APPEALS_COUNCIL") return "AC";
+  if (s === "FEDERAL_COURT" || s === "FEDERAL") return "FEDERAL_COURT";
+  if (s === "FEE_PETITION" || s === "FEE_PET") return "FEE_PETITION";
+  return null;
+};
+
+const mapDecision = (raw: string | null): ParsedCaseRow["t2Decision"] => {
+  const s = (raw ?? "").trim().toLowerCase();
+  if (!s) return "unknown";
+  if (s.includes("partially favorable")) return "partially_favorable";
+  if (s.includes("favorable")) return "fully_favorable";
+  if (s.includes("unfavorable") || s.includes("denied") || s === "ufd") return "unfavorable";
+  if (s.includes("dismiss")) return "dismissed";
+  if (s.includes("remand")) return "remand";
+  return "unknown";
+};
+
+const mapWinSheetStatus = (row: MyCaseDbRow): ParsedCaseRow["winSheetStatus"] => {
+  const pif = (cf(row, "PAID IN FULL") ?? "").toLowerCase();
+  if (pif === "yes") return "paid_in_full";
+
+  const stage = (row.case_stage ?? "").toLowerCase();
+  if (stage.includes("fees paid") || stage.includes("fee paid")) return "paid_in_full";
+  if (stage.includes("pending fees") || stage.includes("fee due") || stage.includes("pending fee"))
+    return "pending_payment";
+  if (stage.includes("closed") || stage.includes("turndown") || stage.includes("withdraw"))
+    return "closed";
+
+  const t2Received = Number(cf(row, "T2 FEE PAID") ?? "0");
+  const t16Received = Number(cf(row, "T16 FEE PAID") ?? "0");
+  if (t2Received > 0 || t16Received > 0) return "partially_paid";
+
+  const approvalDate = dateOnly(cf(row, "APPROVAL DATE"));
+  if (approvalDate) return "in_progress";
+
+  return "not_started";
+};
+
+const computeApprovalCategory = (days: number | null): string | null => {
+  if (days == null) return null;
+  if (days > 60) return ">60";
+  if (days > 30) return "31-60";
+  return "0-30";
+};
+
+export const mapMyCaseRows = (
+  rows: MyCaseDbRow[],
+): { rows: ParsedCaseRow[]; warnings: { row: number; message: string }[] } => {
+  const out: ParsedCaseRow[] = [];
+  const warnings: { row: number; message: string }[] = [];
+
+  for (let i = 0; i < rows.length; i++) {
+    const r = rows[i];
+
+    const caseLink = r.name?.trim() ?? "";
+    if (!caseLink) {
+      warnings.push({ row: i + 1, message: `Row ${r.id}: no case name — skipped` });
+      continue;
+    }
+
+    const { firstName, lastName, aljFirstName, aljLastName } = parseCaseLink(caseLink);
+
+    const resolvedFirst = firstName || r.client_first_name?.trim() || "Unknown";
+    const resolvedLast = lastName || r.client_last_name?.trim() || "Unknown";
+
+    const approvalDate = dateOnly(cf(r, "APPROVAL DATE"));
+
+    const daysAfterApproval = approvalDate
+      ? Math.floor((Date.now() - new Date(approvalDate).getTime()) / (1000 * 60 * 60 * 24))
+      : null;
+
+    const ct = mapClaimType(cf(r, "CLAIM TYPE") ?? cf(r, "What TYPE of CLAIM?"));
+
+    const t2Retro = num(cf(r, "T2 RETRO"));
+    const t2FeeDue = num(cf(r, "T2 FEE DUE"));
+    const t2FeeReceived = num(cf(r, "T2 FEE PAID") ?? cf(r, "FEE RECEIVED"));
+    const t2Pending = String(Math.max(0, Number(t2FeeDue) - Number(t2FeeReceived)));
+
+    const t16Retro = num(cf(r, "T16 RETRO"));
+    const t16FeeDue = num(cf(r, "T16 FEE DUE"));
+    const t16FeeReceived = num(cf(r, "T16 FEE PAID"));
+    const t16Pending = String(Math.max(0, Number(t16FeeDue) - Number(t16FeeReceived)));
+
+    const chronicleLinkRaw = cf(r, "CHRONICLE LINK");
+    const chronicleMatch = chronicleLinkRaw?.match(/\/clients\/(\d+)/);
+    const externalId = chronicleMatch
+      ? chronicleLinkRaw
+      : `https://app.mycase.com/court_cases/${r.id}`;
+
+    out.push({
+      clientId: Number(r.id),
+      externalId: externalId ?? null,
+      caseLink,
+      firstName: resolvedFirst,
+      lastName: resolvedLast,
+      approvalDate,
+      levelWon: mapLevelWon(cf(r, "Level of Win") ?? cf(r, "STAGE PAID")),
+      claimType: ct.claimType,
+      claimTypeLabel: ct.claimTypeLabel,
+      aljFirstName,
+      aljLastName,
+
+      assignedTo: cf(r, "FEE ASSIGNMENT"),
+      winSheetStatus: mapWinSheetStatus(r),
+      winSheetLink: null,
+      winSheetLinkText: null,
+      caseStatus: r.case_stage ?? r.status ?? null,
+      feesConfirmation: cf(r, "FEES CONFIRMATION")?.slice(0, 50) ?? null,
+      dateAssignedToAgent: null,
+      approvedBy: null,
+
+      t16Retro,
+      t16FeeDue,
+      t16FeeReceived,
+      t16Pending,
+      t16FeeReceivedDate: dateOnly(cf(r, "DATE T16 FEE PAID")),
+
+      t2Retro,
+      t2FeeDue,
+      t2FeeReceived,
+      t2Pending,
+      t2FeeReceivedDate: dateOnly(cf(r, "DATE T2 FEE PAID") ?? cf(r, "T2 FEE REC'D DATE")),
+
+      auxRetro: "0",
+      auxFeeDue: "0",
+      auxFeeReceived: "0",
+      auxPending: "0",
+      auxFeeReceivedDate: null,
+
+      daysAfterApproval,
+      approvalCategory: computeApprovalCategory(daysAfterApproval),
+      feesStatus: null,
+      weekAssignedToAgent: null,
+      monthAssignedToAgent: null,
+
+      t2Decision: mapDecision(cf(r, "T2 DECISION")),
+      t16Decision: mapDecision(cf(r, "T16 DECISION")),
+
+      notes: cf(r, "COLLECTION NOTES"),
+    });
+  }
+
+  return { rows: out, warnings };
+};

--- a/src/lib/import/sheets-mapper.ts
+++ b/src/lib/import/sheets-mapper.ts
@@ -114,11 +114,14 @@ const mapWinSheetStatus = (raw: unknown): ParsedCaseRow["winSheetStatus"] => {
   return "started";
 };
 
+export type NeedsLinkRow = { row: number; caseLink: string };
+
 export const mapSheetRows = (
   rows: SheetRow[],
-): { rows: ParsedCaseRow[]; warnings: { row: number; message: string }[] } => {
+): { rows: ParsedCaseRow[]; warnings: { row: number; message: string }[]; needsLink: NeedsLinkRow[] } => {
   const out: ParsedCaseRow[] = [];
   const warnings: { row: number; message: string }[] = [];
+  const needsLink: NeedsLinkRow[] = [];
   const seenIds = new Set<number>();
   let synthetic = SYNTHETIC_ID_BASE;
 
@@ -131,23 +134,21 @@ export const mapSheetRows = (
     const myCaseMatch = url?.match(MYCASE_URL_RE);
     const myCaseId = myCaseMatch ? Number(myCaseMatch[1]) : null;
 
+    if (!myCaseId) {
+      needsLink.push({ row: i + 2, caseLink: linkText });
+      continue;
+    }
+
     let clientId: number;
-    if (myCaseId && !seenIds.has(myCaseId)) {
+    if (!seenIds.has(myCaseId)) {
       clientId = myCaseId;
     } else {
       while (seenIds.has(synthetic)) synthetic++;
       clientId = synthetic++;
-      if (myCaseId) {
-        warnings.push({
-          row: i + 2,
-          message: `Duplicate MyCase id ${myCaseId} — using synthetic ${clientId}`,
-        });
-      } else {
-        warnings.push({
-          row: i + 2,
-          message: "No valid MyCase URL — synthetic ID assigned; row will create a duplicate on every re-sync",
-        });
-      }
+      warnings.push({
+        row: i + 2,
+        message: `Duplicate MyCase id ${myCaseId} — using synthetic ${clientId}`,
+      });
     }
     seenIds.add(clientId);
 
@@ -241,7 +242,7 @@ export const mapSheetRows = (
     });
   }
 
-  return { rows: out, warnings };
+  return { rows: out, warnings, needsLink };
 };
 
 export const MOCK_SHEET_ROWS: SheetRow[] = [

--- a/src/lib/import/sheets-mapper.ts
+++ b/src/lib/import/sheets-mapper.ts
@@ -235,6 +235,8 @@ export const mapSheetRows = (
       feesStatus: r["FEES STATUS"] ? String(r["FEES STATUS"]).trim() : null,
       weekAssignedToAgent: r["WEEK ASSIGNED TO AGENT"] ? String(r["WEEK ASSIGNED TO AGENT"]).trim() : null,
       monthAssignedToAgent: r["MONTH ASSIGNED TO AGENT"] ? String(r["MONTH ASSIGNED TO AGENT"]).trim() : null,
+      t2Decision: "unknown",
+      t16Decision: "unknown",
       notes: r["COLLECTION NOTES"] ? String(r["COLLECTION NOTES"]).trim() : null,
     });
   }

--- a/src/lib/import/xlsx-mapper.ts
+++ b/src/lib/import/xlsx-mapper.ts
@@ -62,6 +62,9 @@ export interface ParsedCaseRow {
   weekAssignedToAgent: string | null;
   monthAssignedToAgent: string | null;
 
+  t2Decision: "fully_favorable" | "partially_favorable" | "unfavorable" | "dismissed" | "remand" | "unknown";
+  t16Decision: "fully_favorable" | "partially_favorable" | "unfavorable" | "dismissed" | "remand" | "unknown";
+
   // Notes — entire raw blob, stored as one activity_log entry per case
   notes: string | null;
 }
@@ -344,6 +347,8 @@ export const parseWorksheet = (buffer: Buffer): ParseResult => {
       feesStatus: null,
       weekAssignedToAgent: null,
       monthAssignedToAgent: null,
+      t2Decision: "unknown",
+      t16Decision: "unknown",
       notes: row[C.notes] ? String(row[C.notes]).trim() : null,
     });
   }

--- a/src/lib/mycase-proxy.ts
+++ b/src/lib/mycase-proxy.ts
@@ -1,4 +1,5 @@
 import "server-only";
+import { unstable_cache } from "next/cache";
 
 /**
  * Calls the n8n webhook that proxies MyCase Open API. MyCase OAuth credentials
@@ -29,9 +30,7 @@ export type MyCaseCaseDetail = {
   }>;
 };
 
-export async function fetchCaseDetails(
-  caseId: number,
-): Promise<MyCaseCaseDetail> {
+async function _fetchCaseDetails(caseId: number): Promise<MyCaseCaseDetail> {
   if (!CASE_DETAIL_WEBHOOK_URL) {
     throw new Error(
       "MyCase case detail webhook is not configured (N8N_MYCASE_CASE_DETAIL_WEBHOOK_URL)",
@@ -54,6 +53,14 @@ export async function fetchCaseDetails(
 
   return res.json() as Promise<MyCaseCaseDetail>;
 }
+
+// Cache per caseId for 5 minutes — avoids hitting the n8n webhook on every
+// sheet open for cases whose chronicle link isn't in the mirror DB yet.
+export const fetchCaseDetails = unstable_cache(
+  _fetchCaseDetails,
+  ["mycase-case-details"],
+  { revalidate: 300 },
+);
 
 // Shape returned by MyCase's GET /v1/cases/{id}/documents endpoint.
 export type MyCaseDocument = {

--- a/src/lib/mycase-proxy.ts
+++ b/src/lib/mycase-proxy.ts
@@ -10,7 +10,50 @@ const WEBHOOK_URL = process.env.N8N_MYCASE_DOCS_WEBHOOK_URL;
 const WEBHOOK_TOKEN = process.env.N8N_MYCASE_DOCS_WEBHOOK_TOKEN;
 // Separate webhook for single-document downloads; shares the same auth token.
 const DOC_FILE_WEBHOOK_URL = process.env.N8N_MYCASE_DOC_FILE_WEBHOOK_URL;
+// Case detail webhook — no auth header; n8n uses auth: None.
+const CASE_DETAIL_WEBHOOK_URL = process.env.N8N_MYCASE_CASE_DETAIL_WEBHOOK_URL;
 const AUTH_HEADER = "Fee-Collections-Docs-App-Token";
+
+export type MyCaseCaseDetail = {
+  id: number;
+  name: string;
+  case_stage: string | null;
+  status: string;
+  opened_date: string | null;
+  closed_date: string | null;
+  custom_field_values: Array<{
+    custom_field: { id: number };
+    value: string | number | null;
+    created_at: string | null;
+    updated_at: string | null;
+  }>;
+};
+
+export async function fetchCaseDetails(
+  caseId: number,
+): Promise<MyCaseCaseDetail> {
+  if (!CASE_DETAIL_WEBHOOK_URL) {
+    throw new Error(
+      "MyCase case detail webhook is not configured (N8N_MYCASE_CASE_DETAIL_WEBHOOK_URL)",
+    );
+  }
+
+  const res = await fetch(CASE_DETAIL_WEBHOOK_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ id: caseId }),
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `MyCase case detail webhook returned ${res.status}${text ? `: ${text.slice(0, 200)}` : ""}`,
+    );
+  }
+
+  return res.json() as Promise<MyCaseCaseDetail>;
+}
 
 // Shape returned by MyCase's GET /v1/cases/{id}/documents endpoint.
 export type MyCaseDocument = {


### PR DESCRIPTION
## Summary
- **Win sheet quick look** — new side sheet showing live MyCase data alongside local DB data: approval date, case stage, T16/T2 fee breakdown, decisions, chronicle link, and collection notes. Fields fall back through MyCase mirror DB → live MyCase API → local DB so nothing is left blank when data exists somewhere.
- **MyCase sync case tagging** — new `mycase_sync_tags` table and tags API (`POST/DELETE /api/mycase/sync/tags`). After a sync run, new cases that were not selected are automatically tagged as "viewed" so they don't surface as new on the next preview fetch. Viewed cases can be untagged individually from Step 4 of the sync modal.
- **Sync modal viewed status** — "VIEWED" category added across all steps (stat cards, Step 3 preview, Step 4 selection table with Mark Viewed / Unmark actions).
- **Decision mapping fix** — `mapDecision` now uses `includes()` for unfavorable/denied matching, catching values like `"T2 Unfavorable"` and `"Initial 06/13/25: T2 Unfavorable"` that were previously returning `"unknown"`.
- **Code standards fixes** — `import "server-only"` on details route, AbortController signals on tag/untag fetches, `role="alert"` on MyCase error block, `"unknown"` decisions hidden in UI, chronicle link extracted from duplicated JSX expression.

## Migration
`0017_mycase_sync_tags.sql` — creates `mycase_sync_tags` table. Applied to test DB; needs to be run against production.