### PR TITLE
feat: fee petitions bulk close to Fees Closed

### DIFF
--- a/src/app/api/fee-petitions/route.ts
+++ b/src/app/api/fee-petitions/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
-import { cases, feePetitions } from "@/lib/db/schema";
+import { cases, feePetitions, feeRecords } from "@/lib/db/schema";
 import { eq, ilike, sql } from "drizzle-orm";
 
 const SORT_KEYS = ["claimant", "approvalDate", "updatedAt", "progress"] as const;
@@ -77,8 +77,9 @@ export const GET = async (req: NextRequest) => {
 
     // Accept both the legacy enum value and the worksheet-direct label
     // saved via the dashboard dropdown (column C in the master sheet uses
-    // "FEE PETITION" with a space).
+    // "FEE PETITION" with a space). Exclude cases already closed to Fees Closed.
     const whereClause = sql`${cases.levelWon} IN ('FEE_PETITION', 'FEE PETITION')
+      AND (${feeRecords.isClosed} IS NULL OR ${feeRecords.isClosed} = false)
       ${searchClause}
       ${statusClause}
       ${touchedClause}
@@ -94,6 +95,7 @@ export const GET = async (req: NextRequest) => {
       })
       .from(cases)
       .leftJoin(feePetitions, eq(feePetitions.caseId, cases.clientId))
+      .leftJoin(feeRecords, eq(feeRecords.caseId, cases.clientId))
       .where(whereClause);
 
     const total = agg?.total ?? 0;
@@ -128,6 +130,7 @@ export const GET = async (req: NextRequest) => {
       })
       .from(cases)
       .leftJoin(feePetitions, eq(feePetitions.caseId, cases.clientId))
+      .leftJoin(feeRecords, eq(feeRecords.caseId, cases.clientId))
       .where(whereClause)
       .orderBy(orderClause)
       .limit(limit)

--- a/src/components/fee-petitions/FeePetitions.tsx
+++ b/src/components/fee-petitions/FeePetitions.tsx
@@ -18,10 +18,12 @@ import {
   Download,
   X,
   Undo2,
+  ArchiveX,
 } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
 import { fmtDate } from "@/lib/formatters";
 import { upsertFeePetition, bulkMarkComplete, bulkRestoreChecklists } from "@/app/(dashboard)/fee-petitions/actions";
+import { useCapabilities } from "@/hooks/useCapabilities";
 
 // ---------- types ----------
 interface FeePetitionRow {
@@ -157,7 +159,12 @@ export const FeePetitions = () => {
     expiresAt: number;
   } | null>(null);
   const [undoing, setUndoing] = useState(false);
+  const [bulkCloseConfirming, setBulkCloseConfirming] = useState(false);
+  const [bulkClosing, setBulkClosing] = useState(false);
   const selectAllRef = useRef<HTMLInputElement>(null);
+
+  const { can } = useCapabilities();
+  const canFinalize = can("case.finalize");
 
   const urlMethodRef = useRef<"push" | "replace">("replace");
 
@@ -237,6 +244,11 @@ export const FeePetitions = () => {
   }, [search]);
 
   const fetchAbortRef = useRef<AbortController | null>(null);
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => { mountedRef.current = false; };
+  }, []);
 
   const fetchPetitions = useCallback(async () => {
     fetchAbortRef.current?.abort();
@@ -265,6 +277,7 @@ export const FeePetitions = () => {
       setRows(data);
       setSelectedIds(new Set());
       setBulkConfirming(false);
+      setBulkCloseConfirming(false);
       setTotal(typeof json.total === "number" ? json.total : data.length);
       setStats({
         completeCount: typeof json.completeCount === "number" ? json.completeCount : 0,
@@ -313,6 +326,7 @@ export const FeePetitions = () => {
   const clearSelection = () => {
     setSelectedIds(new Set());
     setBulkConfirming(false);
+    setBulkCloseConfirming(false);
   };
 
   const toggleSelectAll = () => {
@@ -443,6 +457,49 @@ export const FeePetitions = () => {
   const ariaSortFor = (key: SortKey): "ascending" | "descending" | "none" => {
     if (sortKey !== key) return "none";
     return sortDir === "asc" ? "ascending" : "descending";
+  };
+
+  const handleBulkClosePetitions = async () => {
+    if (bulkClosing) return;
+    setBulkClosing(true);
+    const ids = [...selectedIds];
+    const closingRows = rows.filter((r) => ids.includes(r.id));
+    const closingComplete = closingRows.filter((r) => CHECKBOX_COLUMNS.every((c) => r[c.key])).length;
+    const closingIncomplete = closingRows.length - closingComplete;
+    try {
+      await Promise.all(
+        ids.map((id) =>
+          fetch(`/api/cases/${id}`, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              feeFields: { isClosed: true },
+              logMessage: "Fee petition complete — case moved to Fees Closed.",
+            }),
+          }).then(async (res) => {
+            if (!res.ok) {
+              const j = await res.json().catch(() => ({}));
+              throw new Error(j.error || `Failed to close case ${id} (${res.status})`);
+            }
+          }),
+        ),
+      );
+      if (!mountedRef.current) return;
+      setRows((prev) => prev.filter((r) => !ids.includes(r.id)));
+      setTotal((t) => Math.max(0, t - ids.length));
+      setStats((s) => ({
+        ...s,
+        completeCount: Math.max(0, s.completeCount - closingComplete),
+        incompleteCount: Math.max(0, s.incompleteCount - closingIncomplete),
+      }));
+      setSelectedIds(new Set());
+      setBulkCloseConfirming(false);
+    } catch (err) {
+      if (!mountedRef.current) return;
+      setError((err as Error).message);
+    } finally {
+      if (mountedRef.current) setBulkClosing(false);
+    }
   };
 
   const sortIcon = (key: SortKey) => {
@@ -725,6 +782,29 @@ export const FeePetitions = () => {
                       Cancel
                     </button>
                   </>
+                ) : bulkCloseConfirming ? (
+                  <>
+                    <span className={`text-sm ${t.textMuted}`}>
+                      Close {selectedIds.size} case{selectedIds.size !== 1 ? "s" : ""} to Fees Closed?
+                    </span>
+                    <button
+                      onClick={handleBulkClosePetitions}
+                      disabled={bulkClosing}
+                      className={`h-7 px-3 rounded-md text-xs font-medium flex items-center gap-1.5 ${dark ? "bg-indigo-700 hover:bg-indigo-600 text-white" : "bg-indigo-600 hover:bg-indigo-700 text-white"} disabled:opacity-40 disabled:cursor-not-allowed transition-colors`}
+                    >
+                      {bulkClosing
+                        ? <Loader2 aria-hidden="true" className="h-3 w-3 animate-spin" />
+                        : <ArchiveX aria-hidden="true" className="h-3 w-3" />}
+                      Confirm
+                    </button>
+                    <button
+                      onClick={() => setBulkCloseConfirming(false)}
+                      disabled={bulkClosing}
+                      className={`h-7 px-3 rounded-md border text-xs font-medium ${t.outlineBtn} disabled:opacity-40`}
+                    >
+                      Cancel
+                    </button>
+                  </>
                 ) : (
                   <>
                     <span className={`text-sm font-bold ${t.text}`}>
@@ -745,6 +825,16 @@ export const FeePetitions = () => {
                       <Check aria-hidden="true" className="h-3 w-3" />
                       Mark Complete
                     </button>
+                    {canFinalize && (
+                      <button
+                        onClick={() => setBulkCloseConfirming(true)}
+                        aria-label="Move selected cases to Fees Closed"
+                        className={`h-7 px-3 rounded-md border text-xs font-medium flex items-center gap-1.5 ${t.outlineBtn} transition-colors`}
+                      >
+                        <ArchiveX aria-hidden="true" className="h-3 w-3" />
+                        Close to Fees Closed
+                      </button>
+                    )}
                     <button
                       onClick={clearSelection}
                       aria-label="Clear selection"

--- a/src/components/fee-petitions/FeePetitions.tsx
+++ b/src/components/fee-petitions/FeePetitions.tsx
@@ -244,10 +244,14 @@ export const FeePetitions = () => {
   }, [search]);
 
   const fetchAbortRef = useRef<AbortController | null>(null);
+  const bulkCloseAbortRef = useRef<AbortController | null>(null);
   const mountedRef = useRef(true);
   useEffect(() => {
     mountedRef.current = true;
-    return () => { mountedRef.current = false; };
+    return () => {
+      mountedRef.current = false;
+      bulkCloseAbortRef.current?.abort();
+    };
   }, []);
 
   const fetchPetitions = useCallback(async () => {
@@ -464,6 +468,8 @@ export const FeePetitions = () => {
     setBulkClosing(true);
     const ids = [...selectedIds];
     const closingRows = rows.filter((r) => ids.includes(r.id));
+    const controller = new AbortController();
+    bulkCloseAbortRef.current = controller;
     try {
       const results = await Promise.allSettled(
         ids.map((id) =>
@@ -474,6 +480,7 @@ export const FeePetitions = () => {
               feeFields: { isClosed: true },
               logMessage: "Fee petition complete — case moved to Fees Closed.",
             }),
+            signal: controller.signal,
           }).then(async (res) => {
             if (!res.ok) {
               const j = await res.json().catch(() => ({}));

--- a/src/components/fee-petitions/FeePetitions.tsx
+++ b/src/components/fee-petitions/FeePetitions.tsx
@@ -464,10 +464,8 @@ export const FeePetitions = () => {
     setBulkClosing(true);
     const ids = [...selectedIds];
     const closingRows = rows.filter((r) => ids.includes(r.id));
-    const closingComplete = closingRows.filter((r) => CHECKBOX_COLUMNS.every((c) => r[c.key])).length;
-    const closingIncomplete = closingRows.length - closingComplete;
     try {
-      await Promise.all(
+      const results = await Promise.allSettled(
         ids.map((id) =>
           fetch(`/api/cases/${id}`, {
             method: "PATCH",
@@ -481,22 +479,41 @@ export const FeePetitions = () => {
               const j = await res.json().catch(() => ({}));
               throw new Error(j.error || `Failed to close case ${id} (${res.status})`);
             }
+            return id;
           }),
         ),
       );
+
       if (!mountedRef.current) return;
-      setRows((prev) => prev.filter((r) => !ids.includes(r.id)));
-      setTotal((t) => Math.max(0, t - ids.length));
-      setStats((s) => ({
-        ...s,
-        completeCount: Math.max(0, s.completeCount - closingComplete),
-        incompleteCount: Math.max(0, s.incompleteCount - closingIncomplete),
-      }));
+
+      const succeeded = results
+        .filter((r): r is PromiseFulfilledResult<number> => r.status === "fulfilled")
+        .map((r) => r.value);
+      const failures = results.filter((r): r is PromiseRejectedResult => r.status === "rejected");
+
+      if (succeeded.length > 0) {
+        const closedRows = closingRows.filter((r) => succeeded.includes(r.id));
+        const closedComplete = closedRows.filter((r) => CHECKBOX_COLUMNS.every((c) => r[c.key])).length;
+        const closedIncomplete = closedRows.length - closedComplete;
+        setRows((prev) => prev.filter((r) => !succeeded.includes(r.id)));
+        setTotal((t) => Math.max(0, t - succeeded.length));
+        setStats((s) => ({
+          ...s,
+          completeCount: Math.max(0, s.completeCount - closedComplete),
+          incompleteCount: Math.max(0, s.incompleteCount - closedIncomplete),
+        }));
+      }
+
       setSelectedIds(new Set());
       setBulkCloseConfirming(false);
-    } catch (err) {
-      if (!mountedRef.current) return;
-      setError((err as Error).message);
+
+      if (failures.length > 0) {
+        setError(
+          failures.length === 1
+            ? (failures[0].reason as Error).message
+            : `${failures.length} of ${ids.length} cases failed to close — the rest were moved successfully.`,
+        );
+      }
     } finally {
       if (mountedRef.current) setBulkClosing(false);
     }


### PR DESCRIPTION
## Summary

- Excludes already-closed cases from the fee petitions list via `LEFT JOIN fee_records` + `isClosed = false` filter on the API
- Replaces the per-row hover button with a **bulk close action** in the multi-select toolbar (lead+ only), matching the existing Mark Complete confirm-step pattern
- Mounted-ref guard prevents state updates after component unmount
- Stat cards (`completeCount` / `incompleteCount`) stay in sync after bulk close
- `clearSelection` and `fetchPetitions` both reset `bulkCloseConfirming` to prevent stale confirm state on re-selection