### PR TITLE
chore: sync develop → main (PRs #66–#72)

### DIFF
--- a/drizzle/0023_team_daily_tracking_schema.sql
+++ b/drizzle/0023_team_daily_tracking_schema.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "daily_metrics" ADD COLUMN "win_sheets_created" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "team_members" ADD COLUMN "team" varchar(20);

--- a/drizzle/meta/0023_team_daily_tracking_schema.json
+++ b/drizzle/meta/0023_team_daily_tracking_schema.json
@@ -1,0 +1,3069 @@
+{
+  "id": "c8418e72-751e-4251-b958-847faabd56bb",
+  "prevId": "da0998c0-7f7f-4654-9b03-57c7ed4eddeb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_log": {
+      "name": "activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_record_id": {
+          "name": "fee_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_activity_log_case_id": {
+          "name": "idx_activity_log_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_log_created_at": {
+          "name": "idx_activity_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_log_case_id_cases_client_id_fk": {
+          "name": "activity_log_case_id_cases_client_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_log_fee_record_id_fee_records_id_fk": {
+          "name": "activity_log_fee_record_id_fee_records_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "fee_records",
+          "columnsFrom": [
+            "fee_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_activity_log": {
+      "name": "admin_activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_email": {
+          "name": "target_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_admin_activity_created_at": {
+          "name": "idx_admin_activity_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_activity_log_actor_id_users_id_fk": {
+          "name": "admin_activity_log_actor_id_users_id_fk",
+          "tableFrom": "admin_activity_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "admin_activity_log_target_user_id_users_id_fk": {
+          "name": "admin_activity_log_target_user_id_users_id_fk",
+          "tableFrom": "admin_activity_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_settings": {
+      "name": "app_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approved_by_options": {
+      "name": "approved_by_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "approved_by_options_name_unique": {
+          "name": "approved_by_options_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.case_archive": {
+      "name": "case_archive",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "original_client_id": {
+          "name": "original_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "case_name": {
+          "name": "case_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_link": {
+          "name": "case_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_date": {
+          "name": "approval_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_source": {
+          "name": "archived_source",
+          "type": "archived_source_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_by": {
+          "name": "archived_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_snapshot": {
+          "name": "case_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_record_snapshot": {
+          "name": "fee_record_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_snapshots": {
+          "name": "related_snapshots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_case_archive_client_id": {
+          "name": "idx_case_archive_client_id",
+          "columns": [
+            {
+              "expression": "original_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_case_archive_source": {
+          "name": "idx_case_archive_source",
+          "columns": [
+            {
+              "expression": "archived_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_case_archive_archived_at": {
+          "name": "idx_case_archive_archived_at",
+          "columns": [
+            {
+              "expression": "archived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cases": {
+      "name": "cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dob": {
+          "name": "dob",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last4_ssn": {
+          "name": "last4_ssn",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_type": {
+          "name": "claim_type",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "claim_type_label": {
+          "name": "claim_type_label",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level_won": {
+          "name": "level_won",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "t2_decision": {
+          "name": "t2_decision",
+          "type": "decision_outcome_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'unknown'"
+        },
+        "t16_decision": {
+          "name": "t16_decision",
+          "type": "decision_outcome_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'unknown'"
+        },
+        "application_date": {
+          "name": "application_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alleged_onset_date": {
+          "name": "alleged_onset_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_date": {
+          "name": "approval_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_date": {
+          "name": "closure_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_held_date": {
+          "name": "hearing_held_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_scheduled_date": {
+          "name": "hearing_scheduled_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_scheduled_datetime": {
+          "name": "hearing_scheduled_datetime",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_timezone": {
+          "name": "hearing_timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "office_with_jurisdiction": {
+          "name": "office_with_jurisdiction",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alj_first_name": {
+          "name": "alj_first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alj_last_name": {
+          "name": "alj_last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimant_location": {
+          "name": "claimant_location",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representative_location": {
+          "name": "representative_location",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_expert": {
+          "name": "medical_expert",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vocational_expert": {
+          "name": "vocational_expert",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_file_link": {
+          "name": "all_file_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exhibits_file_link": {
+          "name": "exhibits_file_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_file_updated_at": {
+          "name": "all_file_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exhibits_file_updated_at": {
+          "name": "exhibits_file_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_ssn": {
+          "name": "full_ssn",
+          "type": "varchar(11)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_diagnosis": {
+          "name": "primary_diagnosis",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_diagnosis_code": {
+          "name": "primary_diagnosis_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secondary_diagnosis": {
+          "name": "secondary_diagnosis",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secondary_diagnosis_code": {
+          "name": "secondary_diagnosis_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allegations": {
+          "name": "allegations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blind_dli": {
+          "name": "blind_dli",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firm_name": {
+          "name": "firm_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firm_ein": {
+          "name": "firm_ein",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_office": {
+          "name": "hearing_office",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representatives": {
+          "name": "representatives",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_history": {
+          "name": "decision_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_type": {
+          "name": "report_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expedited_case": {
+          "name": "expedited_case",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_of_case": {
+          "name": "status_of_case",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_date": {
+          "name": "status_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_date": {
+          "name": "request_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_date": {
+          "name": "receipt_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_date_assigned": {
+          "name": "first_date_assigned",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_fqr_starts": {
+          "name": "date_fqr_starts",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_insured": {
+          "name": "last_insured",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_created_at": {
+          "name": "source_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_updated_at": {
+          "name": "source_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ere_session_date": {
+          "name": "last_ere_session_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status_report_date": {
+          "name": "last_status_report_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documents_last_added_at": {
+          "name": "documents_last_added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invalid_ssn": {
+          "name": "invalid_ssn",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ssn_encrypted": {
+          "name": "ssn_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_link": {
+          "name": "case_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_pulled_at": {
+          "name": "last_pulled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_cases_client_id": {
+          "name": "idx_cases_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_external_id": {
+          "name": "idx_cases_external_id",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_claim_type_label": {
+          "name": "idx_cases_claim_type_label",
+          "columns": [
+            {
+              "expression": "claim_type_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_approval_date": {
+          "name": "idx_cases_approval_date",
+          "columns": [
+            {
+              "expression": "approval_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_last_name": {
+          "name": "idx_cases_last_name",
+          "columns": [
+            {
+              "expression": "last_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cases_client_id_unique": {
+          "name": "cases_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chronicle_documents": {
+      "name": "chronicle_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mycase_client_id": {
+          "name": "mycase_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chronicle_client_id": {
+          "name": "chronicle_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chronicle_document_id": {
+          "name": "chronicle_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_name": {
+          "name": "document_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_category": {
+          "name": "document_category",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_document": {
+          "name": "raw_document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chronicle_documents_case_id": {
+          "name": "idx_chronicle_documents_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chronicle_documents_case_id_cases_client_id_fk": {
+          "name": "chronicle_documents_case_id_cases_client_id_fk",
+          "tableFrom": "chronicle_documents",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chronicle_documents_case_id_chronicle_document_id_unique": {
+          "name": "chronicle_documents_case_id_chronicle_document_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id",
+            "chronicle_document_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_metrics": {
+      "name": "daily_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_date": {
+          "name": "metric_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ssa_calls": {
+          "name": "ssa_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "client_calls_ib": {
+          "name": "client_calls_ib",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "client_calls_ob": {
+          "name": "client_calls_ob",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "win_sheets_created": {
+          "name": "win_sheets_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_metrics_agent": {
+          "name": "idx_daily_metrics_agent",
+          "columns": [
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_metrics_date": {
+          "name": "idx_daily_metrics_date",
+          "columns": [
+            {
+              "expression": "metric_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_metrics_agent_name_team_members_name_fk": {
+          "name": "daily_metrics_agent_name_team_members_name_fk",
+          "tableFrom": "daily_metrics",
+          "tableTo": "team_members",
+          "columnsFrom": [
+            "agent_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dropdown_options": {
+      "name": "dropdown_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(150)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_dropdown_options_category_name": {
+          "name": "uq_dropdown_options_category_name",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dropdown_options_category": {
+          "name": "idx_dropdown_options_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_cap_history": {
+      "name": "fee_cap_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cap_amount": {
+          "name": "cap_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fee_cap_history_effective_date_unique": {
+          "name": "fee_cap_history_effective_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "effective_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_petitions": {
+      "name": "fee_petitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "noa": {
+          "name": "noa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "time_delineation": {
+          "name": "time_delineation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "fee_petition_doc": {
+          "name": "fee_petition_doc",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ltr_to_clmt": {
+          "name": "ltr_to_clmt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ltr_to_clmt_with_signature": {
+          "name": "ltr_to_clmt_with_signature",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ltr_to_alj": {
+          "name": "ltr_to_alj",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "fax_conf_fee_pet": {
+          "name": "fax_conf_fee_pet",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "update_note": {
+          "name": "update_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fee_petitions_case_id": {
+          "name": "idx_fee_petitions_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fee_petitions_case_id_cases_client_id_fk": {
+          "name": "fee_petitions_case_id_cases_client_id_fk",
+          "tableFrom": "fee_petitions",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fee_petitions_case_id_unique": {
+          "name": "fee_petitions_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_records": {
+      "name": "fee_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "win_sheet_status": {
+          "name": "win_sheet_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'not_started'"
+        },
+        "win_sheet_link": {
+          "name": "win_sheet_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "win_sheet_link_text": {
+          "name": "win_sheet_link_text",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_status": {
+          "name": "case_status",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fees_confirmation": {
+          "name": "fees_confirmation",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_assigned_to_agent": {
+          "name": "date_assigned_to_agent",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "t16_retro": {
+          "name": "t16_retro",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_fee_due": {
+          "name": "t16_fee_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_fee_received": {
+          "name": "t16_fee_received",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_pending": {
+          "name": "t16_pending",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_fee_received_date": {
+          "name": "t16_fee_received_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "t2_retro": {
+          "name": "t2_retro",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_fee_due": {
+          "name": "t2_fee_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_fee_received": {
+          "name": "t2_fee_received",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_pending": {
+          "name": "t2_pending",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_fee_received_date": {
+          "name": "t2_fee_received_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aux_retro": {
+          "name": "aux_retro",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_fee_due": {
+          "name": "aux_fee_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_fee_received": {
+          "name": "aux_fee_received",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_pending": {
+          "name": "aux_pending",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_fee_received_date": {
+          "name": "aux_fee_received_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_retro_due": {
+          "name": "total_retro_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "total_fees_expected": {
+          "name": "total_fees_expected",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "total_fees_paid": {
+          "name": "total_fees_paid",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "pif_ready_to_close": {
+          "name": "pif_ready_to_close",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_closed": {
+          "name": "is_closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "marked_overpaid": {
+          "name": "marked_overpaid",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_method": {
+          "name": "fee_method",
+          "type": "fee_method_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'fee_agreement'"
+        },
+        "applicable_fee_cap": {
+          "name": "applicable_fee_cap",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'9200'"
+        },
+        "fee_cap_applied": {
+          "name": "fee_cap_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "fee_computed": {
+          "name": "fee_computed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "fee_computed_at": {
+          "name": "fee_computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "days_after_approval": {
+          "name": "days_after_approval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_category": {
+          "name": "approval_category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fees_status": {
+          "name": "fees_status",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "week_assigned_to_agent": {
+          "name": "week_assigned_to_agent",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "month_assigned_to_agent": {
+          "name": "month_assigned_to_agent",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "sync_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'not_synced'"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mycase_record_id": {
+          "name": "mycase_record_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fee_records_case_id": {
+          "name": "idx_fee_records_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_assigned_to": {
+          "name": "idx_fee_records_assigned_to",
+          "columns": [
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_win_sheet_status": {
+          "name": "idx_fee_records_win_sheet_status",
+          "columns": [
+            {
+              "expression": "win_sheet_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_sync_status": {
+          "name": "idx_fee_records_sync_status",
+          "columns": [
+            {
+              "expression": "sync_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_pif": {
+          "name": "idx_fee_records_pif",
+          "columns": [
+            {
+              "expression": "pif_ready_to_close",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_is_closed": {
+          "name": "idx_fee_records_is_closed",
+          "columns": [
+            {
+              "expression": "is_closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fee_records_case_id_cases_client_id_fk": {
+          "name": "fee_records_case_id_cases_client_id_fk",
+          "tableFrom": "fee_records",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fee_records_case_id_unique": {
+          "name": "fee_records_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mycase_sync_tags": {
+      "name": "mycase_sync_tags",
+      "schema": "",
+      "columns": {
+        "mycase_case_id": {
+          "name": "mycase_case_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewed'"
+        },
+        "tagged_at": {
+          "name": "tagged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "tagged_by": {
+          "name": "tagged_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mycase_notice_documents": {
+      "name": "mycase_notice_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mycase_client_id": {
+          "name": "mycase_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mycase_document_id": {
+          "name": "mycase_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_name": {
+          "name": "document_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_pattern": {
+          "name": "matched_pattern",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_document": {
+          "name": "raw_document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mycase_notice_documents_case_id": {
+          "name": "idx_mycase_notice_documents_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mycase_notice_documents_case_id_cases_client_id_fk": {
+          "name": "mycase_notice_documents_case_id_cases_client_id_fk",
+          "tableFrom": "mycase_notice_documents",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mycase_notice_documents_case_id_mycase_document_id_unique": {
+          "name": "mycase_notice_documents_case_id_mycase_document_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id",
+            "mycase_document_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "notification_severity_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notifications_type": {
+          "name": "idx_notifications_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_is_read": {
+          "name": "idx_notifications_is_read",
+          "columns": [
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_created_at": {
+          "name": "idx_notifications_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_agent": {
+          "name": "idx_notifications_agent",
+          "columns": [
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_case_id_cases_client_id_fk": {
+          "name": "notifications_case_id_cases_client_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.overpaid_cases": {
+      "name": "overpaid_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "op_ltr_date": {
+          "name": "op_ltr_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "op_ltr_received": {
+          "name": "op_ltr_received",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overpaid_amount": {
+          "name": "overpaid_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checks_cleared": {
+          "name": "checks_cleared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "checks_cleared_at": {
+          "name": "checks_cleared_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "update_note": {
+          "name": "update_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_overpaid_cases_case_id": {
+          "name": "idx_overpaid_cases_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "overpaid_cases_case_id_cases_client_id_fk": {
+          "name": "overpaid_cases_case_id_cases_client_id_fk",
+          "tableFrom": "overpaid_cases",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "overpaid_cases_case_id_unique": {
+          "name": "overpaid_cases_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pull_logs": {
+      "name": "pull_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_records_pulled": {
+          "name": "total_records_pulled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "new_cases": {
+          "name": "new_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_cases": {
+          "name": "updated_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "errors": {
+          "name": "errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_at": {
+          "name": "triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_logs": {
+      "name": "sync_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cases": {
+          "name": "total_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "case_ids": {
+          "name": "case_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_at": {
+          "name": "triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_sync_logs_triggered_at": {
+          "name": "idx_sync_logs_triggered_at",
+          "columns": [
+            {
+              "expression": "triggered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'collections_specialist'"
+        },
+        "team": {
+          "name": "team",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_members_name_unique": {
+          "name": "team_members_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_access_overrides": {
+      "name": "user_access_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overrides": {
+          "name": "overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_access_overrides_user_id_users_id_fk": {
+          "name": "user_access_overrides_user_id_users_id_fk",
+          "tableFrom": "user_access_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_access_overrides_user_id_unique": {
+          "name": "user_access_overrides_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_details": {
+      "name": "user_details",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chronicle_id": {
+          "name": "chronicle_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line_1": {
+          "name": "address_line_1",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line_2": {
+          "name": "address_line_2",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip_code": {
+          "name": "zip_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cell_phone": {
+          "name": "cell_phone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssn": {
+          "name": "ssn",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssn_last4": {
+          "name": "ssn_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age_at_approval": {
+          "name": "age_at_approval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "place_of_birth": {
+          "name": "place_of_birth",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mothers_first_name_and_maiden_name": {
+          "name": "mothers_first_name_and_maiden_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fathers_first_and_last_name": {
+          "name": "fathers_first_and_last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_details_case_id": {
+          "name": "idx_user_details_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_details_case_id_cases_client_id_fk": {
+          "name": "user_details_case_id_cases_client_id_fk",
+          "tableFrom": "user_details",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_details_case_id_unique": {
+          "name": "user_details_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        },
+        "user_details_chronicle_id_unique": {
+          "name": "user_details_chronicle_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chronicle_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.archived_source_enum": {
+      "name": "archived_source_enum",
+      "schema": "public",
+      "values": [
+        "active_sheet",
+        "fees_closed_sheet"
+      ]
+    },
+    "public.claim_type_enum": {
+      "name": "claim_type_enum",
+      "schema": "public",
+      "values": [
+        "T2",
+        "T16",
+        "T2_T16"
+      ]
+    },
+    "public.decision_outcome_enum": {
+      "name": "decision_outcome_enum",
+      "schema": "public",
+      "values": [
+        "fully_favorable",
+        "partially_favorable",
+        "unfavorable",
+        "dismissed",
+        "remand",
+        "unknown"
+      ]
+    },
+    "public.fee_method_enum": {
+      "name": "fee_method_enum",
+      "schema": "public",
+      "values": [
+        "fee_agreement",
+        "fee_petition"
+      ]
+    },
+    "public.level_won_enum": {
+      "name": "level_won_enum",
+      "schema": "public",
+      "values": [
+        "INITIAL",
+        "RECON",
+        "HEARING",
+        "AC",
+        "FEDERAL_COURT",
+        "FEE_PETITION"
+      ]
+    },
+    "public.notification_severity_enum": {
+      "name": "notification_severity_enum",
+      "schema": "public",
+      "values": [
+        "info",
+        "warning",
+        "critical"
+      ]
+    },
+    "public.notification_type_enum": {
+      "name": "notification_type_enum",
+      "schema": "public",
+      "values": [
+        "case_aging",
+        "fee_payment",
+        "call_target_missed",
+        "case_assigned"
+      ]
+    },
+    "public.sync_status_enum": {
+      "name": "sync_status_enum",
+      "schema": "public",
+      "values": [
+        "not_synced",
+        "syncing",
+        "synced",
+        "error"
+      ]
+    },
+    "public.user_role_enum": {
+      "name": "user_role_enum",
+      "schema": "public",
+      "values": [
+        "admin",
+        "lead",
+        "member",
+        "system_admin"
+      ]
+    },
+    "public.win_sheet_status_enum": {
+      "name": "win_sheet_status_enum",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "started",
+        "in_progress",
+        "pending_payment",
+        "partially_paid",
+        "paid_in_full",
+        "closed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1781639172443,
       "tag": "0022_archive_related_snapshots",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1781721739564,
+      "tag": "0023_team_daily_tracking_schema",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -152,7 +152,7 @@
     {
       "idx": 21,
       "version": "7",
-      "when": 1781625209544,
+      "when": 1781634000000,
       "tag": "0021_case_archive",
       "breakpoints": true
     },

--- a/src/app/(dashboard)/notifications/page.tsx
+++ b/src/app/(dashboard)/notifications/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useCallback, useMemo } from "react";
+import React, { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useTheme } from "next-themes";
 import Link from "next/link";
 import {
@@ -122,17 +122,23 @@ export default function NotificationsPage() {
   const [filter, setFilter] = useState<FilterType>("all");
   const [markingAll, setMarkingAll] = useState(false);
 
+  const fetchAbortRef = useRef<AbortController | null>(null);
+
   const fetchNotifications = useCallback(async () => {
+    fetchAbortRef.current?.abort();
+    const controller = new AbortController();
+    fetchAbortRef.current = controller;
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch("/api/notifications?limit=100&computeLive=true");
-      if (!res.ok) throw new Error("Failed to fetch notifications");
+      const res = await fetch("/api/notifications?limit=100&computeLive=true", { signal: controller.signal });
+      if (!res.ok) throw new Error(`Failed to fetch notifications (${res.status})`);
       const json = await res.json();
       setStored(json.notifications || []);
       setLive(json.liveAlerts || []);
       setUnreadCount(json.unreadCount || 0);
     } catch (err) {
+      if ((err as Error).name === "AbortError") return;
       setError((err as Error).message);
     } finally {
       setLoading(false);
@@ -141,6 +147,7 @@ export default function NotificationsPage() {
 
   useEffect(() => {
     fetchNotifications();
+    return () => fetchAbortRef.current?.abort();
   }, [fetchNotifications]);
 
   // Combine stored + live, dedupe by id, sort desc

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -5,6 +5,7 @@ import React, {
   useEffect,
   useCallback,
   useSyncExternalStore,
+  useRef,
 } from "react";
 import { useTheme } from "next-themes";
 import {
@@ -170,15 +171,20 @@ export default function SettingsPage() {
   const [capNotes, setCapNotes] = useState("");
   const [addingCap, setAddingCap] = useState(false);
 
+  const fetchAbortRef = useRef<AbortController | null>(null);
+
   const fetchSettings = useCallback(async () => {
+    fetchAbortRef.current?.abort();
+    const controller = new AbortController();
+    fetchAbortRef.current = controller;
     setLoading(true);
     setError(null);
     try {
       const [settingsRes, connRes] = await Promise.all([
-        fetch("/api/settings"),
-        fetch("/api/settings/connections"),
+        fetch("/api/settings", { signal: controller.signal }),
+        fetch("/api/settings/connections", { signal: controller.signal }),
       ]);
-      if (!settingsRes.ok) throw new Error("Failed to load settings");
+      if (!settingsRes.ok) throw new Error(`Failed to load settings (${settingsRes.status})`);
       const sJson = await settingsRes.json();
       setSettings(sJson.settings || []);
       setFeeCaps(sJson.feeCaps || []);
@@ -193,6 +199,7 @@ export default function SettingsPage() {
       }
       setEdits(initial);
     } catch (err) {
+      if ((err as Error).name === "AbortError") return;
       setError((err as Error).message);
     } finally {
       setLoading(false);
@@ -201,6 +208,7 @@ export default function SettingsPage() {
 
   useEffect(() => {
     fetchSettings();
+    return () => fetchAbortRef.current?.abort();
   }, [fetchSettings]);
 
   const editValue = (key: string, value: string) => {

--- a/src/app/api/daily-metrics/route.ts
+++ b/src/app/api/daily-metrics/route.ts
@@ -21,6 +21,7 @@ export const GET = async (req: NextRequest) => {
           dm.ssa_calls,
           dm.client_calls_ib,
           dm.client_calls_ob,
+          dm.win_sheets_created,
           dm.notes
         FROM daily_metrics dm
         WHERE dm.metric_date >= ${week}::date
@@ -37,6 +38,7 @@ export const GET = async (req: NextRequest) => {
             ssa_calls: number;
             client_calls_ib: number;
             client_calls_ob: number;
+            win_sheets_created: number;
             notes: string | null;
           }[]
         ).map((r) => ({
@@ -45,6 +47,7 @@ export const GET = async (req: NextRequest) => {
           ssaCalls: r.ssa_calls,
           clientCallsIb: r.client_calls_ib,
           clientCallsOb: r.client_calls_ob,
+          winSheetsCreated: r.win_sheets_created,
           notes: r.notes,
         })),
       });
@@ -87,6 +90,7 @@ export const GET = async (req: NextRequest) => {
       ssaCalls: row.ssaCalls,
       clientCallsIb: row.clientCallsIb,
       clientCallsOb: row.clientCallsOb,
+      winSheetsCreated: row.winSheetsCreated,
       notes: row.notes,
     });
   } catch (error) {
@@ -109,20 +113,18 @@ export const POST = async (req: NextRequest) => {
     if (body.entries && Array.isArray(body.entries)) {
       const results = [];
       for (const entry of body.entries) {
-        const { agent, date, ssaCalls, clientCallsIb, clientCallsOb, notes } =
+        const { agent, date, ssaCalls, clientCallsIb, clientCallsOb, winSheetsCreated, notes } =
           entry;
         if (!agent || !date) continue;
 
-        // Raw SQL upsert — works even without unique constraint via
-        // INSERT ... ON CONFLICT approach, but we use delete+insert pattern
-        // to be safe since the schema may not have the unique constraint yet
         await db.execute(sql`
-          INSERT INTO daily_metrics (id, agent_name, metric_date, ssa_calls, client_calls_ib, client_calls_ob, notes, created_at, updated_at)
-          VALUES (gen_random_uuid(), ${agent}, ${date}::date, ${ssaCalls ?? 0}, ${clientCallsIb ?? 0}, ${clientCallsOb ?? 0}, ${notes || null}, NOW(), NOW())
+          INSERT INTO daily_metrics (id, agent_name, metric_date, ssa_calls, client_calls_ib, client_calls_ob, win_sheets_created, notes, created_at, updated_at)
+          VALUES (gen_random_uuid(), ${agent}, ${date}::date, ${ssaCalls ?? 0}, ${clientCallsIb ?? 0}, ${clientCallsOb ?? 0}, ${winSheetsCreated ?? 0}, ${notes || null}, NOW(), NOW())
           ON CONFLICT (agent_name, metric_date) DO UPDATE SET
             ssa_calls = EXCLUDED.ssa_calls,
             client_calls_ib = EXCLUDED.client_calls_ib,
             client_calls_ob = EXCLUDED.client_calls_ob,
+            win_sheets_created = EXCLUDED.win_sheets_created,
             notes = EXCLUDED.notes,
             updated_at = NOW()
         `);
@@ -132,6 +134,7 @@ export const POST = async (req: NextRequest) => {
           ssaCalls: ssaCalls ?? 0,
           clientCallsIb: clientCallsIb ?? 0,
           clientCallsOb: clientCallsOb ?? 0,
+          winSheetsCreated: winSheetsCreated ?? 0,
         });
       }
       return NextResponse.json({
@@ -142,7 +145,7 @@ export const POST = async (req: NextRequest) => {
     }
 
     // Single mode
-    const { agent, date, ssaCalls, clientCallsIb, clientCallsOb, notes } = body;
+    const { agent, date, ssaCalls, clientCallsIb, clientCallsOb, winSheetsCreated, notes } = body;
 
     if (!agent) {
       return NextResponse.json({ error: "agent is required" }, { status: 400 });
@@ -151,12 +154,13 @@ export const POST = async (req: NextRequest) => {
     const metricDate = date || new Date().toISOString().split("T")[0];
 
     await db.execute(sql`
-      INSERT INTO daily_metrics (id, agent_name, metric_date, ssa_calls, client_calls_ib, client_calls_ob, notes, created_at, updated_at)
-      VALUES (gen_random_uuid(), ${agent}, ${metricDate}::date, ${ssaCalls ?? 0}, ${clientCallsIb ?? 0}, ${clientCallsOb ?? 0}, ${notes || null}, NOW(), NOW())
+      INSERT INTO daily_metrics (id, agent_name, metric_date, ssa_calls, client_calls_ib, client_calls_ob, win_sheets_created, notes, created_at, updated_at)
+      VALUES (gen_random_uuid(), ${agent}, ${metricDate}::date, ${ssaCalls ?? 0}, ${clientCallsIb ?? 0}, ${clientCallsOb ?? 0}, ${winSheetsCreated ?? 0}, ${notes || null}, NOW(), NOW())
       ON CONFLICT (agent_name, metric_date) DO UPDATE SET
         ssa_calls = EXCLUDED.ssa_calls,
         client_calls_ib = EXCLUDED.client_calls_ib,
         client_calls_ob = EXCLUDED.client_calls_ob,
+        win_sheets_created = EXCLUDED.win_sheets_created,
         notes = EXCLUDED.notes,
         updated_at = NOW()
     `);
@@ -169,6 +173,7 @@ export const POST = async (req: NextRequest) => {
         ssaCalls: ssaCalls ?? 0,
         clientCallsIb: clientCallsIb ?? 0,
         clientCallsOb: clientCallsOb ?? 0,
+        winSheetsCreated: winSheetsCreated ?? 0,
       },
     });
   } catch (error) {

--- a/src/app/api/fee-petitions/route.ts
+++ b/src/app/api/fee-petitions/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
-import { cases, feePetitions } from "@/lib/db/schema";
+import { cases, feePetitions, feeRecords } from "@/lib/db/schema";
 import { eq, ilike, sql } from "drizzle-orm";
 
 const SORT_KEYS = ["claimant", "approvalDate", "updatedAt", "progress"] as const;
@@ -77,8 +77,9 @@ export const GET = async (req: NextRequest) => {
 
     // Accept both the legacy enum value and the worksheet-direct label
     // saved via the dashboard dropdown (column C in the master sheet uses
-    // "FEE PETITION" with a space).
+    // "FEE PETITION" with a space). Exclude cases already closed to Fees Closed.
     const whereClause = sql`${cases.levelWon} IN ('FEE_PETITION', 'FEE PETITION')
+      AND (${feeRecords.isClosed} IS NULL OR ${feeRecords.isClosed} = false)
       ${searchClause}
       ${statusClause}
       ${touchedClause}
@@ -94,6 +95,7 @@ export const GET = async (req: NextRequest) => {
       })
       .from(cases)
       .leftJoin(feePetitions, eq(feePetitions.caseId, cases.clientId))
+      .leftJoin(feeRecords, eq(feeRecords.caseId, cases.clientId))
       .where(whereClause);
 
     const total = agg?.total ?? 0;
@@ -128,6 +130,7 @@ export const GET = async (req: NextRequest) => {
       })
       .from(cases)
       .leftJoin(feePetitions, eq(feePetitions.caseId, cases.clientId))
+      .leftJoin(feeRecords, eq(feeRecords.caseId, cases.clientId))
       .where(whereClause)
       .orderBy(orderClause)
       .limit(limit)

--- a/src/app/api/scoreboard/route.ts
+++ b/src/app/api/scoreboard/route.ts
@@ -53,14 +53,27 @@ export const GET = async (req: NextRequest) => {
     const startDate = useRange ? fromParam! : monday;
     const endExclusive = useRange ? addDays(toParam!, 1) : addDays(monday, 7);
 
-    // Team-wide totals for the week
+    // Per-agent totals for the window
     const teamTotals = await db.execute(sql`
       SELECT
         tm.name AS agent,
+        tm.team AS team,
+
         -- Cases assigned (current snapshot)
         (SELECT COUNT(*) FROM fee_records fr WHERE fr.assigned_to = tm.name) AS cases_assigned,
 
-        -- Completed win sheets (status = paid_in_full or closed)
+        -- Open cases (current snapshot)
+        (SELECT COUNT(*) FROM fee_records fr
+         WHERE fr.assigned_to = tm.name
+         AND fr.is_closed = FALSE) AS open_cases,
+
+        -- Cases closed within the window
+        (SELECT COUNT(*) FROM fee_records fr
+         WHERE fr.assigned_to = tm.name
+         AND fr.closed_at >= ${startDate}::date
+         AND fr.closed_at < ${endExclusive}::date) AS cases_closed,
+
+        -- Completed win sheets (status = paid_in_full or closed, current snapshot)
         (SELECT COUNT(*) FROM fee_records fr
          WHERE fr.assigned_to = tm.name
          AND fr.win_sheet_status IN ('paid_in_full', 'closed')) AS completed_win_sheets,
@@ -95,12 +108,23 @@ export const GET = async (req: NextRequest) => {
         -- Total fees collected (all time for this agent)
         COALESCE((SELECT SUM(fr.total_fees_paid::numeric) FROM fee_records fr WHERE fr.assigned_to = tm.name), 0) AS total_collected,
 
+        -- Fees collected within the window (derived from per-type received dates)
+        COALESCE((
+          SELECT SUM(
+            CASE WHEN fr.t2_fee_received_date >= ${startDate}::date AND fr.t2_fee_received_date < ${endExclusive}::date THEN fr.t2_fee_received::numeric ELSE 0 END +
+            CASE WHEN fr.t16_fee_received_date >= ${startDate}::date AND fr.t16_fee_received_date < ${endExclusive}::date THEN fr.t16_fee_received::numeric ELSE 0 END +
+            CASE WHEN fr.aux_fee_received_date >= ${startDate}::date AND fr.aux_fee_received_date < ${endExclusive}::date THEN fr.aux_fee_received::numeric ELSE 0 END
+          )
+          FROM fee_records fr
+          WHERE fr.assigned_to = tm.name
+        ), 0) AS fees_collected_in_window,
+
         -- Cases with full fee collected (PIF)
         (SELECT COUNT(*) FROM fee_records fr
          WHERE fr.assigned_to = tm.name
          AND fr.pif_ready_to_close = TRUE) AS cases_full_fee,
 
-        -- Daily metrics from daily_metrics table for the week
+        -- Call and win sheet metrics from daily_metrics for the window
         COALESCE((SELECT SUM(dm.ssa_calls) FROM daily_metrics dm
          WHERE dm.agent_name = tm.name
          AND dm.metric_date >= ${startDate}::date
@@ -109,14 +133,19 @@ export const GET = async (req: NextRequest) => {
         COALESCE((SELECT SUM(dm.client_calls_ib + dm.client_calls_ob) FROM daily_metrics dm
          WHERE dm.agent_name = tm.name
          AND dm.metric_date >= ${startDate}::date
-         AND dm.metric_date < ${endExclusive}::date), 0) AS week_client_calls
+         AND dm.metric_date < ${endExclusive}::date), 0) AS week_client_calls,
+
+        COALESCE((SELECT SUM(dm.win_sheets_created) FROM daily_metrics dm
+         WHERE dm.agent_name = tm.name
+         AND dm.metric_date >= ${startDate}::date
+         AND dm.metric_date < ${endExclusive}::date), 0) AS week_win_sheets_created
 
       FROM team_members tm
       WHERE tm.is_active = TRUE
-      ORDER BY tm.name
+      ORDER BY tm.team NULLS LAST, tm.name
     `);
 
-    // Daily breakdown for the week (from daily_metrics)
+    // Daily breakdown for the window (from daily_metrics)
     const dailyBreakdown = await db.execute(sql`
       SELECT
         dm.agent_name AS agent,
@@ -124,6 +153,7 @@ export const GET = async (req: NextRequest) => {
         dm.ssa_calls,
         dm.client_calls_ib,
         dm.client_calls_ob,
+        dm.win_sheets_created,
         dm.notes
       FROM daily_metrics dm
       WHERE dm.metric_date >= ${startDate}::date
@@ -131,36 +161,72 @@ export const GET = async (req: NextRequest) => {
       ORDER BY dm.agent_name, dm.metric_date
     `);
 
-    // Compute team-wide summary
-    const agents = (teamTotals as Record<string, string | number>[]).map(
+    const agents = (teamTotals as Record<string, string | number | null>[]).map(
       (r) => ({
         agent: String(r.agent),
+        team: r.team ? String(r.team) : null,
         casesAssigned: Number(r.cases_assigned),
+        openCases: Number(r.open_cases),
+        casesClosed: Number(r.cases_closed),
         completedWinSheets: Number(r.completed_win_sheets),
+        winSheetsCreated: Number(r.week_win_sheets_created),
         unpaidT2Over60: Number(r.unpaid_t2_over_60),
         unpaidT16Over60: Number(r.unpaid_t16_over_60),
         unpaidConcOver60: Number(r.unpaid_conc_over_60),
         totalCollected: Number(r.total_collected),
+        feesCollectedInWindow: Number(r.fees_collected_in_window),
         casesFullFee: Number(r.cases_full_fee),
         weekSsaCalls: Number(r.week_ssa_calls),
         weekClientCalls: Number(r.week_client_calls),
       }),
     );
 
+    // Overall summary (all agents)
     const summary = {
       totalCasesAssigned: agents.reduce((s, a) => s + a.casesAssigned, 0),
-      totalCompletedWinSheets: agents.reduce(
-        (s, a) => s + a.completedWinSheets,
-        0,
-      ),
+      totalOpenCases: agents.reduce((s, a) => s + a.openCases, 0),
+      totalCasesClosed: agents.reduce((s, a) => s + a.casesClosed, 0),
+      totalCompletedWinSheets: agents.reduce((s, a) => s + a.completedWinSheets, 0),
+      totalWinSheetsCreated: agents.reduce((s, a) => s + a.winSheetsCreated, 0),
       totalUnpaidT2Over60: agents.reduce((s, a) => s + a.unpaidT2Over60, 0),
       totalUnpaidT16Over60: agents.reduce((s, a) => s + a.unpaidT16Over60, 0),
       totalUnpaidConcOver60: agents.reduce((s, a) => s + a.unpaidConcOver60, 0),
       totalCollected: agents.reduce((s, a) => s + a.totalCollected, 0),
+      totalFeesCollectedInWindow: agents.reduce((s, a) => s + a.feesCollectedInWindow, 0),
       totalCasesFullFee: agents.reduce((s, a) => s + a.casesFullFee, 0),
       totalSsaCalls: agents.reduce((s, a) => s + a.weekSsaCalls, 0),
       totalClientCalls: agents.reduce((s, a) => s + a.weekClientCalls, 0),
     };
+
+    // Team-level aggregation — group agents by team, exclude unassigned
+    const TEAM_ORDER = ["T2", "T16", "Concurrent"];
+    const teamMap = new Map<string, typeof agents>();
+    for (const a of agents) {
+      if (!a.team) continue;
+      const bucket = teamMap.get(a.team) ?? [];
+      bucket.push(a);
+      teamMap.set(a.team, bucket);
+    }
+    const teams = TEAM_ORDER.filter((t) => teamMap.has(t)).map((teamName) => {
+      const members = teamMap.get(teamName)!;
+      return {
+        team: teamName,
+        agentCount: members.length,
+        casesAssigned: members.reduce((s, a) => s + a.casesAssigned, 0),
+        openCases: members.reduce((s, a) => s + a.openCases, 0),
+        casesClosed: members.reduce((s, a) => s + a.casesClosed, 0),
+        completedWinSheets: members.reduce((s, a) => s + a.completedWinSheets, 0),
+        winSheetsCreated: members.reduce((s, a) => s + a.winSheetsCreated, 0),
+        unpaidT2Over60: members.reduce((s, a) => s + a.unpaidT2Over60, 0),
+        unpaidT16Over60: members.reduce((s, a) => s + a.unpaidT16Over60, 0),
+        unpaidConcOver60: members.reduce((s, a) => s + a.unpaidConcOver60, 0),
+        totalCollected: members.reduce((s, a) => s + a.totalCollected, 0),
+        feesCollectedInWindow: members.reduce((s, a) => s + a.feesCollectedInWindow, 0),
+        casesFullFee: members.reduce((s, a) => s + a.casesFullFee, 0),
+        ssaCalls: members.reduce((s, a) => s + a.weekSsaCalls, 0),
+        clientCalls: members.reduce((s, a) => s + a.weekClientCalls, 0),
+      };
+    });
 
     const daily = (dailyBreakdown as Record<string, string | number>[]).map(
       (r) => ({
@@ -169,6 +235,7 @@ export const GET = async (req: NextRequest) => {
         ssaCalls: Number(r.ssa_calls),
         clientCallsIb: Number(r.client_calls_ib),
         clientCallsOb: Number(r.client_calls_ob),
+        winSheetsCreated: Number(r.win_sheets_created),
         notes: r.notes ? String(r.notes) : null,
       }),
     );
@@ -179,6 +246,7 @@ export const GET = async (req: NextRequest) => {
       end: useRange ? toParam : addDays(monday, 6),
       summary,
       agents,
+      teams,
       daily,
     });
   } catch (error) {

--- a/src/app/api/team-members/route.ts
+++ b/src/app/api/team-members/route.ts
@@ -11,6 +11,7 @@ export const GET = async () => {
         id: teamMembers.id,
         name: teamMembers.name,
         role: teamMembers.role,
+        team: teamMembers.team,
         isActive: teamMembers.isActive,
         createdAt: teamMembers.createdAt,
         caseCount: count(feeRecords.id),
@@ -28,6 +29,7 @@ export const GET = async () => {
         teamMembers.id,
         teamMembers.name,
         teamMembers.role,
+        teamMembers.team,
         teamMembers.isActive,
         teamMembers.createdAt,
       )
@@ -37,6 +39,7 @@ export const GET = async () => {
       id: r.id,
       name: r.name,
       role: r.role,
+      team: r.team ?? null,
       isActive: r.isActive,
       createdAt: r.createdAt,
       cases: Number(r.caseCount) || 0,
@@ -59,7 +62,7 @@ export const GET = async () => {
 export const POST = async (req: NextRequest) => {
   try {
     const body = await req.json();
-    const { name, role } = body;
+    const { name, role, team } = body;
 
     if (!name || typeof name !== "string" || name.trim().length === 0) {
       return NextResponse.json({ error: "Name is required" }, { status: 400 });
@@ -67,6 +70,7 @@ export const POST = async (req: NextRequest) => {
 
     const trimmedName = name.trim();
     const trimmedRole = (role || "collections_specialist").trim();
+    const trimmedTeam = team ? String(team).trim() : null;
 
     // Check for duplicate
     const existing = await db
@@ -84,7 +88,7 @@ export const POST = async (req: NextRequest) => {
 
     const [created] = await db
       .insert(teamMembers)
-      .values({ name: trimmedName, role: trimmedRole })
+      .values({ name: trimmedName, role: trimmedRole, team: trimmedTeam })
       .returning();
 
     return NextResponse.json({ data: created }, { status: 201 });
@@ -101,7 +105,7 @@ export const POST = async (req: NextRequest) => {
 export const PATCH = async (req: NextRequest) => {
   try {
     const body = await req.json();
-    const { id, name, role, isActive } = body;
+    const { id, name, role, team, isActive } = body;
 
     if (!id || typeof id !== "number") {
       return NextResponse.json(
@@ -113,6 +117,7 @@ export const PATCH = async (req: NextRequest) => {
     const updates: Record<string, unknown> = {};
     if (name !== undefined) updates.name = name.trim();
     if (role !== undefined) updates.role = role.trim();
+    if (team !== undefined) updates.team = team ? String(team).trim() : null;
     if (isActive !== undefined) updates.isActive = Boolean(isActive);
 
     if (Object.keys(updates).length === 0) {

--- a/src/components/admin/UsersTable.tsx
+++ b/src/components/admin/UsersTable.tsx
@@ -259,11 +259,12 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
                             )}
                           </div>
                           {user.name && (
-                            <div
-                              className={`text-[10px] ${t.textMuted} truncate`}
+                            <a
+                              href={`mailto:${user.email}`}
+                              className={`text-[10px] ${t.textMuted} truncate hover:underline`}
                             >
                               {user.email}
-                            </div>
+                            </a>
                           )}
                         </div>
                       </div>
@@ -638,7 +639,7 @@ function ResetPasswordDialog({
           <DialogTitle>Reset password</DialogTitle>
           <DialogDescription>
             A new temporary password has been generated for{" "}
-            <span className="font-semibold">{target?.email}</span>. Copy it and
+            <a href={`mailto:${target?.email}`} className="font-semibold hover:underline">{target?.email}</a>. Copy it and
             share out-of-band before closing.
           </DialogDescription>
         </DialogHeader>

--- a/src/components/cases/CaseDetailSheet.tsx
+++ b/src/components/cases/CaseDetailSheet.tsx
@@ -147,7 +147,7 @@ function ClientDetailsSection({
           {ud.cellPhone && (
             <div>
               <p className={`${lbl} flex items-center gap-1`}><Phone aria-hidden="true" className="h-3 w-3" /> Cell Phone</p>
-              <p className={val}>{ud.cellPhone}</p>
+              <a href={`tel:${ud.cellPhone}`} className={`${val} hover:underline`}>{ud.cellPhone}</a>
             </div>
           )}
           {ud.email && (

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -79,12 +79,13 @@ const patchSingleField = async (
   field: CaseField | FeeField,
   value: string | null,
   fieldLabel: string,
+  signal?: AbortSignal,
 ) => {
   const payload =
     target === "case"
       ? { caseFields: { [field]: value } }
       : { feeFields: { [field]: value } };
-  await fetch(`/api/cases/${caseId}`, {
+  const res = await fetch(`/api/cases/${caseId}`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
@@ -93,7 +94,15 @@ const patchSingleField = async (
         ? `${fieldLabel} set to "${value}"`
         : `${fieldLabel} cleared`,
     }),
+    signal,
   });
+  if (!res.ok) {
+    const j = await res.json().catch(() => ({}));
+    throw new Error(
+      (j as { error?: string }).error ||
+        `Failed to update ${fieldLabel} (${res.status})`,
+    );
+  }
 };
 
 const currency = (v: number) => (v > 0 ? fmtFull(v) : "—");
@@ -216,6 +225,14 @@ export const FeeRecordsTable = ({
   >({});
   const [batchLoading, setBatchLoading] = useState(false);
   const selectAllRef = useRef<HTMLInputElement>(null);
+  const patchAbortRef = useRef<Map<string, AbortController>>(new Map());
+  useEffect(() => {
+    const abortMap = patchAbortRef.current;
+    return () => {
+      for (const ctrl of abortMap.values()) ctrl.abort();
+      abortMap.clear();
+    };
+  }, []);
 
   const toggleRowSelection = (id: number) => {
     setSelectedIds((prev) => {
@@ -444,14 +461,20 @@ export const FeeRecordsTable = ({
     fieldLabel: string,
     next: string,
   ) => {
+    const key = `${c.id}:${field}`;
+    patchAbortRef.current.get(key)?.abort();
+    const controller = new AbortController();
+    patchAbortRef.current.set(key, controller);
+
     const value = next || null;
     setPending((prev) => ({
       ...prev,
       [c.id]: { ...prev[c.id], [rowKey]: value ?? "" },
     }));
     try {
-      await patchSingleField(c.id, target, field, value, fieldLabel);
+      await patchSingleField(c.id, target, field, value, fieldLabel, controller.signal);
     } catch (err) {
+      if ((err as Error).name === "AbortError") return;
       console.error(`Failed to update ${fieldLabel}:`, err);
       setPending((prev) => {
         const copy = { ...prev };
@@ -462,6 +485,10 @@ export const FeeRecordsTable = ({
         }
         return copy;
       });
+    } finally {
+      if (patchAbortRef.current.get(key) === controller) {
+        patchAbortRef.current.delete(key);
+      }
     }
   };
 
@@ -1012,10 +1039,7 @@ export const FeeRecordsTable = ({
                       className={`${tdBase} ${t.textSub} ${stickyTd2}`}
                       onClick={(e) => e.stopPropagation()}
                     >
-                      {mode === "closed" ? (
-                        c.assigned
-                      ) : (
-                        <select
+                      <select
                           value={cellValue(c, "assigned")}
                           onClick={(e) => e.stopPropagation()}
                           onChange={(e) =>
@@ -1057,21 +1081,13 @@ export const FeeRecordsTable = ({
                               </option>
                             ))}
                         </select>
-                      )}
                     </td>
                     {/* Level — varchar; lives on the cases row. */}
                     <td
                       className={`${tdBase}`}
                       onClick={(e) => e.stopPropagation()}
                     >
-                      {mode === "closed" ? (
-                        <span
-                          className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${t.pillBg}`}
-                        >
-                          {cellValue(c, "level") || "—"}
-                        </span>
-                      ) : (
-                        <select
+                      <select
                           value={cellValue(c, "level")}
                           onClick={(e) => e.stopPropagation()}
                           onChange={(e) =>
@@ -1112,21 +1128,13 @@ export const FeeRecordsTable = ({
                               </option>
                             ))}
                         </select>
-                      )}
                     </td>
                     {/* Claim — varchar; lives on the cases row. */}
                     <td
                       className={`${tdBase}`}
                       onClick={(e) => e.stopPropagation()}
                     >
-                      {mode === "closed" ? (
-                        <span
-                          className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${t.pillBg}`}
-                        >
-                          {fmtClaim(cellValue(c, "claim")) || "—"}
-                        </span>
-                      ) : (
-                        <select
+                      <select
                           value={cellValue(c, "claim")}
                           onClick={(e) => e.stopPropagation()}
                           onChange={(e) =>
@@ -1167,7 +1175,6 @@ export const FeeRecordsTable = ({
                               </option>
                             ))}
                         </select>
-                      )}
                     </td>
                     <td className={`${tdBase} ${t.textSub} tabular-nums`}>
                       {dateStr(c.date)}
@@ -1177,16 +1184,7 @@ export const FeeRecordsTable = ({
                       className={`${tdBase}`}
                       onClick={(e) => e.stopPropagation()}
                     >
-                      {mode === "closed" ? (
-                        <span
-                          className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold ${getStatusColor(cellValue(c, "status"), dark)}`}
-                        >
-                          {STATUS_LABELS[cellValue(c, "status")] ||
-                            cellValue(c, "status") ||
-                            "—"}
-                        </span>
-                      ) : (
-                        <select
+                      <select
                           value={cellValue(c, "status")}
                           onClick={(e) => e.stopPropagation()}
                           onChange={(e) =>
@@ -1227,7 +1225,6 @@ export const FeeRecordsTable = ({
                               </option>
                             ))}
                         </select>
-                      )}
                     </td>
 
                     {/* Win Sheet Link */}
@@ -1483,10 +1480,7 @@ export const FeeRecordsTable = ({
                       className={`${tdBase} ${t.textSub}`}
                       onClick={(e) => e.stopPropagation()}
                     >
-                      {mode === "closed" ? (
-                        cellValue(c, "caseStatus") || "—"
-                      ) : (
-                        <select
+                      <select
                           value={cellValue(c, "caseStatus")}
                           onClick={(e) => e.stopPropagation()}
                           onChange={(e) =>
@@ -1528,7 +1522,6 @@ export const FeeRecordsTable = ({
                               </option>
                             ))}
                         </select>
-                      )}
                     </td>
                     <td className={`${tdBase} ${t.textSub} max-w-65`}>
                       {c.update && c.update !== "—" ? (

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -824,7 +824,7 @@ export const FeeRecordsTable = ({
                     Approval <ArrowUpDown className="h-3 w-3" />
                   </span>
                 </th>
-                <th className={`${thBase} ${t.textSub} text-left`}>Status</th>
+                <th className={`${thBase} ${t.textSub} text-left`}>Win Sheet Status</th>
                 <th className={`${thBase} ${t.textSub} text-left`}>
                   Win Sheet
                 </th>
@@ -910,7 +910,7 @@ export const FeeRecordsTable = ({
                   Fees Conf
                 </th>
                 <th className={`${thBase} ${t.textSub} text-left`}>
-                  Case Status
+                  Remarks
                 </th>
                 <th className={`${thBase} ${t.textSub} text-left`}>
                   Recent Update
@@ -1478,7 +1478,7 @@ export const FeeRecordsTable = ({
                         </select>
                       )}
                     </td>
-                    {/* Case Status */}
+                    {/* Remarks */}
                     <td
                       className={`${tdBase} ${t.textSub}`}
                       onClick={(e) => e.stopPropagation()}
@@ -1495,7 +1495,7 @@ export const FeeRecordsTable = ({
                               "fee",
                               "caseStatus",
                               "caseStatus",
-                              "Case Status",
+                              "Remarks",
                               e.target.value,
                             )
                           }

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -24,10 +24,7 @@ import { themeClasses } from "@/lib/theme-classes";
 import {
   fmtFull,
   fmtDate,
-  fmtClaim,
   fmtClaimLong,
-  STATUS_LABELS,
-  getStatusColor,
 } from "@/lib/formatters";
 import type { CaseRow, ApprovedByOption } from "@/types";
 import type { DropdownOptionsByCategory } from "@/hooks/useDashboard";

--- a/src/components/fee-petitions/FeePetitions.tsx
+++ b/src/components/fee-petitions/FeePetitions.tsx
@@ -18,10 +18,12 @@ import {
   Download,
   X,
   Undo2,
+  ArchiveX,
 } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
 import { fmtDate } from "@/lib/formatters";
 import { upsertFeePetition, bulkMarkComplete, bulkRestoreChecklists } from "@/app/(dashboard)/fee-petitions/actions";
+import { useCapabilities } from "@/hooks/useCapabilities";
 
 // ---------- types ----------
 interface FeePetitionRow {
@@ -157,7 +159,12 @@ export const FeePetitions = () => {
     expiresAt: number;
   } | null>(null);
   const [undoing, setUndoing] = useState(false);
+  const [bulkCloseConfirming, setBulkCloseConfirming] = useState(false);
+  const [bulkClosing, setBulkClosing] = useState(false);
   const selectAllRef = useRef<HTMLInputElement>(null);
+
+  const { can } = useCapabilities();
+  const canFinalize = can("case.finalize");
 
   const urlMethodRef = useRef<"push" | "replace">("replace");
 
@@ -237,6 +244,11 @@ export const FeePetitions = () => {
   }, [search]);
 
   const fetchAbortRef = useRef<AbortController | null>(null);
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => { mountedRef.current = false; };
+  }, []);
 
   const fetchPetitions = useCallback(async () => {
     fetchAbortRef.current?.abort();
@@ -265,6 +277,7 @@ export const FeePetitions = () => {
       setRows(data);
       setSelectedIds(new Set());
       setBulkConfirming(false);
+      setBulkCloseConfirming(false);
       setTotal(typeof json.total === "number" ? json.total : data.length);
       setStats({
         completeCount: typeof json.completeCount === "number" ? json.completeCount : 0,
@@ -313,6 +326,7 @@ export const FeePetitions = () => {
   const clearSelection = () => {
     setSelectedIds(new Set());
     setBulkConfirming(false);
+    setBulkCloseConfirming(false);
   };
 
   const toggleSelectAll = () => {
@@ -443,6 +457,49 @@ export const FeePetitions = () => {
   const ariaSortFor = (key: SortKey): "ascending" | "descending" | "none" => {
     if (sortKey !== key) return "none";
     return sortDir === "asc" ? "ascending" : "descending";
+  };
+
+  const handleBulkClosePetitions = async () => {
+    if (bulkClosing) return;
+    setBulkClosing(true);
+    const ids = [...selectedIds];
+    const closingRows = rows.filter((r) => ids.includes(r.id));
+    const closingComplete = closingRows.filter((r) => CHECKBOX_COLUMNS.every((c) => r[c.key])).length;
+    const closingIncomplete = closingRows.length - closingComplete;
+    try {
+      await Promise.all(
+        ids.map((id) =>
+          fetch(`/api/cases/${id}`, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              feeFields: { isClosed: true },
+              logMessage: "Fee petition complete — case moved to Fees Closed.",
+            }),
+          }).then(async (res) => {
+            if (!res.ok) {
+              const j = await res.json().catch(() => ({}));
+              throw new Error(j.error || `Failed to close case ${id} (${res.status})`);
+            }
+          }),
+        ),
+      );
+      if (!mountedRef.current) return;
+      setRows((prev) => prev.filter((r) => !ids.includes(r.id)));
+      setTotal((t) => Math.max(0, t - ids.length));
+      setStats((s) => ({
+        ...s,
+        completeCount: Math.max(0, s.completeCount - closingComplete),
+        incompleteCount: Math.max(0, s.incompleteCount - closingIncomplete),
+      }));
+      setSelectedIds(new Set());
+      setBulkCloseConfirming(false);
+    } catch (err) {
+      if (!mountedRef.current) return;
+      setError((err as Error).message);
+    } finally {
+      if (mountedRef.current) setBulkClosing(false);
+    }
   };
 
   const sortIcon = (key: SortKey) => {
@@ -725,6 +782,29 @@ export const FeePetitions = () => {
                       Cancel
                     </button>
                   </>
+                ) : bulkCloseConfirming ? (
+                  <>
+                    <span className={`text-sm ${t.textMuted}`}>
+                      Close {selectedIds.size} case{selectedIds.size !== 1 ? "s" : ""} to Fees Closed?
+                    </span>
+                    <button
+                      onClick={handleBulkClosePetitions}
+                      disabled={bulkClosing}
+                      className={`h-7 px-3 rounded-md text-xs font-medium flex items-center gap-1.5 ${dark ? "bg-indigo-700 hover:bg-indigo-600 text-white" : "bg-indigo-600 hover:bg-indigo-700 text-white"} disabled:opacity-40 disabled:cursor-not-allowed transition-colors`}
+                    >
+                      {bulkClosing
+                        ? <Loader2 aria-hidden="true" className="h-3 w-3 animate-spin" />
+                        : <ArchiveX aria-hidden="true" className="h-3 w-3" />}
+                      Confirm
+                    </button>
+                    <button
+                      onClick={() => setBulkCloseConfirming(false)}
+                      disabled={bulkClosing}
+                      className={`h-7 px-3 rounded-md border text-xs font-medium ${t.outlineBtn} disabled:opacity-40`}
+                    >
+                      Cancel
+                    </button>
+                  </>
                 ) : (
                   <>
                     <span className={`text-sm font-bold ${t.text}`}>
@@ -745,6 +825,16 @@ export const FeePetitions = () => {
                       <Check aria-hidden="true" className="h-3 w-3" />
                       Mark Complete
                     </button>
+                    {canFinalize && (
+                      <button
+                        onClick={() => setBulkCloseConfirming(true)}
+                        aria-label="Move selected cases to Fees Closed"
+                        className={`h-7 px-3 rounded-md border text-xs font-medium flex items-center gap-1.5 ${t.outlineBtn} transition-colors`}
+                      >
+                        <ArchiveX aria-hidden="true" className="h-3 w-3" />
+                        Close to Fees Closed
+                      </button>
+                    )}
                     <button
                       onClick={clearSelection}
                       aria-label="Clear selection"

--- a/src/components/fee-petitions/FeePetitions.tsx
+++ b/src/components/fee-petitions/FeePetitions.tsx
@@ -244,10 +244,14 @@ export const FeePetitions = () => {
   }, [search]);
 
   const fetchAbortRef = useRef<AbortController | null>(null);
+  const bulkCloseAbortRef = useRef<AbortController | null>(null);
   const mountedRef = useRef(true);
   useEffect(() => {
     mountedRef.current = true;
-    return () => { mountedRef.current = false; };
+    return () => {
+      mountedRef.current = false;
+      bulkCloseAbortRef.current?.abort();
+    };
   }, []);
 
   const fetchPetitions = useCallback(async () => {
@@ -464,6 +468,8 @@ export const FeePetitions = () => {
     setBulkClosing(true);
     const ids = [...selectedIds];
     const closingRows = rows.filter((r) => ids.includes(r.id));
+    const controller = new AbortController();
+    bulkCloseAbortRef.current = controller;
     try {
       const results = await Promise.allSettled(
         ids.map((id) =>
@@ -474,6 +480,7 @@ export const FeePetitions = () => {
               feeFields: { isClosed: true },
               logMessage: "Fee petition complete — case moved to Fees Closed.",
             }),
+            signal: controller.signal,
           }).then(async (res) => {
             if (!res.ok) {
               const j = await res.json().catch(() => ({}));

--- a/src/components/fee-petitions/FeePetitions.tsx
+++ b/src/components/fee-petitions/FeePetitions.tsx
@@ -464,10 +464,8 @@ export const FeePetitions = () => {
     setBulkClosing(true);
     const ids = [...selectedIds];
     const closingRows = rows.filter((r) => ids.includes(r.id));
-    const closingComplete = closingRows.filter((r) => CHECKBOX_COLUMNS.every((c) => r[c.key])).length;
-    const closingIncomplete = closingRows.length - closingComplete;
     try {
-      await Promise.all(
+      const results = await Promise.allSettled(
         ids.map((id) =>
           fetch(`/api/cases/${id}`, {
             method: "PATCH",
@@ -481,22 +479,41 @@ export const FeePetitions = () => {
               const j = await res.json().catch(() => ({}));
               throw new Error(j.error || `Failed to close case ${id} (${res.status})`);
             }
+            return id;
           }),
         ),
       );
+
       if (!mountedRef.current) return;
-      setRows((prev) => prev.filter((r) => !ids.includes(r.id)));
-      setTotal((t) => Math.max(0, t - ids.length));
-      setStats((s) => ({
-        ...s,
-        completeCount: Math.max(0, s.completeCount - closingComplete),
-        incompleteCount: Math.max(0, s.incompleteCount - closingIncomplete),
-      }));
+
+      const succeeded = results
+        .filter((r): r is PromiseFulfilledResult<number> => r.status === "fulfilled")
+        .map((r) => r.value);
+      const failures = results.filter((r): r is PromiseRejectedResult => r.status === "rejected");
+
+      if (succeeded.length > 0) {
+        const closedRows = closingRows.filter((r) => succeeded.includes(r.id));
+        const closedComplete = closedRows.filter((r) => CHECKBOX_COLUMNS.every((c) => r[c.key])).length;
+        const closedIncomplete = closedRows.length - closedComplete;
+        setRows((prev) => prev.filter((r) => !succeeded.includes(r.id)));
+        setTotal((t) => Math.max(0, t - succeeded.length));
+        setStats((s) => ({
+          ...s,
+          completeCount: Math.max(0, s.completeCount - closedComplete),
+          incompleteCount: Math.max(0, s.incompleteCount - closedIncomplete),
+        }));
+      }
+
       setSelectedIds(new Set());
       setBulkCloseConfirming(false);
-    } catch (err) {
-      if (!mountedRef.current) return;
-      setError((err as Error).message);
+
+      if (failures.length > 0) {
+        setError(
+          failures.length === 1
+            ? (failures[0].reason as Error).message
+            : `${failures.length} of ${ids.length} cases failed to close — the rest were moved successfully.`,
+        );
+      }
     } finally {
       if (mountedRef.current) setBulkClosing(false);
     }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -54,20 +54,22 @@ export const Header = ({ dateRange, onDateRangeChange }: HeaderProps) => {
 
   // Fetch unread notification count
   useEffect(() => {
+    const controller = new AbortController();
+    const { signal } = controller;
     const fetchCount = async () => {
       try {
-        const res = await fetch("/api/notifications?unread=true&limit=1");
+        const res = await fetch("/api/notifications?unread=true&limit=1", { signal });
         if (res.ok) {
           const json = await res.json();
           setUnreadCount(json.unreadCount || 0);
         }
-      } catch {
-        /* silent */
+      } catch (err) {
+        if ((err as Error).name === "AbortError") return;
       }
     };
     fetchCount();
     const interval = setInterval(fetchCount, 60000); // poll every 60s
-    return () => clearInterval(interval);
+    return () => { clearInterval(interval); controller.abort(); };
   }, []);
 
   useEffect(() => {

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -116,20 +116,22 @@ export const Sidebar = ({ open, onToggle, onMobileClose }: SidebarProps) => {
 
   // Poll notification unread count
   useEffect(() => {
+    const controller = new AbortController();
+    const { signal } = controller;
     const fetchCount = async () => {
       try {
-        const res = await fetch("/api/notifications?unread=true&limit=1");
+        const res = await fetch("/api/notifications?unread=true&limit=1", { signal });
         if (res.ok) {
           const json = await res.json();
           setNotifCount(json.unreadCount || 0);
         }
-      } catch {
-        /* silent */
+      } catch (err) {
+        if ((err as Error).name === "AbortError") return;
       }
     };
     fetchCount();
     const interval = setInterval(fetchCount, 60000);
-    return () => clearInterval(interval);
+    return () => { clearInterval(interval); controller.abort(); };
   }, []);
 
   useEffect(() => {
@@ -160,21 +162,26 @@ export const Sidebar = ({ open, onToggle, onMobileClose }: SidebarProps) => {
         if (debounceRef.current) clearTimeout(debounceRef.current);
       };
     }
+    const controller = new AbortController();
     debounceRef.current = setTimeout(async () => {
       setSearching(true);
       try {
         const res = await fetch(
           `/api/cases?search=${encodeURIComponent(searchQuery.trim())}&limit=8`,
+          { signal: controller.signal },
         );
         if (res.ok) {
           const data = await res.json();
           setSearchResults(data.data || []);
         }
-      } catch {}
+      } catch (err) {
+        if ((err as Error).name === "AbortError") return;
+      }
       setSearching(false);
     }, 300);
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
+      controller.abort();
     };
   }, [searchQuery]);
 
@@ -208,7 +215,7 @@ export const Sidebar = ({ open, onToggle, onMobileClose }: SidebarProps) => {
   return (
     <>
       <aside
-        className={`${open ? "w-64" : "w-14"} ${t.bg} border-r ${t.border} flex flex-col transition-all duration-200 shrink-0 overflow-hidden`}
+        className={`${open ? "w-64" : "w-14"} ${t.bg} border-r ${t.border} flex flex-col transition-[width] duration-200 shrink-0 overflow-hidden`}
       >
         {/* Logo */}
         <div
@@ -301,6 +308,7 @@ export const Sidebar = ({ open, onToggle, onMobileClose }: SidebarProps) => {
                   >
                     <div className="relative shrink-0">
                       <item.icon
+                        aria-hidden="true"
                         className={`h-4 w-4 ${active ? "" : t.textMuted}`}
                       />
                       {item.path === "/notifications" &&
@@ -343,7 +351,7 @@ export const Sidebar = ({ open, onToggle, onMobileClose }: SidebarProps) => {
                 }}
                 className={`w-full flex items-center gap-2 px-3 py-2 text-[13px] font-medium text-left transition-colors ${t.textSub} ${dark ? "hover:bg-neutral-800" : "hover:bg-neutral-50"}`}
               >
-                <KeyRound className="h-4 w-4 shrink-0" />
+                <KeyRound aria-hidden="true" className="h-4 w-4 shrink-0" />
                 Change password
               </button>
               <div className={`border-t ${t.borderLight}`} />
@@ -351,7 +359,7 @@ export const Sidebar = ({ open, onToggle, onMobileClose }: SidebarProps) => {
                 onClick={() => signOut({ callbackUrl: "/login" })}
                 className={`w-full flex items-center gap-2 px-3 py-2 text-[13px] font-medium text-left transition-colors ${dark ? "text-red-400 hover:bg-neutral-800" : "text-red-600 hover:bg-neutral-50"}`}
               >
-                <LogOut className="h-4 w-4 shrink-0" />
+                <LogOut aria-hidden="true" className="h-4 w-4 shrink-0" />
                 Sign out
               </button>
             </div>

--- a/src/components/overpaid-cases/OverpaidCases.tsx
+++ b/src/components/overpaid-cases/OverpaidCases.tsx
@@ -784,7 +784,7 @@ export const OverpaidCases = () => {
           {!isInitialLoad && total > 0 && (
             <div className={`mt-2 h-1.5 rounded-full ${dark ? "bg-neutral-700" : "bg-neutral-200"}`}>
               <div
-                className="h-1.5 rounded-full bg-emerald-500 transition-all duration-300"
+                className="h-1.5 rounded-full bg-emerald-500 transition-[width] duration-300"
                 style={{ width: `${Math.min(100, (stats.clearedCount / total) * 100)}%` }}
               />
             </div>
@@ -799,7 +799,7 @@ export const OverpaidCases = () => {
           {!isInitialLoad && total > 0 && (
             <div className={`mt-2 h-1.5 rounded-full ${dark ? "bg-neutral-700" : "bg-neutral-200"}`}>
               <div
-                className="h-1.5 rounded-full bg-indigo-500 transition-all duration-300"
+                className="h-1.5 rounded-full bg-indigo-500 transition-[width] duration-300"
                 style={{ width: `${Math.min(100, (stats.ltrCount / total) * 100)}%` }}
               />
             </div>

--- a/src/components/overpaid-cases/OverpaidCases.tsx
+++ b/src/components/overpaid-cases/OverpaidCases.tsx
@@ -680,7 +680,7 @@ export const OverpaidCases = () => {
         const json = await res.json();
         all = json.data || [];
       }
-      const headers = ["Case", "Assigned To", "Region", "Fees Received", "Overpaid Amount", "Fees Confirmation", "O/P Ltr Date", "O/P LTR Date Received", "Notes", "Checks Cleared", "Last Updated"];
+      const headers = ["Case", "Assigned To", "Region", "Fees Received", "Overpaid Amount", "Fees Confirmation", "Notice Sent", "Notice Received", "Notes", "Checks Cleared", "Last Updated"];
       const escape = (v: string) => {
         const safe = /^[=+\-@\t\r]/.test(v) ? `'${v}` : v;
         return `"${safe.replace(/"/g, '""')}"`;
@@ -1183,7 +1183,7 @@ export const OverpaidCases = () => {
                   </button>
                 </th>
                 <th className={`${thBase} ${t.textSub} text-left sticky top-0 z-20 ${stickyHeaderBg}`}>Fees Confirmation</th>
-                <th className={`${thBase} ${t.textSub} text-left sticky top-0 z-20 ${stickyHeaderBg}`}>O/P Ltr Date</th>
+                <th className={`${thBase} ${t.textSub} text-left sticky top-0 z-20 ${stickyHeaderBg}`}>Notice Sent</th>
                 <th
                   aria-sort={ariaSortFor("opLtrDate")}
                   className={`${thBase} ${t.textSub} text-left sticky top-0 z-20 ${stickyHeaderBg}`}
@@ -1193,7 +1193,7 @@ export const OverpaidCases = () => {
                     onClick={() => toggleSort("opLtrDate")}
                     className="inline-flex items-center gap-1 cursor-pointer rounded-sm focus:outline-none focus:ring-2 focus:ring-inset focus:ring-neutral-300 dark:focus:ring-neutral-600"
                   >
-                    O/P LTR Date Received {sortIcon("opLtrDate")}
+                    Notice Received {sortIcon("opLtrDate")}
                   </button>
                 </th>
                 <th className={`${thBase} ${t.textSub} text-left min-w-48 sticky top-0 z-20 ${stickyHeaderBg}`}>Notes</th>

--- a/src/components/reports/Reports.tsx
+++ b/src/components/reports/Reports.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useTheme } from "next-themes";
 import {
   BarChart3,
@@ -151,15 +151,21 @@ export const Reports = () => {
   const [expandedAgent, setExpandedAgent] = useState<string | null>(null);
   const [showPresets, setShowPresets] = useState(false);
 
+  const fetchAbortRef = useRef<AbortController | null>(null);
+
   const fetchReport = useCallback(async () => {
+    fetchAbortRef.current?.abort();
+    const controller = new AbortController();
+    fetchAbortRef.current = controller;
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch(`/api/reports?from=${fromDate}&to=${toDate}`);
-      if (!res.ok) throw new Error("Failed to load report");
+      const res = await fetch(`/api/reports?from=${fromDate}&to=${toDate}`, { signal: controller.signal });
+      if (!res.ok) throw new Error(`Failed to load report (${res.status})`);
       const json = await res.json();
       setData(json.data);
     } catch (err) {
+      if ((err as Error).name === "AbortError") return;
       setError((err as Error).message);
     } finally {
       setLoading(false);
@@ -168,6 +174,7 @@ export const Reports = () => {
 
   useEffect(() => {
     fetchReport();
+    return () => fetchAbortRef.current?.abort();
   }, [fetchReport]);
 
   const handleSort = (key: SortKey) => {

--- a/src/components/scoreboard/Scoreboard.tsx
+++ b/src/components/scoreboard/Scoreboard.tsx
@@ -303,16 +303,21 @@ export const Scoreboard = () => {
         : formatWeekLabel(monday);
 
   // Fetch scoreboard data
+  const fetchAbortRef = useRef<AbortController | null>(null);
+
   const fetchScoreboard = useCallback(async () => {
     if (!windowReady) {
       setLoading(false);
       return;
     }
+    fetchAbortRef.current?.abort();
+    const controller = new AbortController();
+    fetchAbortRef.current = controller;
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch(`/api/scoreboard?${scoreboardQuery}`);
-      if (!res.ok) throw new Error("Failed to fetch scoreboard");
+      const res = await fetch(`/api/scoreboard?${scoreboardQuery}`, { signal: controller.signal });
+      if (!res.ok) throw new Error(`Failed to fetch scoreboard (${res.status})`);
       const json = await res.json();
       setData(json);
 
@@ -331,6 +336,7 @@ export const Scoreboard = () => {
       setCells(map);
       setDirty(false);
     } catch (err) {
+      if ((err as Error).name === "AbortError") return;
       setError((err as Error).message);
     } finally {
       setLoading(false);
@@ -339,6 +345,7 @@ export const Scoreboard = () => {
 
   useEffect(() => {
     fetchScoreboard();
+    return () => fetchAbortRef.current?.abort();
   }, [fetchScoreboard]);
 
   // Auto-scroll to entry panel when opened
@@ -442,7 +449,7 @@ export const Scoreboard = () => {
         body: JSON.stringify({ entries }),
       });
 
-      if (!res.ok) throw new Error("Failed to save");
+      if (!res.ok) throw new Error(`Failed to save (${res.status})`);
 
       setSaveMsg(`Saved ${entries.length} entries`);
       setDirty(false);

--- a/src/components/scoreboard/Scoreboard.tsx
+++ b/src/components/scoreboard/Scoreboard.tsx
@@ -31,24 +31,51 @@ import { fmt } from "@/lib/formatters";
 
 interface AgentScore {
   agent: string;
+  team: string | null;
   casesAssigned: number;
+  openCases: number;
+  casesClosed: number;
   completedWinSheets: number;
+  winSheetsCreated: number;
   unpaidT2Over60: number;
   unpaidT16Over60: number;
   unpaidConcOver60: number;
   totalCollected: number;
+  feesCollectedInWindow: number;
   casesFullFee: number;
   weekSsaCalls: number;
   weekClientCalls: number;
 }
 
+interface TeamScore {
+  team: string;
+  agentCount: number;
+  casesAssigned: number;
+  openCases: number;
+  casesClosed: number;
+  completedWinSheets: number;
+  winSheetsCreated: number;
+  unpaidT2Over60: number;
+  unpaidT16Over60: number;
+  unpaidConcOver60: number;
+  totalCollected: number;
+  feesCollectedInWindow: number;
+  casesFullFee: number;
+  ssaCalls: number;
+  clientCalls: number;
+}
+
 interface Summary {
   totalCasesAssigned: number;
+  totalOpenCases: number;
+  totalCasesClosed: number;
   totalCompletedWinSheets: number;
+  totalWinSheetsCreated: number;
   totalUnpaidT2Over60: number;
   totalUnpaidT16Over60: number;
   totalUnpaidConcOver60: number;
   totalCollected: number;
+  totalFeesCollectedInWindow: number;
   totalCasesFullFee: number;
   totalSsaCalls: number;
   totalClientCalls: number;
@@ -60,6 +87,7 @@ interface DailyEntry {
   ssaCalls: number;
   clientCallsIb: number;
   clientCallsOb: number;
+  winSheetsCreated: number;
   notes: string | null;
 }
 
@@ -67,15 +95,17 @@ interface ScoreboardData {
   week: string;
   summary: Summary;
   agents: AgentScore[];
+  teams: TeamScore[];
   daily: DailyEntry[];
 }
 
-// Cell value for the entry grid: [ssaCalls, clientCallsIb, clientCallsOb]
+// Cell value for the entry grid
 type CellKey = `${string}|${string}`;
 interface CellValues {
   ssaCalls: string;
   clientCallsIb: string;
   clientCallsOb: string;
+  winSheetsCreated: string;
 }
 
 // ============================================================================
@@ -223,20 +253,15 @@ export const Scoreboard = () => {
   const filteredSummary = useMemo(
     () => ({
       totalCasesAssigned: filteredAgents.reduce((s, a) => s + a.casesAssigned, 0),
-      totalCompletedWinSheets: filteredAgents.reduce(
-        (s, a) => s + a.completedWinSheets,
-        0,
-      ),
+      totalOpenCases: filteredAgents.reduce((s, a) => s + a.openCases, 0),
+      totalCasesClosed: filteredAgents.reduce((s, a) => s + a.casesClosed, 0),
+      totalCompletedWinSheets: filteredAgents.reduce((s, a) => s + a.completedWinSheets, 0),
+      totalWinSheetsCreated: filteredAgents.reduce((s, a) => s + a.winSheetsCreated, 0),
       totalUnpaidT2Over60: filteredAgents.reduce((s, a) => s + a.unpaidT2Over60, 0),
-      totalUnpaidT16Over60: filteredAgents.reduce(
-        (s, a) => s + a.unpaidT16Over60,
-        0,
-      ),
-      totalUnpaidConcOver60: filteredAgents.reduce(
-        (s, a) => s + a.unpaidConcOver60,
-        0,
-      ),
+      totalUnpaidT16Over60: filteredAgents.reduce((s, a) => s + a.unpaidT16Over60, 0),
+      totalUnpaidConcOver60: filteredAgents.reduce((s, a) => s + a.unpaidConcOver60, 0),
       totalCollected: filteredAgents.reduce((s, a) => s + a.totalCollected, 0),
+      totalFeesCollectedInWindow: filteredAgents.reduce((s, a) => s + a.feesCollectedInWindow, 0),
       totalCasesFullFee: filteredAgents.reduce((s, a) => s + a.casesFullFee, 0),
       totalSsaCalls: filteredAgents.reduce((s, a) => s + a.weekSsaCalls, 0),
       totalClientCalls: filteredAgents.reduce((s, a) => s + a.weekClientCalls, 0),
@@ -299,6 +324,7 @@ export const Scoreboard = () => {
             ssaCalls: d.ssaCalls > 0 ? String(d.ssaCalls) : "",
             clientCallsIb: d.clientCallsIb > 0 ? String(d.clientCallsIb) : "",
             clientCallsOb: d.clientCallsOb > 0 ? String(d.clientCallsOb) : "",
+            winSheetsCreated: d.winSheetsCreated > 0 ? String(d.winSheetsCreated) : "",
           });
         }
       }
@@ -328,15 +354,10 @@ export const Scoreboard = () => {
   }, [entryOpen]);
 
   // Cell accessors
-  const getCell = (agent: string, date: string): CellValues => {
-    return (
-      cells.get(cellKey(agent, date)) || {
-        ssaCalls: "",
-        clientCallsIb: "",
-        clientCallsOb: "",
-      }
-    );
-  };
+  const EMPTY_CELL: CellValues = { ssaCalls: "", clientCallsIb: "", clientCallsOb: "", winSheetsCreated: "" };
+
+  const getCell = (agent: string, date: string): CellValues =>
+    cells.get(cellKey(agent, date)) ?? { ...EMPTY_CELL };
 
   const setCell = (
     agent: string,
@@ -346,11 +367,7 @@ export const Scoreboard = () => {
   ) => {
     setCells((prev) => {
       const next = new Map(prev);
-      const existing = next.get(cellKey(agent, date)) || {
-        ssaCalls: "",
-        clientCallsIb: "",
-        clientCallsOb: "",
-      };
+      const existing = next.get(cellKey(agent, date)) ?? { ...EMPTY_CELL };
       next.set(cellKey(agent, date), { ...existing, [field]: value });
       return next;
     });
@@ -360,16 +377,15 @@ export const Scoreboard = () => {
 
   // Agent weekly totals from cells
   const agentCellTotals = (agent: string) => {
-    let ssa = 0,
-      ib = 0,
-      ob = 0;
+    let ssa = 0, ib = 0, ob = 0, ws = 0;
     for (const day of weekDays) {
       const c = getCell(agent, day.date);
       ssa += parseInt(c.ssaCalls) || 0;
       ib += parseInt(c.clientCallsIb) || 0;
       ob += parseInt(c.clientCallsOb) || 0;
+      ws += parseInt(c.winSheetsCreated) || 0;
     }
-    return { ssa, ib, ob, total: ssa + ib + ob };
+    return { ssa, ib, ob, ws, total: ssa + ib + ob };
   };
 
   // Save all cells
@@ -383,6 +399,7 @@ export const Scoreboard = () => {
         ssaCalls: number;
         clientCallsIb: number;
         clientCallsOb: number;
+        winSheetsCreated: number;
       }[] = [];
 
       if (data) {
@@ -392,11 +409,12 @@ export const Scoreboard = () => {
             const ssa = parseInt(c.ssaCalls) || 0;
             const ib = parseInt(c.clientCallsIb) || 0;
             const ob = parseInt(c.clientCallsOb) || 0;
-            // Only send if there's any value (or if there was previously a value — to allow clearing)
+            const ws = parseInt(c.winSheetsCreated) || 0;
             if (
               ssa > 0 ||
               ib > 0 ||
               ob > 0 ||
+              ws > 0 ||
               cells.has(cellKey(agent.agent, day.date))
             ) {
               entries.push({
@@ -405,6 +423,7 @@ export const Scoreboard = () => {
                 ssaCalls: ssa,
                 clientCallsIb: ib,
                 clientCallsOb: ob,
+                winSheetsCreated: ws,
               });
             }
           }
@@ -648,6 +667,58 @@ export const Scoreboard = () => {
                   </div>
                 ))}
               </div>
+
+              {/* Team breakdown — only shown when teams data is present */}
+              {data.teams && data.teams.length > 0 && (
+                <div className={`p-4 border-b ${t.borderLight}`}>
+                  <p className={`text-[10px] font-semibold uppercase tracking-wider ${t.textMuted} mb-3`}>
+                    By Team — {windowLabel}
+                  </p>
+                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                    {data.teams.map((team) => {
+                      const teamColor =
+                        team.team === "T2"
+                          ? dark ? "border-blue-700/50 bg-blue-900/10" : "border-blue-200 bg-blue-50/60"
+                          : team.team === "T16"
+                          ? dark ? "border-purple-700/50 bg-purple-900/10" : "border-purple-200 bg-purple-50/60"
+                          : dark ? "border-teal-700/50 bg-teal-900/10" : "border-teal-200 bg-teal-50/60";
+                      const teamLabel =
+                        team.team === "T2" ? "T2 Team"
+                        : team.team === "T16" ? "T16 Team"
+                        : "Concurrent Team";
+                      const accentText =
+                        team.team === "T2"
+                          ? dark ? "text-blue-400" : "text-blue-700"
+                          : team.team === "T16"
+                          ? dark ? "text-purple-400" : "text-purple-700"
+                          : dark ? "text-teal-400" : "text-teal-700";
+                      return (
+                        <div key={team.team} className={`rounded-lg border p-4 ${teamColor}`}>
+                          <div className="flex items-center justify-between mb-3">
+                            <span className={`text-xs font-bold ${accentText}`}>{teamLabel}</span>
+                            <span className={`text-[10px] ${t.textMuted}`}>{team.agentCount} agent{team.agentCount !== 1 ? "s" : ""}</span>
+                          </div>
+                          <div className="grid grid-cols-3 gap-2">
+                            {[
+                              { label: "Fees Collected", value: fmt(team.feesCollectedInWindow) },
+                              { label: "SSA Calls", value: team.ssaCalls },
+                              { label: "CL Calls", value: team.clientCalls },
+                              { label: "Win Sheets", value: team.winSheetsCreated },
+                              { label: "Cases Closed", value: team.casesClosed },
+                              { label: "Open Cases", value: team.openCases },
+                            ].map((stat) => (
+                              <div key={stat.label}>
+                                <p className={`text-[9px] font-medium uppercase tracking-wide ${t.textMuted}`}>{stat.label}</p>
+                                <p className={`text-sm font-bold ${t.text} mt-0.5`}>{stat.value}</p>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
 
               {/* Monitoring filters (client-side, current week) */}
               <div
@@ -991,7 +1062,7 @@ export const Scoreboard = () => {
                       <tr className={rowBorder}>
                         <td
                           className={`${tdBase} ${t.text} font-semibold align-middle`}
-                          rowSpan={3}
+                          rowSpan={4}
                         >
                           <div className="flex items-center gap-2">
                             <div
@@ -1067,7 +1138,7 @@ export const Scoreboard = () => {
                         </td>
                       </tr>
                       {/* Row 3: Client OB */}
-                      <tr className={`border-b ${rowBorder}`}>
+                      <tr className={rowBorder}>
                         <td
                           className={`px-2 py-1.5 text-[10px] font-medium ${dark ? "text-amber-400" : "text-amber-600"} whitespace-nowrap`}
                         >
@@ -1098,6 +1169,33 @@ export const Scoreboard = () => {
                           className={`px-2 py-1 text-center text-[11px] font-semibold tabular-nums ${totals.ob > 0 ? (dark ? "text-amber-400" : "text-amber-600") : t.textMuted}`}
                         >
                           {totals.ob || "—"}
+                        </td>
+                      </tr>
+                      {/* Row 4: Win Sheets Created */}
+                      <tr className={`border-b ${rowBorder}`}>
+                        <td
+                          className={`px-2 py-1.5 text-[10px] font-medium ${dark ? "text-violet-400" : "text-violet-600"} whitespace-nowrap`}
+                        >
+                          Win Sheets
+                        </td>
+                        {weekDays.map((day) => (
+                          <td key={day.date} className="px-1 py-1 text-center">
+                            <input
+                              type="number"
+                              min="0"
+                              value={getCell(agent.agent, day.date).winSheetsCreated}
+                              onChange={(e) =>
+                                setCell(agent.agent, day.date, "winSheetsCreated", e.target.value)
+                              }
+                              placeholder="0"
+                              className={miniInput}
+                            />
+                          </td>
+                        ))}
+                        <td
+                          className={`px-2 py-1 text-center text-[11px] font-semibold tabular-nums ${totals.ws > 0 ? (dark ? "text-violet-400" : "text-violet-600") : t.textMuted}`}
+                        >
+                          {totals.ws || "—"}
                         </td>
                       </tr>
                     </React.Fragment>

--- a/src/components/settings/DropdownOptionsCard.tsx
+++ b/src/components/settings/DropdownOptionsCard.tsx
@@ -61,7 +61,7 @@ export function DropdownOptionsCard({ category, label, description }: Props) {
       const res = await fetch(
         `/api/settings/dropdown-options?category=${encodeURIComponent(category)}`,
       );
-      if (!res.ok) throw new Error("Failed to load options");
+      if (!res.ok) throw new Error(`Failed to load options (${res.status})`);
       const json = await res.json();
       setOptions(json.data || []);
     } catch (e) {
@@ -87,7 +87,7 @@ export function DropdownOptionsCard({ category, label, description }: Props) {
         body: JSON.stringify({ category, name }),
       });
       const json = await res.json().catch(() => ({}));
-      if (!res.ok) throw new Error(json.error || "Failed to add");
+      if (!res.ok) throw new Error(json.error || `Failed to add (${res.status})`);
       setNewName("");
       await load();
     } catch (e) {
@@ -111,7 +111,7 @@ export function DropdownOptionsCard({ category, label, description }: Props) {
         body: JSON.stringify(patch),
       });
       const json = await res.json().catch(() => ({}));
-      if (!res.ok) throw new Error(json.error || "Failed to update");
+      if (!res.ok) throw new Error(json.error || `Failed to update (${res.status})`);
       setEditingId(null);
       await load();
     } catch (e) {
@@ -137,7 +137,7 @@ export function DropdownOptionsCard({ category, label, description }: Props) {
       });
       if (!res.ok) {
         const j = await res.json().catch(() => ({}));
-        throw new Error(j.error || "Failed to delete");
+        throw new Error(j.error || `Failed to delete (${res.status})`);
       }
       await load();
     } catch (e) {
@@ -273,12 +273,13 @@ export function DropdownOptionsCard({ category, label, description }: Props) {
                           rowBusy ||
                           editName.trim() === opt.name
                         }
+                        aria-label="Save"
                         className="h-7"
                       >
                         {rowBusy ? (
-                          <Loader2 className="h-3 w-3 animate-spin" />
+                          <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
                         ) : (
-                          <Check className="h-3 w-3" />
+                          <Check className="h-3 w-3" aria-hidden="true" />
                         )}
                       </Button>
                       <Button
@@ -287,9 +288,10 @@ export function DropdownOptionsCard({ category, label, description }: Props) {
                         variant="outline"
                         onClick={cancelEdit}
                         disabled={rowBusy}
+                        aria-label="Cancel"
                         className="h-7"
                       >
-                        <X className="h-3 w-3" />
+                        <X className="h-3 w-3" aria-hidden="true" />
                       </Button>
                     </>
                   ) : (
@@ -318,9 +320,10 @@ export function DropdownOptionsCard({ category, label, description }: Props) {
                         variant="outline"
                         onClick={() => startEdit(opt)}
                         disabled={rowBusy}
+                        aria-label={`Edit ${opt.name}`}
                         className="h-7"
                       >
-                        <Pencil className="h-3 w-3" />
+                        <Pencil className="h-3 w-3" aria-hidden="true" />
                       </Button>
                       <Button
                         type="button"
@@ -328,12 +331,13 @@ export function DropdownOptionsCard({ category, label, description }: Props) {
                         variant="outline"
                         onClick={() => handleDelete(opt)}
                         disabled={rowBusy}
+                        aria-label={`Delete ${opt.name}`}
                         className={`h-7 ${dark ? "text-red-400" : "text-red-600"}`}
                       >
                         {rowBusy ? (
-                          <Loader2 className="h-3 w-3 animate-spin" />
+                          <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
                         ) : (
-                          <Trash2 className="h-3 w-3" />
+                          <Trash2 className="h-3 w-3" aria-hidden="true" />
                         )}
                       </Button>
                     </>

--- a/src/components/settings/DropdownOptionsCard.tsx
+++ b/src/components/settings/DropdownOptionsCard.tsx
@@ -176,9 +176,14 @@ export function DropdownOptionsCard({ category, label, description }: Props) {
     const a = options[idx];
     const b = options[swapIdx];
 
+    // Use position-based sort_order values rather than swapping existing ones,
+    // so items that share sort_order=0 (e.g. newly added options) still move correctly.
+    const newOrderA = (swapIdx + 1) * 10;
+    const newOrderB = (idx + 1) * 10;
+
     const reordered = [...options];
-    reordered[idx] = b;
-    reordered[swapIdx] = a;
+    reordered[idx] = { ...b, sortOrder: newOrderB };
+    reordered[swapIdx] = { ...a, sortOrder: newOrderA };
     setOptions(reordered);
     setBusyId(id);
     setError(null);
@@ -190,7 +195,7 @@ export function DropdownOptionsCard({ category, label, description }: Props) {
         fetch(`/api/settings/dropdown-options/${a.id}`, {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ sortOrder: b.sortOrder }),
+          body: JSON.stringify({ sortOrder: newOrderA }),
           signal: controller.signal,
         }).then(async (res) => {
           if (!res.ok) {
@@ -201,7 +206,7 @@ export function DropdownOptionsCard({ category, label, description }: Props) {
         fetch(`/api/settings/dropdown-options/${b.id}`, {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ sortOrder: a.sortOrder }),
+          body: JSON.stringify({ sortOrder: newOrderB }),
           signal: controller.signal,
         }).then(async (res) => {
           if (!res.ok) {

--- a/src/components/settings/DropdownOptionsCard.tsx
+++ b/src/components/settings/DropdownOptionsCard.tsx
@@ -11,6 +11,8 @@ import {
   Pencil,
   Check,
   X,
+  ChevronUp,
+  ChevronDown,
 } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
 import { Button } from "@/components/ui/button";
@@ -161,6 +163,47 @@ export function DropdownOptionsCard({ category, label, description }: Props) {
     handleUpdate(id, { name });
   };
 
+  const handleMove = async (id: number, direction: "up" | "down") => {
+    const idx = options.findIndex((o) => o.id === id);
+    if (idx === -1) return;
+    if (direction === "up" && idx === 0) return;
+    if (direction === "down" && idx === options.length - 1) return;
+    if (busyId !== null) return;
+
+    const reordered = [...options];
+    const swapIdx = direction === "up" ? idx - 1 : idx + 1;
+    [reordered[idx], reordered[swapIdx]] = [reordered[swapIdx], reordered[idx]];
+
+    setOptions(reordered);
+    setBusyId(id);
+    setError(null);
+    try {
+      await Promise.all(
+        reordered.map((o, i) =>
+          fetch(`/api/settings/dropdown-options/${o.id}`, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ sortOrder: i * 10 }),
+          }).then(async (res) => {
+            if (!res.ok) {
+              const j = await res.json().catch(() => ({}));
+              throw new Error(
+                (j as { error?: string }).error ||
+                  `Failed to reorder (${res.status})`,
+              );
+            }
+          }),
+        ),
+      );
+      await load();
+    } catch (e) {
+      setError((e as Error).message);
+      await load();
+    } finally {
+      setBusyId(null);
+    }
+  };
+
   return (
     <div className={sectionCard}>
       <div
@@ -296,6 +339,26 @@ export function DropdownOptionsCard({ category, label, description }: Props) {
                     </>
                   ) : (
                     <>
+                      <div className="flex flex-col gap-0.5 shrink-0">
+                        <button
+                          type="button"
+                          onClick={() => handleMove(opt.id, "up")}
+                          disabled={rowBusy || busyId !== null || options.indexOf(opt) === 0}
+                          aria-label={`Move ${opt.name} up`}
+                          className={`h-4 w-5 flex items-center justify-center rounded text-[10px] disabled:opacity-30 ${t.hover} ${t.textSub}`}
+                        >
+                          <ChevronUp aria-hidden="true" className="h-3 w-3" />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleMove(opt.id, "down")}
+                          disabled={rowBusy || busyId !== null || options.indexOf(opt) === options.length - 1}
+                          aria-label={`Move ${opt.name} down`}
+                          className={`h-4 w-5 flex items-center justify-center rounded text-[10px] disabled:opacity-30 ${t.hover} ${t.textSub}`}
+                        >
+                          <ChevronDown aria-hidden="true" className="h-3 w-3" />
+                        </button>
+                      </div>
                       <span
                         className={`flex-1 text-xs ${opt.isActive ? t.text : t.textMuted} ${opt.isActive ? "" : "line-through"}`}
                       >

--- a/src/components/settings/DropdownOptionsCard.tsx
+++ b/src/components/settings/DropdownOptionsCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTheme } from "next-themes";
 import {
   Plus,
@@ -53,6 +53,8 @@ export function DropdownOptionsCard({ category, label, description }: Props) {
   const [newName, setNewName] = useState("");
   const [editingId, setEditingId] = useState<number | null>(null);
   const [editName, setEditName] = useState("");
+  const moveAbortRef = useRef<AbortController | null>(null);
+  useEffect(() => () => { moveAbortRef.current?.abort(); }, []);
 
   const sectionCard = `rounded-xl border ${t.card}`;
 
@@ -170,36 +172,51 @@ export function DropdownOptionsCard({ category, label, description }: Props) {
     if (direction === "down" && idx === options.length - 1) return;
     if (busyId !== null) return;
 
-    const reordered = [...options];
     const swapIdx = direction === "up" ? idx - 1 : idx + 1;
-    [reordered[idx], reordered[swapIdx]] = [reordered[swapIdx], reordered[idx]];
+    const a = options[idx];
+    const b = options[swapIdx];
 
+    const reordered = [...options];
+    reordered[idx] = b;
+    reordered[swapIdx] = a;
     setOptions(reordered);
     setBusyId(id);
     setError(null);
+
+    const controller = new AbortController();
+    moveAbortRef.current = controller;
     try {
-      await Promise.all(
-        reordered.map((o, i) =>
-          fetch(`/api/settings/dropdown-options/${o.id}`, {
-            method: "PATCH",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ sortOrder: i * 10 }),
-          }).then(async (res) => {
-            if (!res.ok) {
-              const j = await res.json().catch(() => ({}));
-              throw new Error(
-                (j as { error?: string }).error ||
-                  `Failed to reorder (${res.status})`,
-              );
-            }
-          }),
-        ),
-      );
+      await Promise.all([
+        fetch(`/api/settings/dropdown-options/${a.id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ sortOrder: b.sortOrder }),
+          signal: controller.signal,
+        }).then(async (res) => {
+          if (!res.ok) {
+            const j = await res.json().catch(() => ({}));
+            throw new Error((j as { error?: string }).error || `Failed to reorder (${res.status})`);
+          }
+        }),
+        fetch(`/api/settings/dropdown-options/${b.id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ sortOrder: a.sortOrder }),
+          signal: controller.signal,
+        }).then(async (res) => {
+          if (!res.ok) {
+            const j = await res.json().catch(() => ({}));
+            throw new Error((j as { error?: string }).error || `Failed to reorder (${res.status})`);
+          }
+        }),
+      ]);
       await load();
     } catch (e) {
+      if ((e as Error).name === "AbortError") return;
       setError((e as Error).message);
       await load();
     } finally {
+      if (moveAbortRef.current === controller) moveAbortRef.current = null;
       setBusyId(null);
     }
   };

--- a/src/components/team/TeamManagement.tsx
+++ b/src/components/team/TeamManagement.tsx
@@ -108,14 +108,16 @@ export const TeamManagement = () => {
 
   useEffect(() => {
     fetchMembers();
-    fetch("/api/settings/dropdown-options?category=team")
+    const controller = new AbortController();
+    fetch("/api/settings/dropdown-options?category=team", { signal: controller.signal })
       .then((r) => r.ok ? r.json() : null)
       .then((json) => {
         if (json?.data?.length > 0) {
           setTeamOptions(json.data.map((o: { name: string }) => o.name));
         }
       })
-      .catch(() => {});
+      .catch((e: Error) => { if (e.name !== "AbortError") console.error("Failed to load team options:", e); });
+    return () => controller.abort();
   }, [fetchMembers]);
 
   /* ---- Filter ---- */

--- a/src/components/team/TeamManagement.tsx
+++ b/src/components/team/TeamManagement.tsx
@@ -27,6 +27,7 @@ interface TeamMemberFull {
   id: number;
   name: string;
   role: string;
+  team: string | null;
   isActive: boolean;
   createdAt: string;
   cases: number;
@@ -42,6 +43,8 @@ const ROLES = [
   { value: "attorney", label: "Attorney" },
   { value: "admin", label: "Admin" },
 ] as const;
+
+const DEFAULT_TEAMS = ["T2", "T16", "Concurrent"];
 
 const roleLabel = (role: string) =>
   ROLES.find((r) => r.value === role)?.label ??
@@ -69,6 +72,7 @@ export const TeamManagement = () => {
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [showInactive, setShowInactive] = useState(false);
+  const [teamOptions, setTeamOptions] = useState<string[]>(DEFAULT_TEAMS);
 
   // Dialog state
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -77,6 +81,7 @@ export const TeamManagement = () => {
   );
   const [formName, setFormName] = useState("");
   const [formRole, setFormRole] = useState("collections_specialist");
+  const [formTeam, setFormTeam] = useState<string>("");
   const [saving, setSaving] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
 
@@ -103,6 +108,14 @@ export const TeamManagement = () => {
 
   useEffect(() => {
     fetchMembers();
+    fetch("/api/settings/dropdown-options?category=team")
+      .then((r) => r.ok ? r.json() : null)
+      .then((json) => {
+        if (json?.data?.length > 0) {
+          setTeamOptions(json.data.map((o: { name: string }) => o.name));
+        }
+      })
+      .catch(() => {});
   }, [fetchMembers]);
 
   /* ---- Filter ---- */
@@ -126,6 +139,7 @@ export const TeamManagement = () => {
     setEditingMember(null);
     setFormName("");
     setFormRole("collections_specialist");
+    setFormTeam("");
     setFormError(null);
     setDialogOpen(true);
   };
@@ -134,6 +148,7 @@ export const TeamManagement = () => {
     setEditingMember(m);
     setFormName(m.name);
     setFormRole(m.role);
+    setFormTeam(m.team ?? "");
     setFormError(null);
     setDialogOpen(true);
   };
@@ -155,6 +170,7 @@ export const TeamManagement = () => {
             id: editingMember.id,
             name: formName.trim(),
             role: formRole,
+            team: formTeam || null,
           }),
         });
         const json = await res.json();
@@ -163,7 +179,7 @@ export const TeamManagement = () => {
         const res = await fetch("/api/team-members", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ name: formName.trim(), role: formRole }),
+          body: JSON.stringify({ name: formName.trim(), role: formRole, team: formTeam || null }),
         });
         const json = await res.json();
         if (!res.ok) throw new Error(json.error || "Failed to create");
@@ -354,6 +370,11 @@ export const TeamManagement = () => {
                   Role
                 </th>
                 <th
+                  className={`px-4 py-2.5 text-left font-semibold ${t.textMuted} text-[11px]`}
+                >
+                  Team
+                </th>
+                <th
                   className={`px-4 py-2.5 text-center font-semibold ${t.textMuted} text-[11px]`}
                 >
                   Status
@@ -391,7 +412,7 @@ export const TeamManagement = () => {
               {filtered.length === 0 ? (
                 <tr>
                   <td
-                    colSpan={8}
+                    colSpan={9}
                     className={`px-4 py-12 text-center text-sm ${t.textMuted}`}
                   >
                     {search
@@ -422,6 +443,25 @@ export const TeamManagement = () => {
                     {/* Role */}
                     <td className={`px-4 py-2.5 ${t.textSub}`}>
                       {roleLabel(m.role)}
+                    </td>
+
+                    {/* Team */}
+                    <td className="px-4 py-2.5">
+                      {m.team ? (
+                        <span
+                          className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold ${
+                            m.team === "T2"
+                              ? dark ? "bg-blue-900/30 text-blue-400" : "bg-blue-50 text-blue-700"
+                              : m.team === "T16"
+                              ? dark ? "bg-purple-900/30 text-purple-400" : "bg-purple-50 text-purple-700"
+                              : dark ? "bg-teal-900/30 text-teal-400" : "bg-teal-50 text-teal-700"
+                          }`}
+                        >
+                          {m.team}
+                        </span>
+                      ) : (
+                        <span className={`text-[10px] ${t.textMuted}`}>—</span>
+                      )}
                     </td>
 
                     {/* Status */}
@@ -565,6 +605,34 @@ export const TeamManagement = () => {
                   </select>
                   <ChevronDown
                     className={`absolute right-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 ${t.textMuted} pointer-events-none`}
+                    aria-hidden="true"
+                  />
+                </div>
+              </div>
+
+              {/* Team */}
+              <div>
+                <label
+                  className={`block text-[11px] font-semibold ${t.textMuted} mb-1`}
+                >
+                  Team
+                </label>
+                <div className="relative">
+                  <select
+                    value={formTeam}
+                    onChange={(e) => setFormTeam(e.target.value)}
+                    className={`w-full h-8 px-3 pr-8 rounded-lg border text-xs outline-none appearance-none ${t.inputBg} focus:ring-2 focus:ring-indigo-500/40`}
+                  >
+                    <option value="">— Unassigned —</option>
+                    {teamOptions.map((name) => (
+                      <option key={name} value={name}>
+                        {name}
+                      </option>
+                    ))}
+                  </select>
+                  <ChevronDown
+                    className={`absolute right-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 ${t.textMuted} pointer-events-none`}
+                    aria-hidden="true"
                   />
                 </div>
               </div>

--- a/src/components/team/TeamManagement.tsx
+++ b/src/components/team/TeamManagement.tsx
@@ -95,7 +95,7 @@ export const TeamManagement = () => {
   const fetchMembers = useCallback(async () => {
     try {
       const res = await fetch("/api/team-members");
-      if (!res.ok) throw new Error("Failed to load team members");
+      if (!res.ok) throw new Error(`Failed to load team members (${res.status})`);
       const json = await res.json();
       setMembers(json.data);
       setError(null);
@@ -174,7 +174,7 @@ export const TeamManagement = () => {
           }),
         });
         const json = await res.json();
-        if (!res.ok) throw new Error(json.error || "Failed to update");
+        if (!res.ok) throw new Error(json.error || `Failed to update (${res.status})`);
       } else {
         const res = await fetch("/api/team-members", {
           method: "POST",
@@ -182,7 +182,7 @@ export const TeamManagement = () => {
           body: JSON.stringify({ name: formName.trim(), role: formRole, team: formTeam || null }),
         });
         const json = await res.json();
-        if (!res.ok) throw new Error(json.error || "Failed to create");
+        if (!res.ok) throw new Error(json.error || `Failed to create (${res.status})`);
       }
       setDialogOpen(false);
       await fetchMembers();

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -401,6 +401,7 @@ export const teamMembers = pgTable("team_members", {
   id: serial("id").primaryKey(),
   name: varchar("name", { length: 100 }).notNull().unique(),
   role: varchar("role", { length: 100 }).default("collections_specialist"),
+  team: varchar("team", { length: 20 }),
   isActive: boolean("is_active").default(true),
   createdAt: timestamp("created_at", { withTimezone: true })
     .notNull()
@@ -501,6 +502,7 @@ export const dailyMetrics = pgTable(
     ssaCalls: integer("ssa_calls").notNull().default(0),
     clientCallsIb: integer("client_calls_ib").notNull().default(0),
     clientCallsOb: integer("client_calls_ob").notNull().default(0),
+    winSheetsCreated: integer("win_sheets_created").notNull().default(0),
     notes: text("notes"),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()

--- a/src/lib/dropdown-categories.ts
+++ b/src/lib/dropdown-categories.ts
@@ -11,7 +11,7 @@ export const DROPDOWN_CATEGORIES = [
   { key: "claim_type", label: "Claim Type", description: "Benefit type for the claim (T2, T16, CONC, etc.)." },
   { key: "win_sheet_status", label: "Win Sheet Status", description: "Win-sheet progress states." },
   { key: "fees_confirmation", label: "Fees Confirmation", description: "Final fee disposition labels." },
-  { key: "case_status", label: "Case Status", description: "Workflow status shown in the dashboard." },
+  { key: "case_status", label: "Remarks", description: "Remarks/status notes shown in the dashboard." },
   { key: "team", label: "Team", description: "Team groupings for scoreboard tracking (e.g. T2, T16, Concurrent)." },
 ] as const;
 

--- a/src/lib/dropdown-categories.ts
+++ b/src/lib/dropdown-categories.ts
@@ -12,6 +12,7 @@ export const DROPDOWN_CATEGORIES = [
   { key: "win_sheet_status", label: "Win Sheet Status", description: "Win-sheet progress states." },
   { key: "fees_confirmation", label: "Fees Confirmation", description: "Final fee disposition labels." },
   { key: "case_status", label: "Case Status", description: "Workflow status shown in the dashboard." },
+  { key: "team", label: "Team", description: "Team groupings for scoreboard tracking (e.g. T2, T16, Concurrent)." },
 ] as const;
 
 export type DropdownCategory = (typeof DROPDOWN_CATEGORIES)[number]["key"];


### PR DESCRIPTION
## Summary

Merges all PRs landed on `develop` since the last main sync:

- **#66** `fix/migration-timestamp-order` — corrects out-of-order `when` timestamp for `0021_case_archive` in `_journal.json`
- **#67** `feature/team-daily-tracking` — scoreboard team cards (T2/T16/Concurrent), win sheets daily entry row, team assignment in `/team`, Team sub-tab in Settings → Dropdowns; migration `0023_team_daily_tracking_schema`
- **#68** `fix/ui-label-renames` — renames Status → Win Sheet Status, Case Status → Remarks, O/P Ltr Date → Notice Sent/Received per Ms. Jazz feedback
- **#69** `feature/fee-petition-close-flow` — bulk close fee petitions to Fees Closed; excludes already-closed cases from the list
- **#70** `feature/fees-closed-editable` — unlocks inline worksheet dropdowns (Assigned To, Case Level, Claim Type, Win Sheet Status, Remarks) in Fees Closed view; fixes `patchSingleField` res.ok check
- **#72** `feature/dropdown-ordering` — ↑/↓ reorder buttons for Settings → Dropdown Options; position-based sort_order assignment

All PRs were audited (regression + standards check), rebased onto `develop`, and gates passed (lint ✓ · tests 62/62 ✓ · build ✓). Migration `0023` is confirmed live in production.