### PR TITLE
fix: rename UI labels per Ms. Jazz feedback

### DIFF
--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -824,7 +824,7 @@ export const FeeRecordsTable = ({
                     Approval <ArrowUpDown className="h-3 w-3" />
                   </span>
                 </th>
-                <th className={`${thBase} ${t.textSub} text-left`}>Status</th>
+                <th className={`${thBase} ${t.textSub} text-left`}>Win Sheet Status</th>
                 <th className={`${thBase} ${t.textSub} text-left`}>
                   Win Sheet
                 </th>
@@ -910,7 +910,7 @@ export const FeeRecordsTable = ({
                   Fees Conf
                 </th>
                 <th className={`${thBase} ${t.textSub} text-left`}>
-                  Case Status
+                  Remarks
                 </th>
                 <th className={`${thBase} ${t.textSub} text-left`}>
                   Recent Update
@@ -1478,7 +1478,7 @@ export const FeeRecordsTable = ({
                         </select>
                       )}
                     </td>
-                    {/* Case Status */}
+                    {/* Remarks */}
                     <td
                       className={`${tdBase} ${t.textSub}`}
                       onClick={(e) => e.stopPropagation()}
@@ -1495,7 +1495,7 @@ export const FeeRecordsTable = ({
                               "fee",
                               "caseStatus",
                               "caseStatus",
-                              "Case Status",
+                              "Remarks",
                               e.target.value,
                             )
                           }

--- a/src/components/overpaid-cases/OverpaidCases.tsx
+++ b/src/components/overpaid-cases/OverpaidCases.tsx
@@ -680,7 +680,7 @@ export const OverpaidCases = () => {
         const json = await res.json();
         all = json.data || [];
       }
-      const headers = ["Case", "Assigned To", "Region", "Fees Received", "Overpaid Amount", "Fees Confirmation", "O/P Ltr Date", "O/P LTR Date Received", "Notes", "Checks Cleared", "Last Updated"];
+      const headers = ["Case", "Assigned To", "Region", "Fees Received", "Overpaid Amount", "Fees Confirmation", "Notice Sent", "Notice Received", "Notes", "Checks Cleared", "Last Updated"];
       const escape = (v: string) => {
         const safe = /^[=+\-@\t\r]/.test(v) ? `'${v}` : v;
         return `"${safe.replace(/"/g, '""')}"`;
@@ -1183,7 +1183,7 @@ export const OverpaidCases = () => {
                   </button>
                 </th>
                 <th className={`${thBase} ${t.textSub} text-left sticky top-0 z-20 ${stickyHeaderBg}`}>Fees Confirmation</th>
-                <th className={`${thBase} ${t.textSub} text-left sticky top-0 z-20 ${stickyHeaderBg}`}>O/P Ltr Date</th>
+                <th className={`${thBase} ${t.textSub} text-left sticky top-0 z-20 ${stickyHeaderBg}`}>Notice Sent</th>
                 <th
                   aria-sort={ariaSortFor("opLtrDate")}
                   className={`${thBase} ${t.textSub} text-left sticky top-0 z-20 ${stickyHeaderBg}`}
@@ -1193,7 +1193,7 @@ export const OverpaidCases = () => {
                     onClick={() => toggleSort("opLtrDate")}
                     className="inline-flex items-center gap-1 cursor-pointer rounded-sm focus:outline-none focus:ring-2 focus:ring-inset focus:ring-neutral-300 dark:focus:ring-neutral-600"
                   >
-                    O/P LTR Date Received {sortIcon("opLtrDate")}
+                    Notice Received {sortIcon("opLtrDate")}
                   </button>
                 </th>
                 <th className={`${thBase} ${t.textSub} text-left min-w-48 sticky top-0 z-20 ${stickyHeaderBg}`}>Notes</th>

--- a/src/lib/dropdown-categories.ts
+++ b/src/lib/dropdown-categories.ts
@@ -11,7 +11,7 @@ export const DROPDOWN_CATEGORIES = [
   { key: "claim_type", label: "Claim Type", description: "Benefit type for the claim (T2, T16, CONC, etc.)." },
   { key: "win_sheet_status", label: "Win Sheet Status", description: "Win-sheet progress states." },
   { key: "fees_confirmation", label: "Fees Confirmation", description: "Final fee disposition labels." },
-  { key: "case_status", label: "Case Status", description: "Workflow status shown in the dashboard." },
+  { key: "case_status", label: "Remarks", description: "Remarks/status notes shown in the dashboard." },
   { key: "team", label: "Team", description: "Team groupings for scoreboard tracking (e.g. T2, T16, Concurrent)." },
 ] as const;
 


### PR DESCRIPTION
## Summary

Renames four user-facing labels per Ms. Jazz's post-testing feedback:

- **Fee Records table** — `Status` column header → `Win Sheet Status`
- **Fee Records table** — `Case Status` column header → `Remarks`
- **Overpaid Cases table** — `O/P Ltr Date` column header → `Notice Sent`
- **Overpaid Cases table** — `O/P LTR Date Received` column header → `Notice Received`

The `Remarks` rename is also applied to the activity log label and the Settings → Dropdown Options sub-tab label (`case_status` category).

No schema, API, or logic changes — UI label strings only.