### PR TITLE
feat: scoreboard fees breakdown by claim type

### DIFF
--- a/src/app/api/scoreboard/route.ts
+++ b/src/app/api/scoreboard/route.ts
@@ -116,6 +116,23 @@ export const GET = async (req: NextRequest) => {
       ORDER BY tm.name
     `);
 
+    // Fees collected by claim type (all-time team snapshot)
+    const teamFeesResult = await db.execute(sql`
+      SELECT
+        COALESCE(SUM(CASE WHEN c.claim_type_label = 'T2' THEN fr.total_fees_paid::numeric ELSE 0 END), 0) AS t2_collected,
+        COALESCE(SUM(CASE WHEN c.claim_type_label = 'T16' THEN fr.total_fees_paid::numeric ELSE 0 END), 0) AS t16_collected,
+        COALESCE(SUM(CASE WHEN c.claim_type_label IN ('T2_T16', 'T2/T16') THEN fr.total_fees_paid::numeric ELSE 0 END), 0) AS conc_collected
+      FROM fee_records fr
+      JOIN cases c ON c.client_id = fr.case_id
+    `);
+    const teamFeesRow =
+      (teamFeesResult as Record<string, string | number>[])[0] ?? {};
+    const teamFees = {
+      t2: Number(teamFeesRow.t2_collected ?? 0),
+      t16: Number(teamFeesRow.t16_collected ?? 0),
+      conc: Number(teamFeesRow.conc_collected ?? 0),
+    };
+
     // Daily breakdown for the week (from daily_metrics)
     const dailyBreakdown = await db.execute(sql`
       SELECT
@@ -180,6 +197,7 @@ export const GET = async (req: NextRequest) => {
       summary,
       agents,
       daily,
+      teamFees,
     });
   } catch (error) {
     console.error("GET /api/scoreboard error:", error);

--- a/src/components/scoreboard/Scoreboard.tsx
+++ b/src/components/scoreboard/Scoreboard.tsx
@@ -63,11 +63,18 @@ interface DailyEntry {
   notes: string | null;
 }
 
+interface TeamFees {
+  t2: number;
+  t16: number;
+  conc: number;
+}
+
 interface ScoreboardData {
   week: string;
   summary: Summary;
   agents: AgentScore[];
   daily: DailyEntry[];
+  teamFees?: TeamFees;
 }
 
 // Cell value for the entry grid: [ssaCalls, clientCallsIb, clientCallsOb]
@@ -648,6 +655,43 @@ export const Scoreboard = () => {
                   </div>
                 ))}
               </div>
+
+              {/* Fees by claim type — all-time team snapshot */}
+              {data.teamFees && (
+                <div className={`p-4 border-b ${t.borderLight}`}>
+                  <p
+                    className={`text-[10px] font-semibold uppercase tracking-wider ${t.textMuted} mb-3`}
+                  >
+                    Fees by Claim Type
+                  </p>
+                  <div className="grid grid-cols-3 gap-3">
+                    {[
+                      { label: "T2 Collected", value: data.teamFees.t2 },
+                      { label: "T16 Collected", value: data.teamFees.t16 },
+                      {
+                        label: "Concurrent Collected",
+                        value: data.teamFees.conc,
+                      },
+                    ].map((item) => (
+                      <div
+                        key={item.label}
+                        className={`rounded-lg border p-3 ${t.card}`}
+                      >
+                        <p
+                          className={`text-[10px] font-medium ${t.textMuted} uppercase`}
+                        >
+                          {item.label}
+                        </p>
+                        <p
+                          className={`text-lg font-bold mt-1 ${item.value > 0 ? "text-emerald-500" : t.textMuted}`}
+                        >
+                          {item.value > 0 ? fmt(item.value) : "—"}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
 
               {/* Monitoring filters (client-side, current week) */}
               <div


### PR DESCRIPTION
## Summary

- Adds a **Fees by Claim Type** section to the scoreboard between the summary stat cards and the monitoring filters
- Three cards show all-time fees collected for T2, T16, and Concurrent cases
- New aggregate query in `/api/scoreboard` groups `total_fees_paid` by `claim_type_label`; result is returned as `teamFees` in the response