### PR TITLE
feat: admin activity logs (admin audit + case activity feed)

### DIFF
--- a/drizzle/0020_elite_silk_fever.sql
+++ b/drizzle/0020_elite_silk_fever.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "admin_activity_log" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"actor_id" integer,
+	"actor_email" varchar(255),
+	"action" varchar(50) NOT NULL,
+	"target_user_id" integer,
+	"target_email" varchar(255),
+	"summary" text NOT NULL,
+	"metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "admin_activity_log" ADD CONSTRAINT "admin_activity_log_actor_id_users_id_fk" FOREIGN KEY ("actor_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "admin_activity_log" ADD CONSTRAINT "admin_activity_log_target_user_id_users_id_fk" FOREIGN KEY ("target_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_admin_activity_created_at" ON "admin_activity_log" USING btree ("created_at");

--- a/drizzle/meta/0020_snapshot.json
+++ b/drizzle/meta/0020_snapshot.json
@@ -1,0 +1,2920 @@
+{
+  "id": "ef8f8f1e-0add-41cd-b789-0ab54a5511e7",
+  "prevId": "6dab96e6-2dc9-4f5c-af3c-076bd88faf86",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_log": {
+      "name": "activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_record_id": {
+          "name": "fee_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_activity_log_case_id": {
+          "name": "idx_activity_log_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_log_created_at": {
+          "name": "idx_activity_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_log_case_id_cases_client_id_fk": {
+          "name": "activity_log_case_id_cases_client_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_log_fee_record_id_fee_records_id_fk": {
+          "name": "activity_log_fee_record_id_fee_records_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "fee_records",
+          "columnsFrom": [
+            "fee_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_activity_log": {
+      "name": "admin_activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_email": {
+          "name": "target_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_admin_activity_created_at": {
+          "name": "idx_admin_activity_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_activity_log_actor_id_users_id_fk": {
+          "name": "admin_activity_log_actor_id_users_id_fk",
+          "tableFrom": "admin_activity_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "admin_activity_log_target_user_id_users_id_fk": {
+          "name": "admin_activity_log_target_user_id_users_id_fk",
+          "tableFrom": "admin_activity_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_settings": {
+      "name": "app_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approved_by_options": {
+      "name": "approved_by_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "approved_by_options_name_unique": {
+          "name": "approved_by_options_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cases": {
+      "name": "cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dob": {
+          "name": "dob",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last4_ssn": {
+          "name": "last4_ssn",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_type": {
+          "name": "claim_type",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "claim_type_label": {
+          "name": "claim_type_label",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level_won": {
+          "name": "level_won",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "t2_decision": {
+          "name": "t2_decision",
+          "type": "decision_outcome_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'unknown'"
+        },
+        "t16_decision": {
+          "name": "t16_decision",
+          "type": "decision_outcome_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'unknown'"
+        },
+        "application_date": {
+          "name": "application_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alleged_onset_date": {
+          "name": "alleged_onset_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_date": {
+          "name": "approval_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_date": {
+          "name": "closure_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_held_date": {
+          "name": "hearing_held_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_scheduled_date": {
+          "name": "hearing_scheduled_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_scheduled_datetime": {
+          "name": "hearing_scheduled_datetime",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_timezone": {
+          "name": "hearing_timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "office_with_jurisdiction": {
+          "name": "office_with_jurisdiction",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alj_first_name": {
+          "name": "alj_first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alj_last_name": {
+          "name": "alj_last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimant_location": {
+          "name": "claimant_location",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representative_location": {
+          "name": "representative_location",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_expert": {
+          "name": "medical_expert",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vocational_expert": {
+          "name": "vocational_expert",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_file_link": {
+          "name": "all_file_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exhibits_file_link": {
+          "name": "exhibits_file_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_file_updated_at": {
+          "name": "all_file_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exhibits_file_updated_at": {
+          "name": "exhibits_file_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_ssn": {
+          "name": "full_ssn",
+          "type": "varchar(11)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_diagnosis": {
+          "name": "primary_diagnosis",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_diagnosis_code": {
+          "name": "primary_diagnosis_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secondary_diagnosis": {
+          "name": "secondary_diagnosis",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secondary_diagnosis_code": {
+          "name": "secondary_diagnosis_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allegations": {
+          "name": "allegations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blind_dli": {
+          "name": "blind_dli",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firm_name": {
+          "name": "firm_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firm_ein": {
+          "name": "firm_ein",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_office": {
+          "name": "hearing_office",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representatives": {
+          "name": "representatives",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_history": {
+          "name": "decision_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_type": {
+          "name": "report_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expedited_case": {
+          "name": "expedited_case",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_of_case": {
+          "name": "status_of_case",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_date": {
+          "name": "status_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_date": {
+          "name": "request_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_date": {
+          "name": "receipt_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_date_assigned": {
+          "name": "first_date_assigned",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_fqr_starts": {
+          "name": "date_fqr_starts",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_insured": {
+          "name": "last_insured",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_created_at": {
+          "name": "source_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_updated_at": {
+          "name": "source_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ere_session_date": {
+          "name": "last_ere_session_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status_report_date": {
+          "name": "last_status_report_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documents_last_added_at": {
+          "name": "documents_last_added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invalid_ssn": {
+          "name": "invalid_ssn",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ssn_encrypted": {
+          "name": "ssn_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_link": {
+          "name": "case_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_pulled_at": {
+          "name": "last_pulled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_cases_client_id": {
+          "name": "idx_cases_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_external_id": {
+          "name": "idx_cases_external_id",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_claim_type_label": {
+          "name": "idx_cases_claim_type_label",
+          "columns": [
+            {
+              "expression": "claim_type_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_approval_date": {
+          "name": "idx_cases_approval_date",
+          "columns": [
+            {
+              "expression": "approval_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_last_name": {
+          "name": "idx_cases_last_name",
+          "columns": [
+            {
+              "expression": "last_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cases_client_id_unique": {
+          "name": "cases_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chronicle_documents": {
+      "name": "chronicle_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mycase_client_id": {
+          "name": "mycase_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chronicle_client_id": {
+          "name": "chronicle_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chronicle_document_id": {
+          "name": "chronicle_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_name": {
+          "name": "document_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_category": {
+          "name": "document_category",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_document": {
+          "name": "raw_document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chronicle_documents_case_id": {
+          "name": "idx_chronicle_documents_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chronicle_documents_case_id_cases_client_id_fk": {
+          "name": "chronicle_documents_case_id_cases_client_id_fk",
+          "tableFrom": "chronicle_documents",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chronicle_documents_case_id_chronicle_document_id_unique": {
+          "name": "chronicle_documents_case_id_chronicle_document_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id",
+            "chronicle_document_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_metrics": {
+      "name": "daily_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_date": {
+          "name": "metric_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ssa_calls": {
+          "name": "ssa_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "client_calls_ib": {
+          "name": "client_calls_ib",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "client_calls_ob": {
+          "name": "client_calls_ob",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_metrics_agent": {
+          "name": "idx_daily_metrics_agent",
+          "columns": [
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_metrics_date": {
+          "name": "idx_daily_metrics_date",
+          "columns": [
+            {
+              "expression": "metric_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_metrics_agent_name_team_members_name_fk": {
+          "name": "daily_metrics_agent_name_team_members_name_fk",
+          "tableFrom": "daily_metrics",
+          "tableTo": "team_members",
+          "columnsFrom": [
+            "agent_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dropdown_options": {
+      "name": "dropdown_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(150)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_dropdown_options_category_name": {
+          "name": "uq_dropdown_options_category_name",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dropdown_options_category": {
+          "name": "idx_dropdown_options_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_cap_history": {
+      "name": "fee_cap_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cap_amount": {
+          "name": "cap_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fee_cap_history_effective_date_unique": {
+          "name": "fee_cap_history_effective_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "effective_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_petitions": {
+      "name": "fee_petitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "noa": {
+          "name": "noa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "time_delineation": {
+          "name": "time_delineation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "fee_petition_doc": {
+          "name": "fee_petition_doc",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ltr_to_clmt": {
+          "name": "ltr_to_clmt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ltr_to_clmt_with_signature": {
+          "name": "ltr_to_clmt_with_signature",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ltr_to_alj": {
+          "name": "ltr_to_alj",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "fax_conf_fee_pet": {
+          "name": "fax_conf_fee_pet",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "update_note": {
+          "name": "update_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fee_petitions_case_id": {
+          "name": "idx_fee_petitions_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fee_petitions_case_id_cases_client_id_fk": {
+          "name": "fee_petitions_case_id_cases_client_id_fk",
+          "tableFrom": "fee_petitions",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fee_petitions_case_id_unique": {
+          "name": "fee_petitions_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_records": {
+      "name": "fee_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "win_sheet_status": {
+          "name": "win_sheet_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'not_started'"
+        },
+        "win_sheet_link": {
+          "name": "win_sheet_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "win_sheet_link_text": {
+          "name": "win_sheet_link_text",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_status": {
+          "name": "case_status",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fees_confirmation": {
+          "name": "fees_confirmation",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_assigned_to_agent": {
+          "name": "date_assigned_to_agent",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "t16_retro": {
+          "name": "t16_retro",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_fee_due": {
+          "name": "t16_fee_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_fee_received": {
+          "name": "t16_fee_received",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_pending": {
+          "name": "t16_pending",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_fee_received_date": {
+          "name": "t16_fee_received_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "t2_retro": {
+          "name": "t2_retro",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_fee_due": {
+          "name": "t2_fee_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_fee_received": {
+          "name": "t2_fee_received",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_pending": {
+          "name": "t2_pending",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_fee_received_date": {
+          "name": "t2_fee_received_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aux_retro": {
+          "name": "aux_retro",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_fee_due": {
+          "name": "aux_fee_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_fee_received": {
+          "name": "aux_fee_received",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_pending": {
+          "name": "aux_pending",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_fee_received_date": {
+          "name": "aux_fee_received_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_retro_due": {
+          "name": "total_retro_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "total_fees_expected": {
+          "name": "total_fees_expected",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "total_fees_paid": {
+          "name": "total_fees_paid",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "pif_ready_to_close": {
+          "name": "pif_ready_to_close",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_closed": {
+          "name": "is_closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "marked_overpaid": {
+          "name": "marked_overpaid",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_method": {
+          "name": "fee_method",
+          "type": "fee_method_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'fee_agreement'"
+        },
+        "applicable_fee_cap": {
+          "name": "applicable_fee_cap",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'9200'"
+        },
+        "fee_cap_applied": {
+          "name": "fee_cap_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "fee_computed": {
+          "name": "fee_computed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "fee_computed_at": {
+          "name": "fee_computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "days_after_approval": {
+          "name": "days_after_approval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_category": {
+          "name": "approval_category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fees_status": {
+          "name": "fees_status",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "week_assigned_to_agent": {
+          "name": "week_assigned_to_agent",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "month_assigned_to_agent": {
+          "name": "month_assigned_to_agent",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "sync_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'not_synced'"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mycase_record_id": {
+          "name": "mycase_record_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fee_records_case_id": {
+          "name": "idx_fee_records_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_assigned_to": {
+          "name": "idx_fee_records_assigned_to",
+          "columns": [
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_win_sheet_status": {
+          "name": "idx_fee_records_win_sheet_status",
+          "columns": [
+            {
+              "expression": "win_sheet_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_sync_status": {
+          "name": "idx_fee_records_sync_status",
+          "columns": [
+            {
+              "expression": "sync_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_pif": {
+          "name": "idx_fee_records_pif",
+          "columns": [
+            {
+              "expression": "pif_ready_to_close",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_is_closed": {
+          "name": "idx_fee_records_is_closed",
+          "columns": [
+            {
+              "expression": "is_closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fee_records_case_id_cases_client_id_fk": {
+          "name": "fee_records_case_id_cases_client_id_fk",
+          "tableFrom": "fee_records",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fee_records_case_id_unique": {
+          "name": "fee_records_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mycase_sync_tags": {
+      "name": "mycase_sync_tags",
+      "schema": "",
+      "columns": {
+        "mycase_case_id": {
+          "name": "mycase_case_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewed'"
+        },
+        "tagged_at": {
+          "name": "tagged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "tagged_by": {
+          "name": "tagged_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mycase_notice_documents": {
+      "name": "mycase_notice_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mycase_client_id": {
+          "name": "mycase_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mycase_document_id": {
+          "name": "mycase_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_name": {
+          "name": "document_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_pattern": {
+          "name": "matched_pattern",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_document": {
+          "name": "raw_document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mycase_notice_documents_case_id": {
+          "name": "idx_mycase_notice_documents_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mycase_notice_documents_case_id_cases_client_id_fk": {
+          "name": "mycase_notice_documents_case_id_cases_client_id_fk",
+          "tableFrom": "mycase_notice_documents",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mycase_notice_documents_case_id_mycase_document_id_unique": {
+          "name": "mycase_notice_documents_case_id_mycase_document_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id",
+            "mycase_document_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "notification_severity_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notifications_type": {
+          "name": "idx_notifications_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_is_read": {
+          "name": "idx_notifications_is_read",
+          "columns": [
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_created_at": {
+          "name": "idx_notifications_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_agent": {
+          "name": "idx_notifications_agent",
+          "columns": [
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_case_id_cases_client_id_fk": {
+          "name": "notifications_case_id_cases_client_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.overpaid_cases": {
+      "name": "overpaid_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "op_ltr_date": {
+          "name": "op_ltr_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "op_ltr_received": {
+          "name": "op_ltr_received",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overpaid_amount": {
+          "name": "overpaid_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checks_cleared": {
+          "name": "checks_cleared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "checks_cleared_at": {
+          "name": "checks_cleared_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "update_note": {
+          "name": "update_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_overpaid_cases_case_id": {
+          "name": "idx_overpaid_cases_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "overpaid_cases_case_id_cases_client_id_fk": {
+          "name": "overpaid_cases_case_id_cases_client_id_fk",
+          "tableFrom": "overpaid_cases",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "overpaid_cases_case_id_unique": {
+          "name": "overpaid_cases_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pull_logs": {
+      "name": "pull_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_records_pulled": {
+          "name": "total_records_pulled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "new_cases": {
+          "name": "new_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_cases": {
+          "name": "updated_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "errors": {
+          "name": "errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_at": {
+          "name": "triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_logs": {
+      "name": "sync_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cases": {
+          "name": "total_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "case_ids": {
+          "name": "case_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_at": {
+          "name": "triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_sync_logs_triggered_at": {
+          "name": "idx_sync_logs_triggered_at",
+          "columns": [
+            {
+              "expression": "triggered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'collections_specialist'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_members_name_unique": {
+          "name": "team_members_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_access_overrides": {
+      "name": "user_access_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overrides": {
+          "name": "overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_access_overrides_user_id_users_id_fk": {
+          "name": "user_access_overrides_user_id_users_id_fk",
+          "tableFrom": "user_access_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_access_overrides_user_id_unique": {
+          "name": "user_access_overrides_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_details": {
+      "name": "user_details",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chronicle_id": {
+          "name": "chronicle_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line_1": {
+          "name": "address_line_1",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line_2": {
+          "name": "address_line_2",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip_code": {
+          "name": "zip_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cell_phone": {
+          "name": "cell_phone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssn": {
+          "name": "ssn",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssn_last4": {
+          "name": "ssn_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age_at_approval": {
+          "name": "age_at_approval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "place_of_birth": {
+          "name": "place_of_birth",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mothers_first_name_and_maiden_name": {
+          "name": "mothers_first_name_and_maiden_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fathers_first_and_last_name": {
+          "name": "fathers_first_and_last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_details_case_id": {
+          "name": "idx_user_details_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_details_case_id_cases_client_id_fk": {
+          "name": "user_details_case_id_cases_client_id_fk",
+          "tableFrom": "user_details",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_details_case_id_unique": {
+          "name": "user_details_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        },
+        "user_details_chronicle_id_unique": {
+          "name": "user_details_chronicle_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chronicle_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.claim_type_enum": {
+      "name": "claim_type_enum",
+      "schema": "public",
+      "values": [
+        "T2",
+        "T16",
+        "T2_T16"
+      ]
+    },
+    "public.decision_outcome_enum": {
+      "name": "decision_outcome_enum",
+      "schema": "public",
+      "values": [
+        "fully_favorable",
+        "partially_favorable",
+        "unfavorable",
+        "dismissed",
+        "remand",
+        "unknown"
+      ]
+    },
+    "public.fee_method_enum": {
+      "name": "fee_method_enum",
+      "schema": "public",
+      "values": [
+        "fee_agreement",
+        "fee_petition"
+      ]
+    },
+    "public.level_won_enum": {
+      "name": "level_won_enum",
+      "schema": "public",
+      "values": [
+        "INITIAL",
+        "RECON",
+        "HEARING",
+        "AC",
+        "FEDERAL_COURT",
+        "FEE_PETITION"
+      ]
+    },
+    "public.notification_severity_enum": {
+      "name": "notification_severity_enum",
+      "schema": "public",
+      "values": [
+        "info",
+        "warning",
+        "critical"
+      ]
+    },
+    "public.notification_type_enum": {
+      "name": "notification_type_enum",
+      "schema": "public",
+      "values": [
+        "case_aging",
+        "fee_payment",
+        "call_target_missed",
+        "case_assigned"
+      ]
+    },
+    "public.sync_status_enum": {
+      "name": "sync_status_enum",
+      "schema": "public",
+      "values": [
+        "not_synced",
+        "syncing",
+        "synced",
+        "error"
+      ]
+    },
+    "public.user_role_enum": {
+      "name": "user_role_enum",
+      "schema": "public",
+      "values": [
+        "admin",
+        "lead",
+        "member",
+        "system_admin"
+      ]
+    },
+    "public.win_sheet_status_enum": {
+      "name": "win_sheet_status_enum",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "started",
+        "in_progress",
+        "pending_payment",
+        "partially_paid",
+        "paid_in_full",
+        "closed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1781195209448,
       "tag": "0019_user_access_overrides",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1781630742397,
+      "tag": "0020_elite_silk_fever",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(dashboard)/admin/actions.ts
+++ b/src/app/(dashboard)/admin/actions.ts
@@ -6,7 +6,8 @@ import { revalidatePath } from "next/cache";
 
 import { db } from "@/lib/db";
 import { users, userAccessOverrides } from "@/lib/db/schema";
-import { requireAdmin } from "@/lib/auth-helpers";
+import { requireAdmin, type AdminSession } from "@/lib/auth-helpers";
+import { logAdminActivity, type AdminActor } from "@/lib/admin-activity";
 import { PAGE_KEYS, type PageKey } from "@/lib/access/pages";
 import { rolePageDefaults } from "@/lib/access/role-defaults";
 import {
@@ -32,6 +33,12 @@ const ROLES = ["admin", "lead", "member", "system_admin"] as const;
 type Role = (typeof ROLES)[number];
 
 const isRole = (v: unknown): v is Role => ROLES.includes(v as Role);
+
+/** The signed-in admin performing the action, for the audit trail. */
+const actorFromGuard = (session: AdminSession): AdminActor => ({
+  id: Number(session.user.id) || null,
+  email: session.user.email ?? null,
+});
 
 /** Returns true iff `targetId` is the last enabled system_admin in the DB. */
 async function isLastSystemAdmin(targetId: number): Promise<boolean> {
@@ -76,12 +83,23 @@ export async function createUser(input: {
     }
 
     const passwordHash = await bcrypt.hash(input.password, 12);
-    await db.insert(users).values({
-      email,
-      name: input.name?.trim() || null,
-      passwordHash,
-      role: input.role,
-      mustChangePassword: input.mustChangePassword ?? true,
+    const [created] = await db
+      .insert(users)
+      .values({
+        email,
+        name: input.name?.trim() || null,
+        passwordHash,
+        role: input.role,
+        mustChangePassword: input.mustChangePassword ?? true,
+      })
+      .returning({ id: users.id });
+
+    await logAdminActivity({
+      actor: actorFromGuard(guard.session),
+      action: "user.create",
+      targetUserId: created?.id ?? null,
+      targetEmail: email,
+      summary: `Created ${input.role} account ${email}`,
     });
 
     revalidatePath("/admin");
@@ -134,7 +152,12 @@ export async function updateUserRole(input: {
 
   try {
     const [target] = await db
-      .select({ id: users.id, role: users.role, isActive: users.isActive })
+      .select({
+        id: users.id,
+        email: users.email,
+        role: users.role,
+        isActive: users.isActive,
+      })
       .from(users)
       .where(eq(users.id, input.userId))
       .limit(1);
@@ -153,6 +176,15 @@ export async function updateUserRole(input: {
       .update(users)
       .set({ role: input.role, updatedAt: new Date() })
       .where(eq(users.id, input.userId));
+
+    await logAdminActivity({
+      actor: actorFromGuard(guard.session),
+      action: "user.role_change",
+      targetUserId: target.id,
+      targetEmail: target.email,
+      summary: `Changed role of ${target.email} from ${target.role} to ${input.role}`,
+      metadata: { from: target.role, to: input.role },
+    });
 
     revalidatePath("/admin");
     return { ok: true };
@@ -178,7 +210,12 @@ export async function setUserActive(input: {
 
   try {
     const [target] = await db
-      .select({ id: users.id, role: users.role, isActive: users.isActive })
+      .select({
+        id: users.id,
+        email: users.email,
+        role: users.role,
+        isActive: users.isActive,
+      })
       .from(users)
       .where(eq(users.id, input.userId))
       .limit(1);
@@ -197,6 +234,14 @@ export async function setUserActive(input: {
       .update(users)
       .set({ isActive: input.isActive, updatedAt: new Date() })
       .where(eq(users.id, input.userId));
+
+    await logAdminActivity({
+      actor: actorFromGuard(guard.session),
+      action: input.isActive ? "user.activate" : "user.deactivate",
+      targetUserId: target.id,
+      targetEmail: target.email,
+      summary: `${input.isActive ? "Reactivated" : "Deactivated"} account ${target.email}`,
+    });
 
     revalidatePath("/admin");
     return { ok: true };
@@ -220,15 +265,27 @@ export async function resetUserPassword(input: {
   }
 
   try {
+    const [target] = await db
+      .select({ id: users.id, email: users.email })
+      .from(users)
+      .where(eq(users.id, input.userId))
+      .limit(1);
+    if (!target) return { ok: false, error: "User not found" };
+
     const passwordHash = await bcrypt.hash(input.password, 12);
-    const result = await db
+    await db
       .update(users)
       .set({ passwordHash, mustChangePassword: input.mustChangePassword ?? true, updatedAt: new Date() })
       .where(eq(users.id, input.userId));
 
-    if (result.length === 0) {
-      // postgres-js doesn't return rowCount on UPDATE the same as pg; check separately.
-    }
+    await logAdminActivity({
+      actor: actorFromGuard(guard.session),
+      action: "user.password_reset",
+      targetUserId: target.id,
+      targetEmail: target.email,
+      // Never log the password itself.
+      summary: `Reset password for ${target.email}`,
+    });
 
     revalidatePath("/admin");
     return { ok: true };
@@ -311,7 +368,7 @@ export async function updateUserAccess(input: {
 
   try {
     const [user] = await db
-      .select({ role: users.role })
+      .select({ email: users.email, role: users.role })
       .from(users)
       .where(eq(users.id, input.userId))
       .limit(1);
@@ -344,6 +401,20 @@ export async function updateUserAccess(input: {
         target: userAccessOverrides.userId,
         set: { overrides, updatedAt: new Date() },
       });
+
+    const pageDeviationCount = Object.keys(deviations).length;
+    const capDeviationCount = Object.keys(capDeviations).length;
+    await logAdminActivity({
+      actor: actorFromGuard(guard.session),
+      action: "user.access_update",
+      targetUserId: input.userId,
+      targetEmail: user.email,
+      summary:
+        pageDeviationCount + capDeviationCount === 0
+          ? `Reset ${user.email} to role defaults`
+          : `Updated access for ${user.email} (${pageDeviationCount} page, ${capDeviationCount} capability override${pageDeviationCount + capDeviationCount === 1 ? "" : "s"})`,
+      metadata: { pages: deviations, capabilities: capDeviations },
+    });
 
     revalidatePath("/admin");
     return { ok: true };

--- a/src/app/(dashboard)/admin/page.tsx
+++ b/src/app/(dashboard)/admin/page.tsx
@@ -1,10 +1,15 @@
 import { redirect } from "next/navigation";
-import { desc } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 
 import { db } from "@/lib/db";
-import { users } from "@/lib/db/schema";
+import { users, adminActivityLog, activityLog, cases } from "@/lib/db/schema";
 import { requireAdmin } from "@/lib/auth-helpers";
-import { AdminPage, type AdminUser } from "@/components/admin/AdminPage";
+import {
+  AdminPage,
+  type AdminUser,
+  type AdminActivityEntry,
+  type CaseActivityEntry,
+} from "@/components/admin/AdminPage";
 
 // Auth-gated, data depends on cookies → never prerender.
 export const dynamic = "force-dynamic";
@@ -51,9 +56,64 @@ export default async function AdminRoute() {
     createdAt: r.createdAt.toISOString(),
   }));
 
+  // Most recent admin actions for the Activity Logs tab. Emails are snapshots
+  // on the row, so no joins are needed and entries survive account deletion.
+  const logRows = await db
+    .select({
+      id: adminActivityLog.id,
+      actorEmail: adminActivityLog.actorEmail,
+      action: adminActivityLog.action,
+      targetEmail: adminActivityLog.targetEmail,
+      summary: adminActivityLog.summary,
+      createdAt: adminActivityLog.createdAt,
+    })
+    .from(adminActivityLog)
+    .orderBy(desc(adminActivityLog.createdAt))
+    .limit(100);
+
+  const activity: AdminActivityEntry[] = logRows.map((r) => ({
+    id: r.id,
+    actorEmail: r.actorEmail,
+    action: r.action,
+    targetEmail: r.targetEmail,
+    summary: r.summary,
+    createdAt: r.createdAt.toISOString(),
+  }));
+
+  // Recent edits across all cases (case-scoped activity_log) for the admin
+  // "Case Activity" sub-tab. Left join to cases for a readable name.
+  const caseLogRows = await db
+    .select({
+      id: activityLog.id,
+      caseId: activityLog.caseId,
+      firstName: cases.firstName,
+      lastName: cases.lastName,
+      message: activityLog.message,
+      createdBy: activityLog.createdBy,
+      createdAt: activityLog.createdAt,
+    })
+    .from(activityLog)
+    .leftJoin(cases, eq(cases.clientId, activityLog.caseId))
+    .orderBy(desc(activityLog.createdAt))
+    .limit(100);
+
+  const caseActivity: CaseActivityEntry[] = caseLogRows.map((r) => ({
+    id: r.id,
+    caseId: r.caseId,
+    caseName:
+      r.lastName || r.firstName
+        ? `${r.lastName ?? ""}, ${r.firstName ?? ""}`.replace(/^, |, $/g, "")
+        : `Case ${r.caseId}`,
+    message: r.message,
+    createdBy: r.createdBy,
+    createdAt: r.createdAt.toISOString(),
+  }));
+
   return (
     <AdminPage
       users={userList}
+      activity={activity}
+      caseActivity={caseActivity}
       currentUserId={Number(guard.session.user.id)}
     />
   );

--- a/src/components/admin/AdminActivityLog.tsx
+++ b/src/components/admin/AdminActivityLog.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useTheme } from "next-themes";
+import { Activity, Search } from "lucide-react";
+import { themeClasses } from "@/lib/theme-classes";
+import { fmtDateTime } from "@/lib/formatters";
+
+export interface AdminActivityEntry {
+  id: string;
+  actorEmail: string | null;
+  action: string;
+  targetEmail: string | null;
+  summary: string;
+  createdAt: string;
+}
+
+// Per-action badge label + color. Unknown actions fall back to a neutral pill.
+const ACTION_META: Record<string, { label: string; tone: string }> = {
+  "user.create": { label: "Created", tone: "emerald" },
+  "user.role_change": { label: "Role", tone: "blue" },
+  "user.activate": { label: "Activated", tone: "emerald" },
+  "user.deactivate": { label: "Deactivated", tone: "amber" },
+  "user.password_reset": { label: "Password", tone: "violet" },
+  "user.access_update": { label: "Access", tone: "blue" },
+};
+
+const toneClasses = (tone: string, dark: boolean): string => {
+  switch (tone) {
+    case "emerald":
+      return dark
+        ? "bg-emerald-900/40 text-emerald-400"
+        : "bg-emerald-50 text-emerald-700";
+    case "amber":
+      return dark
+        ? "bg-amber-900/40 text-amber-400"
+        : "bg-amber-50 text-amber-700";
+    case "violet":
+      return dark
+        ? "bg-violet-900/40 text-violet-400"
+        : "bg-violet-50 text-violet-700";
+    case "blue":
+      return dark ? "bg-blue-900/40 text-blue-400" : "bg-blue-50 text-blue-700";
+    default:
+      return dark
+        ? "bg-neutral-800 text-neutral-400"
+        : "bg-neutral-100 text-neutral-600";
+  }
+};
+
+export function AdminActivityLog({ entries }: { entries: AdminActivityEntry[] }) {
+  const { resolvedTheme } = useTheme();
+  const dark = resolvedTheme === "dark";
+  const t = themeClasses(dark);
+  const [search, setSearch] = useState("");
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return entries;
+    return entries.filter(
+      (e) =>
+        e.summary.toLowerCase().includes(q) ||
+        (e.actorEmail ?? "").toLowerCase().includes(q) ||
+        (e.targetEmail ?? "").toLowerCase().includes(q),
+    );
+  }, [entries, search]);
+
+  const sectionCard = `rounded-xl border ${t.card}`;
+
+  if (entries.length === 0) {
+    return (
+      <div className={`${sectionCard} p-8 text-center`}>
+        <div
+          className={`mx-auto w-10 h-10 rounded-lg flex items-center justify-center ${dark ? "bg-neutral-800" : "bg-neutral-100"}`}
+        >
+          <Activity className={`h-5 w-5 ${t.textMuted}`} />
+        </div>
+        <h3 className={`text-sm font-semibold mt-3 ${t.text}`}>
+          No admin activity yet
+        </h3>
+        <p className={`text-[11px] ${t.textMuted} mt-1 max-w-md mx-auto`}>
+          User creates, role changes, password resets, and access edits will
+          appear here as they happen.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`${sectionCard} overflow-hidden`}>
+      <div
+        className={`flex items-center justify-between gap-3 px-4 py-3 border-b ${t.borderLight}`}
+      >
+        <h3 className={`text-xs font-bold ${t.text}`}>
+          Activity Log
+          <span className={`ml-1.5 font-normal ${t.textMuted}`}>
+            ({entries.length})
+          </span>
+        </h3>
+        <div className="relative">
+          <Search
+            className={`absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 ${t.textMuted}`}
+            aria-hidden="true"
+          />
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search activity…"
+            className={`h-8 w-48 pl-8 pr-3 rounded-md border text-xs outline-none ${t.inputBg}`}
+          />
+        </div>
+      </div>
+
+      {filtered.length === 0 ? (
+        <p className={`text-xs ${t.textMuted} text-center py-10`}>
+          No entries match “{search}”.
+        </p>
+      ) : (
+        <ul className="divide-y divide-current/5">
+          {filtered.map((e) => {
+            const meta = ACTION_META[e.action] ?? {
+              label: e.action,
+              tone: "neutral",
+            };
+            return (
+              <li
+                key={e.id}
+                className={`flex items-start gap-3 px-4 py-2.5 ${dark ? "hover:bg-neutral-800/30" : "hover:bg-neutral-50"}`}
+              >
+                <span
+                  className={`mt-0.5 shrink-0 text-[10px] font-semibold px-1.5 py-0.5 rounded ${toneClasses(meta.tone, dark)}`}
+                >
+                  {meta.label}
+                </span>
+                <div className="flex-1 min-w-0 select-text">
+                  <p className={`text-[12px] ${t.text} break-words`}>
+                    {e.summary}
+                  </p>
+                  <p className={`text-[10px] ${t.textMuted} mt-0.5`}>
+                    {e.actorEmail ?? "Unknown"} · {fmtDateTime(e.createdAt)}
+                  </p>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/admin/AdminPage.tsx
+++ b/src/components/admin/AdminPage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTheme } from "next-themes";
-import { Shield, Activity } from "lucide-react";
+import { Shield } from "lucide-react";
 import {
   Tabs,
   TabsContent,
@@ -10,15 +10,32 @@ import {
 } from "@/components/ui/tabs";
 import { themeClasses } from "@/lib/theme-classes";
 import { UsersTable, type AdminUser } from "./UsersTable";
+import {
+  AdminActivityLog,
+  type AdminActivityEntry,
+} from "./AdminActivityLog";
+import {
+  CaseActivityFeed,
+  type CaseActivityEntry,
+} from "./CaseActivityFeed";
 
 export type { AdminUser } from "./UsersTable";
+export type { AdminActivityEntry } from "./AdminActivityLog";
+export type { CaseActivityEntry } from "./CaseActivityFeed";
 
 interface AdminPageProps {
   users: AdminUser[];
+  activity: AdminActivityEntry[];
+  caseActivity: CaseActivityEntry[];
   currentUserId: number;
 }
 
-export function AdminPage({ users, currentUserId }: AdminPageProps) {
+export function AdminPage({
+  users,
+  activity,
+  caseActivity,
+  currentUserId,
+}: AdminPageProps) {
   const { resolvedTheme } = useTheme();
   const dark = resolvedTheme === "dark";
   const t = themeClasses(dark);
@@ -54,20 +71,18 @@ export function AdminPage({ users, currentUserId }: AdminPageProps) {
         </TabsContent>
 
         <TabsContent value="activity">
-          <div className={`${sectionCard} p-8 text-center`}>
-            <div
-              className={`mx-auto w-10 h-10 rounded-lg flex items-center justify-center ${dark ? "bg-neutral-800" : "bg-neutral-100"}`}
-            >
-              <Activity className={`h-5 w-5 ${t.textMuted}`} />
-            </div>
-            <h3 className={`text-sm font-semibold mt-3 ${t.text}`}>
-              Activity logs coming soon
-            </h3>
-            <p className={`text-[11px] ${t.textMuted} mt-1 max-w-md mx-auto`}>
-              Auth events, admin actions, and case modifications will surface
-              here once we settle on what to capture.
-            </p>
-          </div>
+          <Tabs defaultValue="admin-actions" className="space-y-3">
+            <TabsList>
+              <TabsTrigger value="admin-actions">Admin Actions</TabsTrigger>
+              <TabsTrigger value="case-activity">Case Activity</TabsTrigger>
+            </TabsList>
+            <TabsContent value="admin-actions">
+              <AdminActivityLog entries={activity} />
+            </TabsContent>
+            <TabsContent value="case-activity">
+              <CaseActivityFeed entries={caseActivity} />
+            </TabsContent>
+          </Tabs>
         </TabsContent>
       </Tabs>
     </div>

--- a/src/components/admin/CaseActivityFeed.tsx
+++ b/src/components/admin/CaseActivityFeed.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { useTheme } from "next-themes";
+import { MessageSquare, Search, ExternalLink } from "lucide-react";
+import { themeClasses } from "@/lib/theme-classes";
+import { fmtDateTime } from "@/lib/formatters";
+
+export interface CaseActivityEntry {
+  id: string;
+  caseId: number;
+  caseName: string;
+  message: string;
+  createdBy: string | null;
+  createdAt: string;
+}
+
+// Recent edits across ALL cases (the case-scoped activity_log), shown to admins
+// as a firm-wide feed. Per-case history still lives on each case's detail view.
+export function CaseActivityFeed({
+  entries,
+}: {
+  entries: CaseActivityEntry[];
+}) {
+  const { resolvedTheme } = useTheme();
+  const dark = resolvedTheme === "dark";
+  const t = themeClasses(dark);
+  const [search, setSearch] = useState("");
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return entries;
+    return entries.filter(
+      (e) =>
+        e.message.toLowerCase().includes(q) ||
+        e.caseName.toLowerCase().includes(q) ||
+        (e.createdBy ?? "").toLowerCase().includes(q),
+    );
+  }, [entries, search]);
+
+  const sectionCard = `rounded-xl border ${t.card}`;
+
+  if (entries.length === 0) {
+    return (
+      <div className={`${sectionCard} p-8 text-center`}>
+        <div
+          className={`mx-auto w-10 h-10 rounded-lg flex items-center justify-center ${dark ? "bg-neutral-800" : "bg-neutral-100"}`}
+        >
+          <MessageSquare className={`h-5 w-5 ${t.textMuted}`} />
+        </div>
+        <h3 className={`text-sm font-semibold mt-3 ${t.text}`}>
+          No case activity yet
+        </h3>
+        <p className={`text-[11px] ${t.textMuted} mt-1 max-w-md mx-auto`}>
+          Edits to cases (fees, status, notes, assignments) will appear here.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`${sectionCard} overflow-hidden`}>
+      <div
+        className={`flex items-center justify-between gap-3 px-4 py-3 border-b ${t.borderLight}`}
+      >
+        <h3 className={`text-xs font-bold ${t.text}`}>
+          Case Activity
+          <span className={`ml-1.5 font-normal ${t.textMuted}`}>
+            ({entries.length})
+          </span>
+        </h3>
+        <div className="relative">
+          <Search
+            className={`absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 ${t.textMuted}`}
+            aria-hidden="true"
+          />
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search case, note, agent…"
+            className={`h-8 w-52 pl-8 pr-3 rounded-md border text-xs outline-none ${t.inputBg}`}
+          />
+        </div>
+      </div>
+
+      {filtered.length === 0 ? (
+        <p className={`text-xs ${t.textMuted} text-center py-10`}>
+          No entries match “{search}”.
+        </p>
+      ) : (
+        <ul className="divide-y divide-current/5">
+          {filtered.map((e) => (
+            <li
+              key={e.id}
+              className={`px-4 py-2.5 ${dark ? "hover:bg-neutral-800/30" : "hover:bg-neutral-50"}`}
+            >
+              <div className="flex items-center gap-2">
+                <Link
+                  href={`/cases/${e.caseId}`}
+                  className={`inline-flex items-center gap-1 text-[11px] font-semibold hover:underline ${dark ? "text-blue-400" : "text-blue-600"}`}
+                >
+                  {e.caseName}
+                  <ExternalLink className="h-2.5 w-2.5" aria-hidden="true" />
+                </Link>
+              </div>
+              <div className="select-text">
+                <p className={`text-[12px] ${t.text} mt-0.5 break-words`}>
+                  {e.message}
+                </p>
+                <p className={`text-[10px] ${t.textMuted} mt-0.5`}>
+                  {e.createdBy ?? "System"} · {fmtDateTime(e.createdAt)}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/lib/admin-activity.ts
+++ b/src/lib/admin-activity.ts
@@ -1,0 +1,46 @@
+import "server-only";
+import { db } from "@/lib/db";
+import { adminActivityLog } from "@/lib/db/schema";
+
+// Action keys for the admin audit trail. Keep these stable — they're stored in
+// the DB and used to pick the badge/label in the UI.
+export type AdminAction =
+  | "user.create"
+  | "user.role_change"
+  | "user.activate"
+  | "user.deactivate"
+  | "user.password_reset"
+  | "user.access_update";
+
+export interface AdminActor {
+  id: number | null;
+  email: string | null;
+}
+
+/**
+ * Append an entry to the admin audit trail. Best-effort: a logging failure
+ * must never break the admin action that triggered it, so errors are swallowed
+ * (and logged to the server console).
+ */
+export async function logAdminActivity(entry: {
+  actor: AdminActor;
+  action: AdminAction;
+  targetUserId?: number | null;
+  targetEmail?: string | null;
+  summary: string;
+  metadata?: Record<string, unknown>;
+}): Promise<void> {
+  try {
+    await db.insert(adminActivityLog).values({
+      actorId: entry.actor.id,
+      actorEmail: entry.actor.email,
+      action: entry.action,
+      targetUserId: entry.targetUserId ?? null,
+      targetEmail: entry.targetEmail ?? null,
+      summary: entry.summary,
+      metadata: entry.metadata ?? null,
+    });
+  } catch (err) {
+    console.error("logAdminActivity error:", err);
+  }
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -743,6 +743,32 @@ export const userAccessOverrides = pgTable("user_access_overrides", {
     .defaultNow(),
 });
 
+// Audit trail of admin actions (user create, role/active changes, password
+// resets, access-override edits). Actor/target ids use ON DELETE SET NULL and
+// we snapshot emails so the log stays readable even after an account is
+// removed. `metadata` holds optional structured detail (e.g. role from→to).
+export const adminActivityLog = pgTable(
+  "admin_activity_log",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    actorId: integer("actor_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    actorEmail: varchar("actor_email", { length: 255 }),
+    action: varchar("action", { length: 50 }).notNull(),
+    targetUserId: integer("target_user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    targetEmail: varchar("target_email", { length: 255 }),
+    summary: text("summary").notNull(),
+    metadata: jsonb("metadata"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [index("idx_admin_activity_created_at").on(table.createdAt)],
+);
+
 // ============================================================================
 // RELATIONS
 // ============================================================================


### PR DESCRIPTION
Adds an audit trail of admin actions and surfaces it (plus recent case edits) on the /admin Activity Logs tab.

- New admin_activity_log table + migration 0020 (actor/target FKs ON DELETE SET NULL, snapshotted emails, action key, summary, metadata).
- logAdminActivity helper (best-effort; never breaks the action).
- All 5 admin server actions log on success: create, role change, activate/deactivate, password reset (password never logged), access override edits. Failures/early-returns don't log.
- Activity Logs tab split into sub-tabs: "Admin Actions" (admin_activity_log) and "Case Activity" (firm-wide recent activity_log edits, linked to each case).
- resetUserPassword now returns "User not found" for a missing target (came with adding the email lookup).