### PR TITLE
feat: skip no-url sheet rows and surface as needs-link list

### DIFF
--- a/src/app/api/sheets/sync/route.ts
+++ b/src/app/api/sheets/sync/route.ts
@@ -149,7 +149,7 @@ export const POST = async (req: NextRequest) => {
       ]);
       sheetCache = { masterRows: masterRaw, feesClosedRows: feesClosedRaw, ts: Date.now() };
 
-      const { rows: parsed, warnings } = mapSheetRows(masterRaw);
+      const { rows: parsed, warnings, needsLink } = mapSheetRows(masterRaw);
       const { rows: feesClosedParsed } = mapFeesClosedRows(feesClosedRaw);
 
       // Build lookup sets
@@ -321,12 +321,14 @@ export const POST = async (req: NextRequest) => {
           feesClosed: feesClosedRows.length,
           missing: missingRows.length,
           synthetic: sheetRows.filter((r) => r.isSynthetic).length,
+          needsLink: needsLink.length,
           warnings,
         },
         rows: {
           sheet: sheetRows,
           feesClosed: feesClosedRows,
           missing: missingRows,
+          needsLink,
         },
       });
     }

--- a/src/components/modals/SheetSyncModal.tsx
+++ b/src/components/modals/SheetSyncModal.tsx
@@ -40,6 +40,11 @@ interface DbOnlyRow {
   status: "fees_closed" | "missing";
 }
 
+interface NeedsLinkRow {
+  row: number;
+  caseLink: string;
+}
+
 type Step4Filter = "all" | "new" | "changed" | "unchanged" | "fees_closed" | "missing";
 
 type Step4PreviewRow =
@@ -56,12 +61,14 @@ interface SyncPreviewResponse {
     feesClosed: number;
     missing: number;
     synthetic: number;
+    needsLink: number;
     warnings: { row: number; message: string }[];
   };
   rows: {
     sheet: SheetPreviewRow[];
     feesClosed: DbOnlyRow[];
     missing: DbOnlyRow[];
+    needsLink: NeedsLinkRow[];
   };
 }
 
@@ -205,6 +212,10 @@ export default function SheetSyncModal({
   );
   const syntheticRows = useMemo(
     () => preview?.rows.sheet.filter((r) => r.isSynthetic) ?? [],
+    [preview],
+  );
+  const needsLinkRows = useMemo(
+    () => preview?.rows.needsLink ?? [],
     [preview],
   );
 
@@ -456,10 +467,10 @@ export default function SheetSyncModal({
                     />
                     <Stat
                       t={t}
-                      label="No URL"
-                      value={preview.summary.synthetic.toLocaleString()}
+                      label="Needs Link"
+                      value={preview.summary.needsLink.toLocaleString()}
                       accent={
-                        preview.summary.synthetic > 0
+                        preview.summary.needsLink > 0
                           ? dark ? "text-red-400" : "text-red-600"
                           : undefined
                       }
@@ -479,6 +490,23 @@ export default function SheetSyncModal({
                       </ul>
                       {preview.summary.warnings.length > 25 && (
                         <p className="mt-1 opacity-70">…and {preview.summary.warnings.length - 25} more</p>
+                      )}
+                    </div>
+                  )}
+                  {needsLinkRows.length > 0 && (
+                    <div className={`rounded-md border p-3 text-[11px] ${dark ? "bg-red-900/20 border-red-800 text-red-300" : "bg-red-50 border-red-200 text-red-800"}`}>
+                      <div className="flex items-center gap-1.5 font-semibold mb-1">
+                        <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
+                        {needsLinkRows.length} row{needsLinkRows.length === 1 ? "" : "s"} {needsLinkRows.length === 1 ? "has" : "have"} no MyCase link — skipped
+                      </div>
+                      <p className="opacity-80 mb-2">These rows will not be synced until a valid MyCase URL is added to the sheet.</p>
+                      <ul className="space-y-0.5 max-h-36 overflow-y-auto">
+                        {needsLinkRows.slice(0, 25).map((r, i) => (
+                          <li key={i}>Row {r.row}: {r.caseLink}</li>
+                        ))}
+                      </ul>
+                      {needsLinkRows.length > 25 && (
+                        <p className="mt-1 opacity-70">…and {needsLinkRows.length - 25} more</p>
                       )}
                     </div>
                   )}

--- a/src/lib/import/__tests__/sheets-mapper.test.ts
+++ b/src/lib/import/__tests__/sheets-mapper.test.ts
@@ -168,20 +168,20 @@ describe("CASE LINK name parsing", () => {
 // ─── Synthetic ID assignment ──────────────────────────────────────────────────
 
 describe("synthetic ID", () => {
-  it("emits warning when CASE LINK_url is absent", () => {
-    const ws = warnings([row({ "CASE LINK_url": null })]);
-    const w = ws.find((w) => w.message.includes("No valid MyCase URL"));
-    expect(w).toBeDefined();
+  it("adds to needsLink when CASE LINK_url is absent", () => {
+    const { needsLink } = mapSheetRows([row({ "CASE LINK_url": null })]);
+    expect(needsLink).toHaveLength(1);
+    expect(needsLink[0].row).toBe(2);
   });
 
-  it("emits warning when URL does not contain a mycase.com court_cases path", () => {
-    const ws = warnings([row({ "CASE LINK_url": "https://example.com/case/99" })]);
-    expect(ws.some((w) => w.message.includes("No valid MyCase URL"))).toBe(true);
+  it("adds to needsLink when URL does not contain a mycase.com court_cases path", () => {
+    const { needsLink } = mapSheetRows([row({ "CASE LINK_url": "https://example.com/case/99" })]);
+    expect(needsLink).toHaveLength(1);
   });
 
-  it("assigns a clientId >= SYNTHETIC_ID_BASE when no URL", () => {
-    const [r] = parsed([row({ "CASE LINK_url": null })]);
-    expect(r.clientId).toBeGreaterThanOrEqual(SYNTHETIC_ID_BASE);
+  it("does not include no-URL rows in parsed output", () => {
+    const { rows } = mapSheetRows([row({ "CASE LINK_url": null })]);
+    expect(rows).toHaveLength(0);
   });
 
   it("emits duplicate-ID warning and assigns synthetic for second row with same MyCase id", () => {
@@ -236,33 +236,30 @@ describe("monetary amounts", () => {
 
 describe("warning row numbers", () => {
   it("row number is 1-indexed with header offset (first data row = row 2)", () => {
-    const ws = warnings([row({ "CASE LINK_url": null })]);
-    expect(ws[0].row).toBe(2);
+    const { needsLink } = mapSheetRows([row({ "CASE LINK_url": null })]);
+    expect(needsLink[0].row).toBe(2);
   });
 
   it("row number increments correctly for later rows", () => {
-    const ws = warnings([
+    const { needsLink } = mapSheetRows([
       row(),
       row({ "CASE LINK_url": null, "CASE LINK": "2024.02.01 Jones, Mary v. ALJ Smith" }),
     ]);
-    const w = ws.find((w) => w.message.includes("No valid MyCase URL"));
-    expect(w!.row).toBe(3);
+    expect(needsLink[0].row).toBe(3);
   });
 });
 
 // ─── Multiple issues in one row ───────────────────────────────────────────────
 
 describe("multiple malformed fields", () => {
-  it("collects all warnings for a single bad row", () => {
+  it("collects all warnings for a single bad row (with valid URL)", () => {
     const ws = warnings([
       row({
-        "CASE LINK_url": null,
         "APPROVAL DATE": "March 15 2024",
         "CLAIM TYPE": "UNKNOWN_TYPE",
         "CASE LINK": "2024.01.15 SmithJohn v. ALJ Doe",
       }),
     ]);
-    expect(ws.some((w) => w.message.includes("No valid MyCase URL"))).toBe(true);
     expect(ws.some((w) => w.message.includes("Approval date"))).toBe(true);
     expect(ws.some((w) => w.message.includes("Unrecognized claim type"))).toBe(true);
     expect(ws.some((w) => w.message.includes("Could not parse name"))).toBe(true);

--- a/src/lib/import/sheets-mapper.ts
+++ b/src/lib/import/sheets-mapper.ts
@@ -114,11 +114,14 @@ const mapWinSheetStatus = (raw: unknown): ParsedCaseRow["winSheetStatus"] => {
   return "started";
 };
 
+export type NeedsLinkRow = { row: number; caseLink: string };
+
 export const mapSheetRows = (
   rows: SheetRow[],
-): { rows: ParsedCaseRow[]; warnings: { row: number; message: string }[] } => {
+): { rows: ParsedCaseRow[]; warnings: { row: number; message: string }[]; needsLink: NeedsLinkRow[] } => {
   const out: ParsedCaseRow[] = [];
   const warnings: { row: number; message: string }[] = [];
+  const needsLink: NeedsLinkRow[] = [];
   const seenIds = new Set<number>();
   let synthetic = SYNTHETIC_ID_BASE;
 
@@ -131,23 +134,21 @@ export const mapSheetRows = (
     const myCaseMatch = url?.match(MYCASE_URL_RE);
     const myCaseId = myCaseMatch ? Number(myCaseMatch[1]) : null;
 
+    if (!myCaseId) {
+      needsLink.push({ row: i + 2, caseLink: linkText });
+      continue;
+    }
+
     let clientId: number;
-    if (myCaseId && !seenIds.has(myCaseId)) {
+    if (!seenIds.has(myCaseId)) {
       clientId = myCaseId;
     } else {
       while (seenIds.has(synthetic)) synthetic++;
       clientId = synthetic++;
-      if (myCaseId) {
-        warnings.push({
-          row: i + 2,
-          message: `Duplicate MyCase id ${myCaseId} — using synthetic ${clientId}`,
-        });
-      } else {
-        warnings.push({
-          row: i + 2,
-          message: "No valid MyCase URL — synthetic ID assigned; row will create a duplicate on every re-sync",
-        });
-      }
+      warnings.push({
+        row: i + 2,
+        message: `Duplicate MyCase id ${myCaseId} — using synthetic ${clientId}`,
+      });
     }
     seenIds.add(clientId);
 
@@ -239,7 +240,7 @@ export const mapSheetRows = (
     });
   }
 
-  return { rows: out, warnings };
+  return { rows: out, warnings, needsLink };
 };
 
 export const MOCK_SHEET_ROWS: SheetRow[] = [


### PR DESCRIPTION
## Summary

- Rows with no valid MyCase URL are now skipped entirely during sheets sync — no synthetic ID is assigned and they cannot be selected or upserted
- They surface in a \"Needs Link\" info panel in Step 1 of the sync modal, listing each row number and case name so staff know what to fix in the sheet
- The Step 1 stat card now shows a **Needs Link** count (rows skipped) instead of the old \"No URL\" synthetic count
- Synthetic IDs are still assigned for the rare case of duplicate MyCase IDs — that path is unchanged

## Files changed

- `src/lib/import/sheets-mapper.ts` — export `NeedsLinkRow` type; skip no-URL rows via `continue` instead of assigning synthetic IDs
- `src/app/api/sheets/sync/route.ts` — include `needsLink` in preview summary count and rows array
- `src/components/modals/SheetSyncModal.tsx` — add `NeedsLinkRow` interface, `needsLinkRows` memo, updated stat label, and red info panel in Step 1
- `src/lib/import/__tests__/sheets-mapper.test.ts` — updated tests to assert no-URL rows land in `needsLink`, not `warnings`