### PR TITLE
feat: make the case detail view text-selectable

### DIFF
--- a/src/app/cases/[id]/page.tsx
+++ b/src/app/cases/[id]/page.tsx
@@ -695,8 +695,10 @@ const CaseDetailPage = () => {
   // ---- Render ----
 
   return (
+    // select-text overrides the app-wide select-none (globals.css body) so the
+    // entire case detail view can be highlighted/copied.
     <div
-      className={`min-h-screen ${dark ? "bg-neutral-950" : "bg-neutral-50"}`}
+      className={`min-h-screen select-text ${dark ? "bg-neutral-950" : "bg-neutral-50"}`}
     >
       {/* Fee Modal */}
       {feeModalOpen && caseData && (
@@ -1538,7 +1540,7 @@ const CaseDetailPage = () => {
                             </span>
                           </div>
                           <p
-                            className={`text-[12px] ${t.textSub} mt-0.5 leading-relaxed`}
+                            className={`text-[12px] ${t.textSub} mt-0.5 leading-relaxed break-words`}
                           >
                             {a.message}
                           </p>


### PR DESCRIPTION
The app sets body { select-none } globally; add select-text on the /cases/[id] root so the whole case detail view (info, fees, activity log, etc.) can be highlighted/copied. Also wrap long activity messages with break-words.