### PR TITLE
fix: correct out-of-order migration timestamp for 0021_case_archive

### DIFF
--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -152,7 +152,7 @@
     {
       "idx": 21,
       "version": "7",
-      "when": 1781625209544,
+      "when": 1781634000000,
       "tag": "0021_case_archive",
       "breakpoints": true
     },


### PR DESCRIPTION
## Problem

`0021_case_archive` had a `when` timestamp (`1781625209544`) earlier than `0020_elite_silk_fever` (`1781630742397`). This happened because the migration was originally numbered 0020, then renumbered to 0021 after the admin-activity-logs merge, but kept its original timestamp.

Drizzle's migrator uses a single timestamp comparison to decide what to run:

```js
// gets the last applied migration by created_at DESC
select ... from __drizzle_migrations order by created_at desc limit 1

// skips any migration whose folderMillis ≤ that value
if (Number(lastDbMigration.created_at) < migration.folderMillis)
```

On any database at migration state ≤ 0020, this caused:
1. 0020 applies → last `created_at` = `1781630742397`
2. 0021 checked: `1781630742397 < 1781625209544` → **false** → **0021 skipped**
3. 0022 runs `ALTER TABLE "case_archive" ADD COLUMN ...` on a table that doesn't exist → **500 error**

## Fix

Corrected `when` for idx 21 from `1781625209544` to `1781634000000` — a value squarely between 0020 (`1781630742397`) and 0022 (`1781639172443`). No SQL files or snapshot content were changed; hashes are unaffected.

## Impact

- Databases already fully migrated (dev): unaffected — last `created_at` is 0022's timestamp, no migrations re-run
- Production (at state 0013): `db:migrate` will now correctly apply 0021 then 0022 in order