### PR TITLE
feat: dropdown option reordering in settings

### DIFF
--- a/src/components/settings/DropdownOptionsCard.tsx
+++ b/src/components/settings/DropdownOptionsCard.tsx
@@ -176,9 +176,14 @@ export function DropdownOptionsCard({ category, label, description }: Props) {
     const a = options[idx];
     const b = options[swapIdx];
 
+    // Use position-based sort_order values rather than swapping existing ones,
+    // so items that share sort_order=0 (e.g. newly added options) still move correctly.
+    const newOrderA = (swapIdx + 1) * 10;
+    const newOrderB = (idx + 1) * 10;
+
     const reordered = [...options];
-    reordered[idx] = b;
-    reordered[swapIdx] = a;
+    reordered[idx] = { ...b, sortOrder: newOrderB };
+    reordered[swapIdx] = { ...a, sortOrder: newOrderA };
     setOptions(reordered);
     setBusyId(id);
     setError(null);
@@ -190,7 +195,7 @@ export function DropdownOptionsCard({ category, label, description }: Props) {
         fetch(`/api/settings/dropdown-options/${a.id}`, {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ sortOrder: b.sortOrder }),
+          body: JSON.stringify({ sortOrder: newOrderA }),
           signal: controller.signal,
         }).then(async (res) => {
           if (!res.ok) {
@@ -201,7 +206,7 @@ export function DropdownOptionsCard({ category, label, description }: Props) {
         fetch(`/api/settings/dropdown-options/${b.id}`, {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ sortOrder: a.sortOrder }),
+          body: JSON.stringify({ sortOrder: newOrderB }),
           signal: controller.signal,
         }).then(async (res) => {
           if (!res.ok) {

--- a/src/components/settings/DropdownOptionsCard.tsx
+++ b/src/components/settings/DropdownOptionsCard.tsx
@@ -11,6 +11,8 @@ import {
   Pencil,
   Check,
   X,
+  ChevronUp,
+  ChevronDown,
 } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
 import { Button } from "@/components/ui/button";
@@ -161,6 +163,47 @@ export function DropdownOptionsCard({ category, label, description }: Props) {
     handleUpdate(id, { name });
   };
 
+  const handleMove = async (id: number, direction: "up" | "down") => {
+    const idx = options.findIndex((o) => o.id === id);
+    if (idx === -1) return;
+    if (direction === "up" && idx === 0) return;
+    if (direction === "down" && idx === options.length - 1) return;
+    if (busyId !== null) return;
+
+    const reordered = [...options];
+    const swapIdx = direction === "up" ? idx - 1 : idx + 1;
+    [reordered[idx], reordered[swapIdx]] = [reordered[swapIdx], reordered[idx]];
+
+    setOptions(reordered);
+    setBusyId(id);
+    setError(null);
+    try {
+      await Promise.all(
+        reordered.map((o, i) =>
+          fetch(`/api/settings/dropdown-options/${o.id}`, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ sortOrder: i * 10 }),
+          }).then(async (res) => {
+            if (!res.ok) {
+              const j = await res.json().catch(() => ({}));
+              throw new Error(
+                (j as { error?: string }).error ||
+                  `Failed to reorder (${res.status})`,
+              );
+            }
+          }),
+        ),
+      );
+      await load();
+    } catch (e) {
+      setError((e as Error).message);
+      await load();
+    } finally {
+      setBusyId(null);
+    }
+  };
+
   return (
     <div className={sectionCard}>
       <div
@@ -296,6 +339,26 @@ export function DropdownOptionsCard({ category, label, description }: Props) {
                     </>
                   ) : (
                     <>
+                      <div className="flex flex-col gap-0.5 shrink-0">
+                        <button
+                          type="button"
+                          onClick={() => handleMove(opt.id, "up")}
+                          disabled={rowBusy || busyId !== null || options.indexOf(opt) === 0}
+                          aria-label={`Move ${opt.name} up`}
+                          className={`h-4 w-5 flex items-center justify-center rounded text-[10px] disabled:opacity-30 ${t.hover} ${t.textSub}`}
+                        >
+                          <ChevronUp aria-hidden="true" className="h-3 w-3" />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleMove(opt.id, "down")}
+                          disabled={rowBusy || busyId !== null || options.indexOf(opt) === options.length - 1}
+                          aria-label={`Move ${opt.name} down`}
+                          className={`h-4 w-5 flex items-center justify-center rounded text-[10px] disabled:opacity-30 ${t.hover} ${t.textSub}`}
+                        >
+                          <ChevronDown aria-hidden="true" className="h-3 w-3" />
+                        </button>
+                      </div>
                       <span
                         className={`flex-1 text-xs ${opt.isActive ? t.text : t.textMuted} ${opt.isActive ? "" : "line-through"}`}
                       >

--- a/src/components/settings/DropdownOptionsCard.tsx
+++ b/src/components/settings/DropdownOptionsCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTheme } from "next-themes";
 import {
   Plus,
@@ -53,6 +53,8 @@ export function DropdownOptionsCard({ category, label, description }: Props) {
   const [newName, setNewName] = useState("");
   const [editingId, setEditingId] = useState<number | null>(null);
   const [editName, setEditName] = useState("");
+  const moveAbortRef = useRef<AbortController | null>(null);
+  useEffect(() => () => { moveAbortRef.current?.abort(); }, []);
 
   const sectionCard = `rounded-xl border ${t.card}`;
 
@@ -170,36 +172,51 @@ export function DropdownOptionsCard({ category, label, description }: Props) {
     if (direction === "down" && idx === options.length - 1) return;
     if (busyId !== null) return;
 
-    const reordered = [...options];
     const swapIdx = direction === "up" ? idx - 1 : idx + 1;
-    [reordered[idx], reordered[swapIdx]] = [reordered[swapIdx], reordered[idx]];
+    const a = options[idx];
+    const b = options[swapIdx];
 
+    const reordered = [...options];
+    reordered[idx] = b;
+    reordered[swapIdx] = a;
     setOptions(reordered);
     setBusyId(id);
     setError(null);
+
+    const controller = new AbortController();
+    moveAbortRef.current = controller;
     try {
-      await Promise.all(
-        reordered.map((o, i) =>
-          fetch(`/api/settings/dropdown-options/${o.id}`, {
-            method: "PATCH",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ sortOrder: i * 10 }),
-          }).then(async (res) => {
-            if (!res.ok) {
-              const j = await res.json().catch(() => ({}));
-              throw new Error(
-                (j as { error?: string }).error ||
-                  `Failed to reorder (${res.status})`,
-              );
-            }
-          }),
-        ),
-      );
+      await Promise.all([
+        fetch(`/api/settings/dropdown-options/${a.id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ sortOrder: b.sortOrder }),
+          signal: controller.signal,
+        }).then(async (res) => {
+          if (!res.ok) {
+            const j = await res.json().catch(() => ({}));
+            throw new Error((j as { error?: string }).error || `Failed to reorder (${res.status})`);
+          }
+        }),
+        fetch(`/api/settings/dropdown-options/${b.id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ sortOrder: a.sortOrder }),
+          signal: controller.signal,
+        }).then(async (res) => {
+          if (!res.ok) {
+            const j = await res.json().catch(() => ({}));
+            throw new Error((j as { error?: string }).error || `Failed to reorder (${res.status})`);
+          }
+        }),
+      ]);
       await load();
     } catch (e) {
+      if ((e as Error).name === "AbortError") return;
       setError((e as Error).message);
       await load();
     } finally {
+      if (moveAbortRef.current === controller) moveAbortRef.current = null;
       setBusyId(null);
     }
   };


### PR DESCRIPTION
## Summary

- Adds ↑/↓ buttons to each row in Settings → Dropdown Options
- Clicking a button reorders the option within its category — optimistic update in the UI, persisted to `sort_order` in the DB via `PATCH /api/settings/dropdown-options/[id]`
- Reassigns `sort_order = index * 10` for all options in the category on each move, keeping values unique and gap-spaced
- Dropdowns in the fee records table already fetch ordered by `sort_order, name` — no other changes needed