### PR TITLE
feat: case-name column links to MyCase + claim/Chronicle sub-line

### DIFF
--- a/src/app/api/cases/route.ts
+++ b/src/app/api/cases/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { db } from "@/lib/db";
-import { cases, feeRecords, activityLog } from "@/lib/db/schema";
+import { cases, feeRecords, activityLog, userDetails } from "@/lib/db/schema";
 import { eq, ilike, sql, desc } from "drizzle-orm";
 import { requireCapability, guardStatus } from "@/lib/auth-helpers";
 
@@ -86,9 +86,14 @@ export const GET = async (req: NextRequest) => {
         caseStatus: feeRecords.caseStatus,
         winSheetLink: feeRecords.winSheetLink,
         winSheetLinkText: feeRecords.winSheetLinkText,
+
+        // Chronicle id (from user_details) — powers the Chronicle link in the
+        // name column. one-to-one join, so it can't multiply rows.
+        udChronicleId: userDetails.chronicleId,
       })
       .from(cases)
       .leftJoin(feeRecords, eq(feeRecords.caseId, cases.clientId))
+      .leftJoin(userDetails, eq(userDetails.caseId, cases.clientId))
       .where(whereClause)
       .orderBy(desc(cases.approvalDate))
       .limit(limit)
@@ -166,6 +171,10 @@ export const GET = async (req: NextRequest) => {
       return {
         id: r.clientId,
         name: `${r.lastName}, ${r.firstName}`,
+        // MyCase case URL (stored on import); makes the name a deep link.
+        externalId: r.externalId ?? null,
+        // Chronicle client id → builds the Chronicle deep link in the name cell.
+        chronicleId: r.udChronicleId ?? null,
         assigned: r.assignedTo || "—",
         level: r.levelWon || "—",
         claim: r.claimTypeLabel === "T2_T16" ? "CONC" : r.claimTypeLabel || "—",
@@ -264,6 +273,12 @@ const createCaseSchema = z.object({
   aljLastName: optionalText,
   assignedTo: optionalText,
   winSheetStatus: optionalText,
+  // Chronicle client id → persisted to user_details so the dashboard can deep
+  // link to Chronicle. Blank/absent stays undefined.
+  chronicleId: z.preprocess(
+    (v) => (v === "" || v == null ? undefined : v),
+    z.coerce.number().int().positive().optional(),
+  ),
 });
 
 export const POST = async (req: NextRequest) => {
@@ -321,6 +336,18 @@ export const POST = async (req: NextRequest) => {
       assignedTo: input.assignedTo,
       winSheetStatus: input.winSheetStatus ?? "not_started",
     });
+
+    // Best-effort: persist the Chronicle id so the case deep-links to Chronicle.
+    // onConflictDoNothing guards the case_id unique key; the .catch swallows a
+    // chronicle_id unique collision (another case already owns it) so a bad id
+    // never fails an otherwise-successful case creation.
+    if (input.chronicleId != null) {
+      await db
+        .insert(userDetails)
+        .values({ caseId: input.clientId, chronicleId: input.chronicleId })
+        .onConflictDoNothing()
+        .catch(() => null);
+    }
 
     await db.insert(activityLog).values({
       caseId: input.clientId,

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -24,6 +24,7 @@ import {
   fmtFull,
   fmtDate,
   fmtClaim,
+  fmtClaimLong,
   STATUS_LABELS,
   getStatusColor,
 } from "@/lib/formatters";
@@ -887,12 +888,60 @@ export const FeeRecordsTable = ({
                     className="h-3.5 w-3.5 cursor-pointer accent-indigo-500"
                   />
                 </td>
-                {/* Case Info — first two columns are frozen */}
-                <td
-                  className={`${tdBase} ${t.text} font-semibold truncate ${stickyTd1}`}
-                  title={c.name}
-                >
-                  {c.name}
+                {/* Case Info — first two columns are frozen.
+                    Name deep-links to MyCase (external_id); a Chronicle link
+                    and the long-form claim label sit on a sub-line. */}
+                <td className={`${tdBase} ${stickyTd1}`} title={c.name}>
+                  {/* overflow-hidden keeps the sub-line from spilling past the
+                      frozen column onto the Assigned cell during h-scroll. */}
+                  <div className="flex flex-col gap-0.5 overflow-hidden">
+                    {c.externalId ? (
+                      <a
+                        href={c.externalId}
+                        target="_blank"
+                        rel="noreferrer"
+                        onClick={(e) => e.stopPropagation()}
+                        className={`inline-flex items-center gap-1 max-w-full ${t.text} font-semibold hover:underline`}
+                      >
+                        <span className="truncate">{c.name}</span>
+                        <ExternalLink
+                          className="h-3 w-3 shrink-0 opacity-50"
+                          aria-hidden="true"
+                        />
+                      </a>
+                    ) : (
+                      <span className={`${t.text} font-semibold truncate`}>
+                        {c.name}
+                      </span>
+                    )}
+                    <div className="flex items-center gap-2 text-[11px] leading-none min-w-0">
+                      {(() => {
+                        // Mirror the Claim column's optimistic value so the
+                        // sub-line updates the instant the dropdown changes.
+                        const claim = cellValue(c, "claim");
+                        return claim && claim !== "—" ? (
+                          <span className={`${t.textMuted} truncate`}>
+                            {fmtClaimLong(claim)}
+                          </span>
+                        ) : null;
+                      })()}
+                      {c.chronicleId != null && (
+                        <a
+                          href={`https://app.chroniclelegal.com/dashboard/clients/${c.chronicleId}`}
+                          target="_blank"
+                          rel="noreferrer"
+                          onClick={(e) => e.stopPropagation()}
+                          className={`inline-flex items-center gap-0.5 hover:underline shrink-0 ${dark ? "text-blue-400" : "text-blue-600"}`}
+                        >
+                          Chronicle
+                          <ExternalLink
+                            className="h-2.5 w-2.5"
+                            aria-hidden="true"
+                          />
+                        </a>
+                      )}
+                    </div>
+                  </div>
                 </td>
                 <td
                   className={`${tdBase} ${t.textSub} ${stickyTd2}`}

--- a/src/components/modals/AddCaseModal.tsx
+++ b/src/components/modals/AddCaseModal.tsx
@@ -3,7 +3,11 @@
 import { useState } from "react";
 import { X, RefreshCw, Plus, CheckCircle2, ExternalLink } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
-import { parseCaseLink, extractMyCaseId } from "@/lib/import/case-link";
+import {
+  parseCaseLink,
+  extractMyCaseId,
+  extractChronicleId,
+} from "@/lib/import/case-link";
 import type { DropdownOptionsByCategory } from "@/hooks/useDashboard";
 
 interface AddCaseModalProps {
@@ -21,6 +25,10 @@ interface FormState {
   firstName: string;
   lastName: string;
   externalId: string;
+  // Chronicle deep link: `chronicleUrl` is the raw input shown to the user;
+  // `chronicleId` is the numeric id extracted from it (what the API persists).
+  chronicleUrl: string;
+  chronicleId: string;
   aljFirstName: string;
   aljLastName: string;
   claimTypeLabel: string;
@@ -37,6 +45,8 @@ const EMPTY: FormState = {
   firstName: "",
   lastName: "",
   externalId: "",
+  chronicleUrl: "",
+  chronicleId: "",
   aljFirstName: "",
   aljLastName: "",
   claimTypeLabel: "",
@@ -87,6 +97,17 @@ export default function AddCaseModal({
       ...f,
       externalId: value,
       clientId: id ? String(id) : f.clientId,
+    }));
+  };
+
+  // Paste a Chronicle URL (or a bare client id); we store the raw value for
+  // display and the extracted numeric id as what the API persists.
+  const onChronicleUrl = (value: string) => {
+    const id = extractChronicleId(value);
+    setForm((f) => ({
+      ...f,
+      chronicleUrl: value,
+      chronicleId: id ? String(id) : "",
     }));
   };
 
@@ -213,6 +234,32 @@ export default function AddCaseModal({
                     </a>
                   )}
                 </div>
+                <label className={`${lblCls} mt-3`}>Chronicle Link</label>
+                <div className="relative">
+                  <input
+                    value={form.chronicleUrl}
+                    onChange={(e) => onChronicleUrl(e.target.value)}
+                    placeholder="https://app.chroniclelegal.com/dashboard/clients/12345"
+                    className={`${inputCls} pr-9`}
+                  />
+                  {form.chronicleId && (
+                    <a
+                      href={`https://app.chroniclelegal.com/dashboard/clients/${form.chronicleId}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={`absolute right-2 top-1/2 -translate-y-1/2 ${t.textSub} hover:opacity-80`}
+                      title="Open in Chronicle"
+                    >
+                      <ExternalLink className="h-4 w-4" />
+                    </a>
+                  )}
+                </div>
+                {form.chronicleUrl.trim() !== "" && !form.chronicleId && (
+                  <p className="mt-2 text-[11px] text-amber-600 dark:text-amber-400">
+                    Couldn’t read a Chronicle client id from that — paste the
+                    full client URL or just the numeric id.
+                  </p>
+                )}
                 {caseLinkMissingAlj && (
                   <p className="mt-2 text-[11px] text-amber-600 dark:text-amber-400">
                     No “v.” separator found — ALJ wasn’t captured. Add it as

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -27,6 +27,24 @@ export const fmtClaim = (claim: string): string => {
   return claim;
 };
 
+// Long-form claim labels for the case-name sub-line:
+//   T2 → Title II, T16 → Title XVI, T2_T16/CONC → Concurrent.
+// Anything else (DWB, DAC, AUX, "—", …) passes through unchanged.
+export const fmtClaimLong = (claim: string): string => {
+  switch (claim) {
+    case "T2":
+      return "Title II";
+    case "T16":
+      return "Title XVI";
+    case "T2_T16":
+    case "T2/T16":
+    case "CONC":
+      return "Concurrent";
+    default:
+      return claim;
+  }
+};
+
 // Win sheet status labels matching the spreadsheet.
 // The DB used to enforce a 7-state enum; it's now varchar so the dropdown
 // values from /settings can be saved directly. The lookup covers BOTH the

--- a/src/lib/import/case-link.ts
+++ b/src/lib/import/case-link.ts
@@ -22,6 +22,23 @@ export const extractMyCaseId = (url: string | null | undefined): number | null =
   return m ? Number(m[1]) : null;
 };
 
+// Chronicle client URLs look like
+//   https://app.chroniclelegal.com/dashboard/clients/12345
+// The path segment before /clients/ can vary, so allow any prefix.
+export const CHRONICLE_URL_RE = /chroniclelegal\.com\/(?:[^/]+\/)*clients\/(\d+)/i;
+
+/**
+ * Pull the numeric Chronicle client id from a Chronicle URL, or null.
+ * Also accepts a bare numeric id (the user may paste just the number).
+ */
+export const extractChronicleId = (value: string | null | undefined): number | null => {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (/^\d+$/.test(trimmed)) return Number(trimmed);
+  const m = trimmed.match(CHRONICLE_URL_RE);
+  return m ? Number(m[1]) : null;
+};
+
 /** Parse a leading "YYYY.MM.DD" (also accepts - or /) into ISO YYYY-MM-DD. */
 export const parseLeadingDate = (text: string): string | null => {
   const m = text.trim().match(/^(\d{4})[.\-/](\d{1,2})[.\-/](\d{1,2})\b/);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,6 +28,10 @@ export type PifStatus = "YES" | "NO" | "PENDING" | null;
 export interface CaseRow {
   id: number;
   name: string;
+  // MyCase case URL (from cases.external_id); null when not imported with a link.
+  externalId: string | null;
+  // Chronicle client id (from user_details); null when not backfilled.
+  chronicleId: number | null;
   assigned: string;
   level: string;
   claim: string;


### PR DESCRIPTION
- GET /api/cases now returns external_id (MyCase URL) and the case's chronicle_id (via a 1:1 user_details join) so the table can deep-link.
- Case-name cell: name links to MyCase, with a sub-line showing the long-form claim label (Title II / Title XVI / Concurrent) and a Chronicle link when a chronicle_id exists. Claim label mirrors the Claim column's optimistic value; cell clips so it can't overflow the frozen column.
- AddCaseModal: new Chronicle Link field; POST /api/cases persists the extracted chronicle_id to user_details (best-effort).
- Shared helpers: fmtClaimLong, extractChronicleId.