### PR TITLE
fix: gate feesConfirmation updates behind admin-only check

### DIFF
--- a/src/app/api/cases/[id]/route.ts
+++ b/src/app/api/cases/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { cases, feeRecords, activityLog, userDetails } from "@/lib/db/schema";
 import { eq, desc, sql } from "drizzle-orm";
-import { requireCapability, guardStatus } from "@/lib/auth-helpers";
+import { requireCapability, requireAdmin, guardStatus } from "@/lib/auth-helpers";
 
 // Fee fields that count as "finalizing" a case — gated by case.finalize rather
 // than the broader case.update (members can record payments but not close,
@@ -345,6 +345,16 @@ export const PATCH = async (
         return NextResponse.json(
           { error: "You don't have permission to close, reopen, mark overpaid, or approve cases." },
           { status: guardStatus(fin.error) },
+        );
+      }
+    }
+
+    if (feeFields && "feesConfirmation" in feeFields) {
+      const admin = await requireAdmin();
+      if (!admin.ok) {
+        return NextResponse.json(
+          { error: "Only admins can update Fees Confirmation." },
+          { status: guardStatus(admin.error) },
         );
       }
     }


### PR DESCRIPTION
## Summary
- Adds a server-side admin guard to `PATCH /api/cases/[id]` for the `feesConfirmation` field
- Previously the admin-only restriction was enforced UI-side only — a member could bypass it via a direct API call
- `requireAdmin()` returns 403 for any non-admin/system_admin role attempting to patch `feesConfirmation`