### PR TITLE
feat: filters for admin activity logs (user + date)

### DIFF
--- a/src/app/(dashboard)/admin/page.tsx
+++ b/src/app/(dashboard)/admin/page.tsx
@@ -69,7 +69,7 @@ export default async function AdminRoute() {
     })
     .from(adminActivityLog)
     .orderBy(desc(adminActivityLog.createdAt))
-    .limit(100);
+    .limit(300);
 
   const activity: AdminActivityEntry[] = logRows.map((r) => ({
     id: r.id,
@@ -95,7 +95,7 @@ export default async function AdminRoute() {
     .from(activityLog)
     .leftJoin(cases, eq(cases.clientId, activityLog.caseId))
     .orderBy(desc(activityLog.createdAt))
-    .limit(100);
+    .limit(300);
 
   const caseActivity: CaseActivityEntry[] = caseLogRows.map((r) => ({
     id: r.id,

--- a/src/components/admin/AdminActivityLog.tsx
+++ b/src/components/admin/AdminActivityLog.tsx
@@ -2,9 +2,14 @@
 
 import { useMemo, useState } from "react";
 import { useTheme } from "next-themes";
-import { Activity, Search } from "lucide-react";
+import { Activity } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
 import { fmtDateTime } from "@/lib/formatters";
+import {
+  ActivityFilterBar,
+  defaultActivityFilters,
+  matchesActivityFilters,
+} from "./activity-filters";
 
 export interface AdminActivityEntry {
   id: string;
@@ -52,18 +57,37 @@ export function AdminActivityLog({ entries }: { entries: AdminActivityEntry[] })
   const { resolvedTheme } = useTheme();
   const dark = resolvedTheme === "dark";
   const t = themeClasses(dark);
-  const [search, setSearch] = useState("");
+  const [filters, setFilters] = useState(() =>
+    defaultActivityFilters(entries[0]?.createdAt),
+  );
 
-  const filtered = useMemo(() => {
-    const q = search.trim().toLowerCase();
-    if (!q) return entries;
-    return entries.filter(
-      (e) =>
-        e.summary.toLowerCase().includes(q) ||
-        (e.actorEmail ?? "").toLowerCase().includes(q) ||
-        (e.targetEmail ?? "").toLowerCase().includes(q),
-    );
-  }, [entries, search]);
+  // Distinct actors + years for the dropdowns (newest year first).
+  const users = useMemo(
+    () =>
+      Array.from(
+        new Set(entries.map((e) => e.actorEmail).filter((v): v is string => !!v)),
+      ).sort(),
+    [entries],
+  );
+  const years = useMemo(
+    () =>
+      Array.from(
+        new Set(entries.map((e) => new Date(e.createdAt).getFullYear())),
+      ).sort((a, b) => b - a),
+    [entries],
+  );
+
+  const filtered = useMemo(
+    () =>
+      entries.filter((e) =>
+        matchesActivityFilters(filters, {
+          user: e.actorEmail,
+          createdAt: e.createdAt,
+          haystack: `${e.summary} ${e.actorEmail ?? ""} ${e.targetEmail ?? ""}`,
+        }),
+      ),
+    [entries, filters],
+  );
 
   const sectionCard = `rounded-xl border ${t.card}`;
 
@@ -88,32 +112,27 @@ export function AdminActivityLog({ entries }: { entries: AdminActivityEntry[] })
 
   return (
     <div className={`${sectionCard} overflow-hidden`}>
-      <div
-        className={`flex items-center justify-between gap-3 px-4 py-3 border-b ${t.borderLight}`}
-      >
+      <div className={`px-4 py-3 border-b ${t.borderLight} space-y-2`}>
         <h3 className={`text-xs font-bold ${t.text}`}>
           Activity Log
           <span className={`ml-1.5 font-normal ${t.textMuted}`}>
-            ({entries.length})
+            ({filtered.length}
+            {filtered.length !== entries.length ? ` of ${entries.length}` : ""})
           </span>
         </h3>
-        <div className="relative">
-          <Search
-            className={`absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 ${t.textMuted}`}
-            aria-hidden="true"
-          />
-          <input
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder="Search activity…"
-            className={`h-8 w-48 pl-8 pr-3 rounded-md border text-xs outline-none ${t.inputBg}`}
-          />
-        </div>
+        <ActivityFilterBar
+          dark={dark}
+          users={users}
+          years={years}
+          state={filters}
+          onChange={setFilters}
+          searchPlaceholder="Search summary, actor, target…"
+        />
       </div>
 
       {filtered.length === 0 ? (
         <p className={`text-xs ${t.textMuted} text-center py-10`}>
-          No entries match “{search}”.
+          No entries match the current filters.
         </p>
       ) : (
         <ul className="divide-y divide-current/5">

--- a/src/components/admin/CaseActivityFeed.tsx
+++ b/src/components/admin/CaseActivityFeed.tsx
@@ -3,9 +3,14 @@
 import { useMemo, useState } from "react";
 import Link from "next/link";
 import { useTheme } from "next-themes";
-import { MessageSquare, Search, ExternalLink } from "lucide-react";
+import { MessageSquare, ExternalLink } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
 import { fmtDateTime } from "@/lib/formatters";
+import {
+  ActivityFilterBar,
+  defaultActivityFilters,
+  matchesActivityFilters,
+} from "./activity-filters";
 
 export interface CaseActivityEntry {
   id: string;
@@ -26,18 +31,37 @@ export function CaseActivityFeed({
   const { resolvedTheme } = useTheme();
   const dark = resolvedTheme === "dark";
   const t = themeClasses(dark);
-  const [search, setSearch] = useState("");
+  const [filters, setFilters] = useState(() =>
+    defaultActivityFilters(entries[0]?.createdAt),
+  );
 
-  const filtered = useMemo(() => {
-    const q = search.trim().toLowerCase();
-    if (!q) return entries;
-    return entries.filter(
-      (e) =>
-        e.message.toLowerCase().includes(q) ||
-        e.caseName.toLowerCase().includes(q) ||
-        (e.createdBy ?? "").toLowerCase().includes(q),
-    );
-  }, [entries, search]);
+  // Distinct authors (agents) + years for the dropdowns.
+  const users = useMemo(
+    () =>
+      Array.from(
+        new Set(entries.map((e) => e.createdBy).filter((v): v is string => !!v)),
+      ).sort(),
+    [entries],
+  );
+  const years = useMemo(
+    () =>
+      Array.from(
+        new Set(entries.map((e) => new Date(e.createdAt).getFullYear())),
+      ).sort((a, b) => b - a),
+    [entries],
+  );
+
+  const filtered = useMemo(
+    () =>
+      entries.filter((e) =>
+        matchesActivityFilters(filters, {
+          user: e.createdBy,
+          createdAt: e.createdAt,
+          haystack: `${e.message} ${e.caseName} ${e.createdBy ?? ""}`,
+        }),
+      ),
+    [entries, filters],
+  );
 
   const sectionCard = `rounded-xl border ${t.card}`;
 
@@ -61,32 +85,27 @@ export function CaseActivityFeed({
 
   return (
     <div className={`${sectionCard} overflow-hidden`}>
-      <div
-        className={`flex items-center justify-between gap-3 px-4 py-3 border-b ${t.borderLight}`}
-      >
+      <div className={`px-4 py-3 border-b ${t.borderLight} space-y-2`}>
         <h3 className={`text-xs font-bold ${t.text}`}>
           Case Activity
           <span className={`ml-1.5 font-normal ${t.textMuted}`}>
-            ({entries.length})
+            ({filtered.length}
+            {filtered.length !== entries.length ? ` of ${entries.length}` : ""})
           </span>
         </h3>
-        <div className="relative">
-          <Search
-            className={`absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 ${t.textMuted}`}
-            aria-hidden="true"
-          />
-          <input
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder="Search case, note, agent…"
-            className={`h-8 w-52 pl-8 pr-3 rounded-md border text-xs outline-none ${t.inputBg}`}
-          />
-        </div>
+        <ActivityFilterBar
+          dark={dark}
+          users={users}
+          years={years}
+          state={filters}
+          onChange={setFilters}
+          searchPlaceholder="Search case, note, agent…"
+        />
       </div>
 
       {filtered.length === 0 ? (
         <p className={`text-xs ${t.textMuted} text-center py-10`}>
-          No entries match “{search}”.
+          No entries match the current filters.
         </p>
       ) : (
         <ul className="divide-y divide-current/5">

--- a/src/components/admin/activity-filters.tsx
+++ b/src/components/admin/activity-filters.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { themeClasses } from "@/lib/theme-classes";
+
+// Shared filter model + UI for the admin Activity Logs sub-tabs. Both feeds
+// filter client-side over the rows the server already sent (capped), so this
+// stays a pure, instant transform — no refetch.
+
+export type DateMode = "all" | "month" | "day" | "range";
+
+export interface ActivityFilterState {
+  search: string;
+  user: string; // "all" or a specific actor/author value
+  dateMode: DateMode;
+  month: number; // 0-11
+  year: number;
+  day: string; // YYYY-MM-DD
+  from: string; // YYYY-MM-DD
+  to: string; // YYYY-MM-DD
+}
+
+const MONTHS = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+/** Default state — date filtering off; month/year seeded from the newest row
+ *  (deterministic from props, so no SSR/client hydration mismatch). */
+export function defaultActivityFilters(
+  newestIso?: string,
+): ActivityFilterState {
+  const d = newestIso ? new Date(newestIso) : null;
+  return {
+    search: "",
+    user: "all",
+    dateMode: "all",
+    month: d ? d.getMonth() : 0,
+    year: d ? d.getFullYear() : new Date().getFullYear(),
+    day: "",
+    from: "",
+    to: "",
+  };
+}
+
+// Local-time YYYY-MM-DD for an ISO timestamp, to compare against <input
+// type="date"> values (which the user picks in local time).
+const localDate = (iso: string): string => {
+  const d = new Date(iso);
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${d.getFullYear()}-${m}-${day}`;
+};
+
+/** True if the entry passes the active search / user / date filters. */
+export function matchesActivityFilters(
+  f: ActivityFilterState,
+  entry: { user: string | null; createdAt: string; haystack: string },
+): boolean {
+  const q = f.search.trim().toLowerCase();
+  if (q && !entry.haystack.toLowerCase().includes(q)) return false;
+
+  if (f.user !== "all" && (entry.user ?? "") !== f.user) return false;
+
+  if (f.dateMode === "all") return true;
+  if (f.dateMode === "month") {
+    const d = new Date(entry.createdAt);
+    return d.getFullYear() === f.year && d.getMonth() === f.month;
+  }
+  const ds = localDate(entry.createdAt);
+  if (f.dateMode === "day") return !f.day || ds === f.day;
+  if (f.dateMode === "range") {
+    if (f.from && ds < f.from) return false;
+    if (f.to && ds > f.to) return false;
+    return true;
+  }
+  return true;
+}
+
+export function ActivityFilterBar({
+  dark,
+  users,
+  years,
+  state,
+  onChange,
+  searchPlaceholder = "Search…",
+}: {
+  dark: boolean;
+  users: string[];
+  years: number[];
+  state: ActivityFilterState;
+  onChange: (next: ActivityFilterState) => void;
+  searchPlaceholder?: string;
+}) {
+  const t = themeClasses(dark);
+  const ctl = `h-8 px-2 rounded-md border text-xs outline-none ${t.inputBg}`;
+  const set = (patch: Partial<ActivityFilterState>) =>
+    onChange({ ...state, ...patch });
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <input
+        value={state.search}
+        onChange={(e) => set({ search: e.target.value })}
+        placeholder={searchPlaceholder}
+        className={`${ctl} flex-1 min-w-40`}
+      />
+
+      <select
+        value={state.user}
+        onChange={(e) => set({ user: e.target.value })}
+        className={`${ctl} cursor-pointer`}
+        aria-label="Filter by user"
+      >
+        <option value="all">All users</option>
+        {users.map((u) => (
+          <option key={u} value={u}>
+            {u}
+          </option>
+        ))}
+      </select>
+
+      <select
+        value={state.dateMode}
+        onChange={(e) => set({ dateMode: e.target.value as DateMode })}
+        className={`${ctl} cursor-pointer`}
+        aria-label="Date filter mode"
+      >
+        <option value="all">All dates</option>
+        <option value="month">Month</option>
+        <option value="day">Specific day</option>
+        <option value="range">Date range</option>
+      </select>
+
+      {state.dateMode === "month" && (
+        <>
+          <select
+            value={state.month}
+            onChange={(e) => set({ month: Number(e.target.value) })}
+            className={`${ctl} cursor-pointer`}
+            aria-label="Month"
+          >
+            {MONTHS.map((m, i) => (
+              <option key={m} value={i}>
+                {m}
+              </option>
+            ))}
+          </select>
+          <select
+            value={state.year}
+            onChange={(e) => set({ year: Number(e.target.value) })}
+            className={`${ctl} cursor-pointer`}
+            aria-label="Year"
+          >
+            {years.map((y) => (
+              <option key={y} value={y}>
+                {y}
+              </option>
+            ))}
+          </select>
+        </>
+      )}
+
+      {state.dateMode === "day" && (
+        <input
+          type="date"
+          value={state.day}
+          onChange={(e) => set({ day: e.target.value })}
+          className={`${ctl} cursor-pointer`}
+          aria-label="Day"
+        />
+      )}
+
+      {state.dateMode === "range" && (
+        <>
+          <input
+            type="date"
+            value={state.from}
+            onChange={(e) => set({ from: e.target.value })}
+            className={`${ctl} cursor-pointer`}
+            aria-label="From date"
+          />
+          <span className={`text-[11px] ${t.textMuted}`}>to</span>
+          <input
+            type="date"
+            value={state.to}
+            onChange={(e) => set({ to: e.target.value })}
+            className={`${ctl} cursor-pointer`}
+            aria-label="To date"
+          />
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Add a shared filter bar to both Activity Logs sub-tabs:
- User dropdown — Admin Actions filters by actor, Case Activity by author/agent (auto-populated from the loaded rows).
- Date filter with mode switch: Month + Year, specific day, or date range; plus free-text search.
- Header shows "(filtered of total)" when a filter is active.

Filtering is client-side (pure, instant) over the loaded rows; raised the server fetch cap 100 -> 300 so the date/user filters have a useful window. Date comparisons use local time to match the pickers and the displayed timestamps.