### PR TITLE
feat: overview restructure — scoreboard summary + recent activity

### DIFF
--- a/src/app/(dashboard)/master-fees/page.tsx
+++ b/src/app/(dashboard)/master-fees/page.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { FeeRecordsTable } from "@/components/cases/FeeRecordsTable";
+import { useDashboard } from "@/hooks/useDashboard";
+import { useDateRange } from "@/lib/date-range-context";
+import { themeClasses } from "@/lib/theme-classes";
+import { RefreshCw, AlertCircle } from "lucide-react";
+
+export default function MasterFeesPage() {
+  const {
+    cases,
+    approvedByOptions,
+    dropdownOptions,
+    casesLoading,
+    error,
+    refresh,
+  } = useDashboard();
+  const { dateRange } = useDateRange();
+  const { resolvedTheme } = useTheme();
+  const dark = resolvedTheme === "dark";
+  const t = themeClasses(dark);
+
+  if (error) {
+    return (
+      <div
+        className={`rounded-xl border p-4 flex items-center gap-3 ${dark ? "bg-red-900/20 border-red-800 text-red-400" : "bg-red-50 border-red-200 text-red-700"}`}
+        role="alert"
+      >
+        <AlertCircle aria-hidden="true" className="h-4 w-4 shrink-0" />
+        <span className="text-sm">Failed to load data: {error}</span>
+        <button onClick={refresh} className="ml-auto text-xs font-medium underline">
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (casesLoading) {
+    return (
+      <div className={`rounded-xl border ${t.card} flex items-center justify-center py-16`}>
+        <RefreshCw aria-hidden="true" className={`h-5 w-5 animate-spin ${t.textMuted}`} />
+        <span className={`ml-3 text-sm ${t.textSub}`}>Loading cases...</span>
+      </div>
+    );
+  }
+
+  const nonPetitionCases = cases.filter((c) => c.level !== "FEE_PETITION");
+
+  return (
+    <FeeRecordsTable
+      cases={nonPetitionCases}
+      dateRange={dateRange}
+      onImported={refresh}
+      approvedByOptions={approvedByOptions}
+      dropdownOptions={dropdownOptions}
+    />
+  );
+}

--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import { useTheme } from "next-themes";
 import { StatCards } from "@/components/cases/StatCards";
 import { CollectionsPanel } from "@/components/cases/CollectionsPanel";
@@ -7,6 +8,21 @@ import { RevenuePanel } from "@/components/cases/RevenuePanel";
 import { useDashboard } from "@/hooks/useDashboard";
 import { themeClasses } from "@/lib/theme-classes";
 import { RefreshCw, AlertCircle } from "lucide-react";
+import {
+  ScoreboardSummaryCards,
+  ScoreboardSummary,
+  ScoreboardTeam,
+} from "@/components/scoreboard/ScoreboardSummaryCards";
+import { RecentActivityFeed, ActivityEntry } from "@/components/reports/RecentActivityFeed";
+
+const toISO = (d: Date) => d.toISOString().slice(0, 10);
+
+const currentMonday = () => {
+  const d = new Date();
+  const day = d.getDay();
+  const diff = d.getDate() - day + (day === 0 ? -6 : 1);
+  return new Date(d.getFullYear(), d.getMonth(), diff);
+};
 
 export default function OverviewPage() {
   const {
@@ -21,12 +37,73 @@ export default function OverviewPage() {
   const dark = resolvedTheme === "dark";
   const t = themeClasses(dark);
 
+  const [scoreboardSummary, setScoreboardSummary] = useState<ScoreboardSummary | null>(null);
+  const [scoreboardTeams, setScoreboardTeams] = useState<ScoreboardTeam[]>([]);
+  const [scoreboardLabel, setScoreboardLabel] = useState("This Week");
+  const [recentActivities, setRecentActivities] = useState<ActivityEntry[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const controller = new AbortController();
+    const week = toISO(currentMonday());
+    fetch(`/api/scoreboard?week=${week}`, { signal: controller.signal })
+      .then((res) => {
+        if (!res.ok) throw new Error(`Failed to load scoreboard (${res.status})`);
+        return res.json();
+      })
+      .then((json) => {
+        if (cancelled) return;
+        setScoreboardSummary(json.summary);
+        setScoreboardTeams(json.teams ?? []);
+        if (json.start && json.end) {
+          const fmt = (s: string) =>
+            new Date(s + "T12:00:00").toLocaleDateString("en-US", {
+              month: "short",
+              day: "numeric",
+            });
+          setScoreboardLabel(`${fmt(json.start)} – ${fmt(json.end)}`);
+        }
+      })
+      .catch((err: Error) => {
+        if (err.name === "AbortError") return;
+      });
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const controller = new AbortController();
+    const to = toISO(new Date());
+    const fromD = new Date();
+    fromD.setDate(fromD.getDate() - 6);
+    const from = toISO(fromD);
+    fetch(`/api/reports?from=${from}&to=${to}`, { signal: controller.signal })
+      .then((res) => {
+        if (!res.ok) throw new Error(`Failed to load recent activity (${res.status})`);
+        return res.json();
+      })
+      .then((json) => {
+        if (cancelled) return;
+        setRecentActivities(json.data?.recentActivity ?? []);
+      })
+      .catch((err: Error) => {
+        if (err.name === "AbortError") return;
+      });
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, []);
+
   if (error) {
     return (
       <div
         className={`rounded-xl border p-4 flex items-center gap-3 ${dark ? "bg-red-900/20 border-red-800 text-red-400" : "bg-red-50 border-red-200 text-red-700"}`}
       >
-        <AlertCircle className="h-4 w-4 shrink-0" />
+        <AlertCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
         <span className="text-sm">Failed to load dashboard data: {error}</span>
         <button
           onClick={refresh}
@@ -41,7 +118,7 @@ export default function OverviewPage() {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-20">
-        <RefreshCw className={`h-6 w-6 animate-spin ${t.textMuted}`} />
+        <RefreshCw className={`h-6 w-6 animate-spin ${t.textMuted}`} aria-hidden="true" />
         <span className={`ml-3 text-sm ${t.textSub}`}>
           Loading dashboard...
         </span>
@@ -56,6 +133,26 @@ export default function OverviewPage() {
         <CollectionsPanel data={monthlyData} />
         <RevenuePanel stats={summary} cases={cases} />
       </div>
+      {scoreboardSummary && (
+        <div
+          className={`rounded-xl border p-4 space-y-4 ${dark ? "bg-neutral-900 border-neutral-800" : "bg-white border-neutral-200"}`}
+        >
+          <ScoreboardSummaryCards
+            summary={scoreboardSummary}
+            teams={[]}
+            label={scoreboardLabel}
+            dark={dark}
+            t={t}
+          />
+        </div>
+      )}
+      {recentActivities.length > 0 && (
+        <RecentActivityFeed
+          activities={recentActivities}
+          dark={dark}
+          t={t}
+        />
+      )}
     </>
   );
 }

--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -4,9 +4,7 @@ import { useTheme } from "next-themes";
 import { StatCards } from "@/components/cases/StatCards";
 import { CollectionsPanel } from "@/components/cases/CollectionsPanel";
 import { RevenuePanel } from "@/components/cases/RevenuePanel";
-import { FeeRecordsTable } from "@/components/cases/FeeRecordsTable";
 import { useDashboard } from "@/hooks/useDashboard";
-import { useDateRange } from "@/lib/date-range-context";
 import { themeClasses } from "@/lib/theme-classes";
 import { RefreshCw, AlertCircle } from "lucide-react";
 
@@ -15,14 +13,10 @@ export default function OverviewPage() {
     cases,
     summary,
     monthlyData,
-    approvedByOptions,
-    dropdownOptions,
     loading,
-    casesLoading,
     error,
     refresh,
   } = useDashboard();
-  const { dateRange } = useDateRange();
   const { resolvedTheme } = useTheme();
   const dark = resolvedTheme === "dark";
   const t = themeClasses(dark);
@@ -62,22 +56,6 @@ export default function OverviewPage() {
         <CollectionsPanel data={monthlyData} />
         <RevenuePanel stats={summary} cases={cases} />
       </div>
-      {casesLoading ? (
-        <div
-          className={`rounded-xl border ${t.card} flex items-center justify-center py-16`}
-        >
-          <RefreshCw className={`h-5 w-5 animate-spin ${t.textMuted}`} />
-          <span className={`ml-3 text-sm ${t.textSub}`}>Loading cases...</span>
-        </div>
-      ) : (
-        <FeeRecordsTable
-          cases={cases}
-          dateRange={dateRange}
-          onImported={refresh}
-          approvedByOptions={approvedByOptions}
-          dropdownOptions={dropdownOptions}
-        />
-      )}
     </>
   );
 }

--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -11,7 +11,6 @@ import { RefreshCw, AlertCircle } from "lucide-react";
 import {
   ScoreboardSummaryCards,
   ScoreboardSummary,
-  ScoreboardTeam,
 } from "@/components/scoreboard/ScoreboardSummaryCards";
 import { RecentActivityFeed, ActivityEntry } from "@/components/reports/RecentActivityFeed";
 
@@ -38,7 +37,6 @@ export default function OverviewPage() {
   const t = themeClasses(dark);
 
   const [scoreboardSummary, setScoreboardSummary] = useState<ScoreboardSummary | null>(null);
-  const [scoreboardTeams, setScoreboardTeams] = useState<ScoreboardTeam[]>([]);
   const [scoreboardLabel, setScoreboardLabel] = useState("This Week");
   const [recentActivities, setRecentActivities] = useState<ActivityEntry[]>([]);
 
@@ -54,7 +52,6 @@ export default function OverviewPage() {
       .then((json) => {
         if (cancelled) return;
         setScoreboardSummary(json.summary);
-        setScoreboardTeams(json.teams ?? []);
         if (json.start && json.end) {
           const fmt = (s: string) =>
             new Date(s + "T12:00:00").toLocaleDateString("en-US", {

--- a/src/app/api/cases/[id]/route.ts
+++ b/src/app/api/cases/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { cases, feeRecords, activityLog, userDetails } from "@/lib/db/schema";
 import { eq, desc, sql } from "drizzle-orm";
-import { requireCapability, guardStatus } from "@/lib/auth-helpers";
+import { requireCapability, requireAdmin, guardStatus } from "@/lib/auth-helpers";
 
 // Fee fields that count as "finalizing" a case — gated by case.finalize rather
 // than the broader case.update (members can record payments but not close,
@@ -345,6 +345,16 @@ export const PATCH = async (
         return NextResponse.json(
           { error: "You don't have permission to close, reopen, mark overpaid, or approve cases." },
           { status: guardStatus(fin.error) },
+        );
+      }
+    }
+
+    if (feeFields && "feesConfirmation" in feeFields) {
+      const admin = await requireAdmin();
+      if (!admin.ok) {
+        return NextResponse.json(
+          { error: "Only admins can update Fees Confirmation." },
+          { status: guardStatus(admin.error) },
         );
       }
     }

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -1,5 +1,6 @@
 import type { NextAuthConfig } from "next-auth";
 import { pageKeyForPath } from "@/lib/access/pages";
+import { rolePageDefaults } from "@/lib/access/role-defaults";
 
 /**
  * Edge-safe Auth.js configuration.
@@ -55,7 +56,13 @@ export const authConfig = {
         pages.length > 0 &&
         !pages.includes(pageKey)
       ) {
-        return Response.redirect(new URL("/", nextUrl));
+        // Stale-token mitigation: if this page was added to role defaults after
+        // the token was minted, the token won't list it. Allow access when the
+        // current role default includes it so users don't need to re-login.
+        const defaults = rolePageDefaults(auth?.user?.role);
+        if (!defaults.includes(pageKey)) {
+          return Response.redirect(new URL("/", nextUrl));
+        }
       }
 
       return true;

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -192,6 +192,8 @@ export const FeeRecordsTable = ({
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState("all");
   const [assignedFilter, setAssignedFilter] = useState("all");
+  const [feesConfFilter, setFeesConfFilter] = useState("all");
+  const [claimFilter, setClaimFilter] = useState("all");
   const [sortKey, setSortKey] = useState<SortKey>("date");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
   // Client-side pagination over the filtered+sorted set. Page size is
@@ -304,6 +306,16 @@ export const FeeRecordsTable = ({
     return Array.from(set).sort();
   }, [cases]);
 
+  // Unique fees-confirmation values present in the data for the filter dropdown.
+  // Derived from cases rather than feesConfirmationOptions so inactive values
+  // that are already set on records remain filterable.
+  const feesConfValues = useMemo(() => {
+    const set = new Set(
+      cases.map((c) => c.feesConfirmation).filter((v): v is string => v != null),
+    );
+    return Array.from(set).sort();
+  }, [cases]);
+
   const filtered = useMemo(() => {
     let d = [...cases];
     // Date range filter (approval date)
@@ -339,8 +351,21 @@ export const FeeRecordsTable = ({
         d = d.filter((c) => c.status === statusFilter);
       }
     }
-    if (assignedFilter !== "all")
-      d = d.filter((c) => c.assigned === assignedFilter);
+    if (assignedFilter === "__unassigned__") {
+      d = d.filter((c) => {
+        const ov = pending[c.id]?.assigned;
+        return ov !== undefined ? !ov : c.assigned === "—";
+      });
+    } else if (assignedFilter !== "all") {
+      d = d.filter((c) => {
+        const ov = pending[c.id]?.assigned;
+        return ov !== undefined ? ov === assignedFilter : c.assigned === assignedFilter;
+      });
+    }
+    if (feesConfFilter !== "all")
+      d = d.filter((c) => c.feesConfirmation === feesConfFilter);
+    if (claimFilter !== "all")
+      d = d.filter((c) => c.claim === claimFilter);
 
     d.sort((a, b) => {
       let av: string | number, bv: string | number;
@@ -349,12 +374,18 @@ export const FeeRecordsTable = ({
           av = a.name;
           bv = b.name;
           break;
-        case "assigned":
+        case "assigned": {
           // Empty assignees ("—") sort last regardless of direction so the
           // unassigned bucket never breaks up real groups in the middle.
-          av = a.assigned === "—" ? "￿" : a.assigned.toLowerCase();
-          bv = b.assigned === "—" ? "￿" : b.assigned.toLowerCase();
+          // Use pending override when present (same logic as the filter above).
+          const ova = pending[a.id]?.assigned;
+          const ovb = pending[b.id]?.assigned;
+          const ea = ova !== undefined ? (ova || "—") : a.assigned;
+          const eb = ovb !== undefined ? (ovb || "—") : b.assigned;
+          av = ea === "—" ? "￿" : ea.toLowerCase();
+          bv = eb === "—" ? "￿" : eb.toLowerCase();
           break;
+        }
         case "date":
           av = a.date || "";
           bv = b.date || "";
@@ -380,9 +411,12 @@ export const FeeRecordsTable = ({
     return d;
   }, [
     cases,
+    pending,
     search,
     statusFilter,
     assignedFilter,
+    feesConfFilter,
+    claimFilter,
     sortKey,
     sortDir,
     dateRange,
@@ -409,6 +443,8 @@ export const FeeRecordsTable = ({
     search,
     statusFilter,
     assignedFilter,
+    feesConfFilter,
+    claimFilter,
     sortKey,
     sortDir,
     pageSize,
@@ -567,6 +603,8 @@ export const FeeRecordsTable = ({
   // Case Name cell can't overflow in front of (cover) the Assigned column.
   const colNameW = `w-36 min-w-36 max-w-36 sm:w-48 sm:min-w-48 sm:max-w-48`;
   const colAssignedW = `w-32 min-w-32 max-w-32 sm:w-40 sm:min-w-40 sm:max-w-40`;
+  // left offset: checkbox(40) + name(192) + assigned(160) = 392px = 24.5rem
+  const colFeesConfW = `w-32 min-w-32 max-w-32 sm:w-36 sm:min-w-36 sm:max-w-36`;
 
   // Every header cell is sticky vertically by default — the column-header
   // row (row 2) parks 32px down. Baking this into `thBase` means the ~24
@@ -588,20 +626,21 @@ export const FeeRecordsTable = ({
   // sticky neighbors during scroll.
   const stickyTh1 = `left-10 z-30 ${colNameW} ${nameDivider}`;
   // z-30 only at sm+ (where Assigned is a frozen corner). On mobile Assigned
+  // scrolls, so no sticky-left. Freeze boundary moved to Fees Conf, so no divider here.
   // scrolls, so it must stay at thBase's z-20 — BELOW the frozen Case Name
   // (z-30) — otherwise it paints over the frozen "front index" on scroll.
-  const stickyTh2 = `sm:left-[14.5rem] sm:z-30 ${colAssignedW} ${stickyDivider}`;
-  // "Case Info" group label is split into two cells so each part's freeze
-  // matches the column beneath it: the label over Case Name freezes on all
-  // screens (stickyGroup); the blank part over Assigned freezes only at sm+
-  // (stickyGroup2). This keeps "Case Info" pinned over the frozen Case Name
-  // column on mobile instead of letting T16/T2 labels slide over it.
+  // Assigned: no divider — freeze boundary now sits after Fees Conf.
+  const stickyTh2 = `sm:left-[14.5rem] sm:z-30 ${colAssignedW}`;
+  // "Case Info" group label is split into cells so each part's freeze matches
+  // the column beneath it. Three frozen columns: Case Name, Assigned, Fees Conf.
   const stickyGroup = `top-0! left-10 z-30 ${colNameW} ${nameDivider}`;
-  // Same as stickyTh2: z-30 only at sm+ so on mobile this scrolls below the
-  // frozen "Case Info" label (z-30) instead of covering it.
-  const stickyGroup2 = `top-0! sm:left-[14.5rem] sm:z-30 ${colAssignedW} ${stickyDivider}`;
+  const stickyGroup2 = `top-0! sm:left-[14.5rem] sm:z-30 ${colAssignedW}`;
+  // Fees Conf is the 3rd frozen column (left offset = 40 + 192 + 160 = 392px = 24.5rem).
+  const stickyGroup3 = `top-0! sm:left-[24.5rem] sm:z-30 ${colFeesConfW} ${stickyDivider}`;
+  const stickyTh3 = `sm:left-[24.5rem] sm:z-30 ${colFeesConfW} ${stickyDivider}`;
   const stickyTd1 = `sticky left-10 z-10 ${colNameW} ${stickyBg} ${stickyHover} ${nameDivider}`;
-  const stickyTd2 = `sm:sticky sm:left-[14.5rem] sm:z-10 ${colAssignedW} ${stickyColBg} ${stickyDivider}`;
+  const stickyTd2 = `sm:sticky sm:left-[14.5rem] sm:z-10 ${colAssignedW} ${stickyColBg}`;
+  const stickyTd3 = `sm:sticky sm:left-[24.5rem] sm:z-10 ${colFeesConfW} ${stickyColBg} ${stickyDivider}`;
   const stickyCheckTh = `sticky top-0! left-0 z-30 w-10 min-w-10 ${stickyBg}`;
   const stickyCheckTd = `sticky left-0 z-10 w-10 min-w-10 ${stickyBg} ${stickyHover}`;
 
@@ -632,6 +671,7 @@ export const FeeRecordsTable = ({
         <div className="flex items-center gap-2 flex-wrap">
           <div className="relative flex-1 sm:flex-none">
             <Search
+              aria-hidden="true"
               className={`absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 ${t.textMuted}`}
             />
             <input
@@ -658,11 +698,34 @@ export const FeeRecordsTable = ({
             className={`h-8 px-2 rounded-md border text-xs outline-none cursor-pointer ${t.inputBg}`}
           >
             <option value="all">All Agents</option>
+            <option value="__unassigned__">Unassigned</option>
             {assignees.map((a) => (
               <option key={a} value={a}>
                 {a}
               </option>
             ))}
+          </select>
+          <select
+            value={feesConfFilter}
+            onChange={(e) => setFeesConfFilter(e.target.value)}
+            className={`h-8 px-2 rounded-md border text-xs outline-none cursor-pointer ${t.inputBg}`}
+          >
+            <option value="all">All Fees Conf</option>
+            {feesConfValues.map((v) => (
+              <option key={v} value={v}>
+                {v}
+              </option>
+            ))}
+          </select>
+          <select
+            value={claimFilter}
+            onChange={(e) => setClaimFilter(e.target.value)}
+            className={`h-8 px-2 rounded-md border text-xs outline-none cursor-pointer ${t.inputBg}`}
+          >
+            <option value="all">All Claims</option>
+            <option value="T2">T2</option>
+            <option value="T16">T16</option>
+            <option value="CONC">CONC</option>
           </select>
           {isAdmin && (
             <>
@@ -783,6 +846,10 @@ export const FeeRecordsTable = ({
                   className={`${thBase} ${t.textSub} text-left ${stickyGroup2}`}
                 />
                 <th
+                  aria-hidden="true"
+                  className={`${thBase} ${t.textSub} text-left ${stickyGroup3}`}
+                />
+                <th
                   colSpan={5}
                   aria-hidden="true"
                   className={`${thBase} ${t.textSub} text-left ${stickyThRow1}`}
@@ -813,7 +880,7 @@ export const FeeRecordsTable = ({
                   Totals
                 </th>
                 <th
-                  colSpan={mode === "closed" ? 8 : 7}
+                  colSpan={mode === "closed" ? 7 : 6}
                   className={`${thBase} text-center ${groupBorder} ${stickyThRow1} ${t.textSub}`}
                 >
                   Workflow
@@ -837,6 +904,9 @@ export const FeeRecordsTable = ({
                   <span className="flex items-center gap-1">
                     Assigned <ArrowUpDown className="h-3 w-3" />
                   </span>
+                </th>
+                <th className={`${thBase} ${t.textSub} text-left ${stickyTh3}`}>
+                  Fees Conf
                 </th>
                 <th className={`${thBase} ${t.textSub} text-left`}>Level</th>
                 <th className={`${thBase} ${t.textSub} text-left`}>Claim</th>
@@ -929,9 +999,6 @@ export const FeeRecordsTable = ({
                 </th>
                 <th className={`${thBase} ${t.textSub} text-left`}>
                   Approved By
-                </th>
-                <th className={`${thBase} ${t.textSub} text-left`}>
-                  Fees Conf
                 </th>
                 <th className={`${thBase} ${t.textSub} text-left`}>
                   Remarks
@@ -1049,7 +1116,7 @@ export const FeeRecordsTable = ({
                               e.target.value,
                             )
                           }
-                          className={`h-7 px-2 rounded-md border text-[11px] outline-none cursor-pointer ${t.inputBg}`}
+                          className={`w-full h-7 px-2 rounded-md border text-[11px] outline-none cursor-pointer ${t.inputBg}`}
                           title={
                             assignedOptions.length === 0
                               ? "No options configured — add them in Settings"
@@ -1078,6 +1145,74 @@ export const FeeRecordsTable = ({
                               </option>
                             ))}
                         </select>
+                    </td>
+                    {/* Fees Confirmation — 3rd frozen column */}
+                    <td
+                      className={`${tdBase} ${t.textSub} ${stickyTd3}`}
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      {mode === "closed" || !isAdmin ? (
+                        cellValue(c, "feesConfirmation") || "—"
+                      ) : (
+                        <select
+                          value={cellValue(c, "feesConfirmation")}
+                          onClick={(e) => e.stopPropagation()}
+                          onChange={(e) => {
+                            const next = e.target.value;
+                            if (
+                              canFinalize &&
+                              next &&
+                              next.toLowerCase() === "paid in full" &&
+                              next !== cellValue(c, "feesConfirmation")
+                            ) {
+                              setAckTarget({
+                                caseId: c.id,
+                                caseName: c.name,
+                                triggerField: "feesConfirmation",
+                                triggerValue: next,
+                                triggerLabel: "Fees Confirmation",
+                              });
+                              return;
+                            }
+                            handleVarcharChange(
+                              c,
+                              "fee",
+                              "feesConfirmation",
+                              "feesConfirmation",
+                              "Fees Confirmation",
+                              next,
+                            );
+                          }}
+                          className={`w-full h-7 px-2 rounded-md border text-[11px] outline-none cursor-pointer ${t.inputBg}`}
+                          title={
+                            feesConfirmationOptions.length === 0
+                              ? "No options configured — add them in Settings"
+                              : undefined
+                          }
+                        >
+                          <option value="">— Select —</option>
+                          {(() => {
+                            const v = cellValue(c, "feesConfirmation");
+                            return (
+                              v &&
+                              !feesConfirmationOptions.some(
+                                (o) => o.name === v,
+                              ) && <option value={v}>{v}</option>
+                            );
+                          })()}
+                          {feesConfirmationOptions
+                            .filter(
+                              (o) =>
+                                o.isActive ||
+                                o.name === cellValue(c, "feesConfirmation"),
+                            )
+                            .map((o) => (
+                              <option key={o.id} value={o.name}>
+                                {o.name}
+                              </option>
+                            ))}
+                        </select>
+                      )}
                     </td>
                     {/* Level — varchar; lives on the cases row. */}
                     <td
@@ -1392,77 +1527,6 @@ export const FeeRecordsTable = ({
                               (o) =>
                                 o.isActive ||
                                 o.name === cellValue(c, "approvedBy"),
-                            )
-                            .map((o) => (
-                              <option key={o.id} value={o.name}>
-                                {o.name}
-                              </option>
-                            ))}
-                        </select>
-                      )}
-                    </td>
-                    {/* Fees Confirmation */}
-                    <td
-                      className={`${tdBase} ${t.textSub}`}
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      {mode === "closed" ? (
-                        cellValue(c, "feesConfirmation") || "—"
-                      ) : (
-                        <select
-                          value={cellValue(c, "feesConfirmation")}
-                          onClick={(e) => e.stopPropagation()}
-                          onChange={(e) => {
-                            const next = e.target.value;
-                            // "Paid In Full" prompts the close flow, which is a
-                            // finalize action — only offer it to users who can
-                            // finalize. Others just set the field value.
-                            if (
-                              canFinalize &&
-                              next &&
-                              next.toLowerCase() === "paid in full" &&
-                              next !== cellValue(c, "feesConfirmation")
-                            ) {
-                              setAckTarget({
-                                caseId: c.id,
-                                caseName: c.name,
-                                triggerField: "feesConfirmation",
-                                triggerValue: next,
-                                triggerLabel: "Fees Confirmation",
-                              });
-                              return;
-                            }
-                            handleVarcharChange(
-                              c,
-                              "fee",
-                              "feesConfirmation",
-                              "feesConfirmation",
-                              "Fees Confirmation",
-                              next,
-                            );
-                          }}
-                          className={`h-7 px-2 rounded-md border text-[11px] outline-none cursor-pointer ${t.inputBg}`}
-                          title={
-                            feesConfirmationOptions.length === 0
-                              ? "No options configured — add them in Settings"
-                              : undefined
-                          }
-                        >
-                          <option value="">— Select —</option>
-                          {(() => {
-                            const v = cellValue(c, "feesConfirmation");
-                            return (
-                              v &&
-                              !feesConfirmationOptions.some(
-                                (o) => o.name === v,
-                              ) && <option value={v}>{v}</option>
-                            );
-                          })()}
-                          {feesConfirmationOptions
-                            .filter(
-                              (o) =>
-                                o.isActive ||
-                                o.name === cellValue(c, "feesConfirmation"),
                             )
                             .map((o) => (
                               <option key={o.id} value={o.name}>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -27,6 +27,7 @@ import {
   KeyRound,
   CheckCircle2,
   Archive,
+  TableProperties,
 } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
 import { fmtClaim } from "@/lib/formatters";
@@ -59,6 +60,7 @@ const NAV_ITEMS: { section: string; items: NavItem[] }[] = [
     section: "General",
     items: [
       { path: "/", icon: Home, label: "Overview" },
+      { path: "/master-fees", icon: TableProperties, label: "Master Fees" },
       { path: "/fees-closed", icon: CheckCircle2, label: "Fees Closed" },
       { path: "/scoreboard", icon: Trophy, label: "Scoreboard" },
       { path: "/chronicle", icon: Database, label: "Chronicle Sync" },

--- a/src/components/reports/RecentActivityFeed.tsx
+++ b/src/components/reports/RecentActivityFeed.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { Clock } from "lucide-react";
+import { themeClasses } from "@/lib/theme-classes";
+
+export interface ActivityEntry {
+  id: string;
+  caseId: number;
+  message: string;
+  createdBy: string;
+  createdAt: string;
+  caseName: string | null;
+}
+
+interface RecentActivityFeedProps {
+  activities: ActivityEntry[];
+  dark: boolean;
+  t: ReturnType<typeof themeClasses>;
+}
+
+export function RecentActivityFeed({ activities, dark, t }: RecentActivityFeedProps) {
+  return (
+    <div className={`rounded-xl border ${t.card} p-4`}>
+      <h4 className={`text-xs font-bold ${t.text} flex items-center gap-2 mb-3`}>
+        <Clock aria-hidden="true" className="h-3.5 w-3.5" /> Recent Activity
+        <span className={`text-[10px] font-normal ${t.textMuted}`}>
+          ({activities.length})
+        </span>
+      </h4>
+      <div className="space-y-2.5 max-h-70 overflow-y-auto pr-1">
+        {activities.length === 0 ? (
+          <p className={`text-xs ${t.textMuted} text-center py-6`}>
+            No recent activity.
+          </p>
+        ) : (
+          activities.slice(0, 20).map((a) => (
+            <div
+              key={a.id}
+              className={`rounded-md p-2 ${dark ? "bg-neutral-800/40" : "bg-neutral-50"}`}
+            >
+              <div className="flex items-center gap-2">
+                <span className={`text-[10px] font-semibold ${t.text}`}>
+                  {a.createdBy}
+                </span>
+                {a.caseName && (
+                  <span className={`text-[10px] ${t.textMuted}`}>
+                    on {a.caseName}
+                  </span>
+                )}
+              </div>
+              <p className={`text-[11px] ${t.textSub} mt-0.5 leading-snug line-clamp-2`}>
+                {a.message}
+              </p>
+              <p className={`text-[9px] ${t.textMuted} mt-0.5`}>
+                {new Date(a.createdAt).toLocaleDateString("en-US", {
+                  month: "short",
+                  day: "numeric",
+                  hour: "numeric",
+                  minute: "2-digit",
+                })}
+              </p>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/reports/RecentActivityFeed.tsx
+++ b/src/components/reports/RecentActivityFeed.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { Clock } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
 

--- a/src/components/reports/Reports.tsx
+++ b/src/components/reports/Reports.tsx
@@ -7,18 +7,12 @@ import {
   Download,
   RefreshCw,
   Calendar,
-  Phone,
-  FileText,
   Users,
-  DollarSign,
   ChevronDown,
   ChevronRight,
   ArrowUpDown,
-  MessageSquare,
-  Clock,
-  TrendingUp,
-  // X,
 } from "lucide-react";
+import { ActivityEntry } from "@/components/reports/RecentActivityFeed";
 import { themeClasses } from "@/lib/theme-classes";
 import { fmtFull, fmtDate } from "@/lib/formatters";
 
@@ -41,22 +35,6 @@ interface AgentRow {
   pendingCount: number;
 }
 
-interface DailyRow {
-  date: string;
-  ssa_calls: number;
-  client_calls_ib: number;
-  client_calls_ob: number;
-}
-
-interface ActivityEntry {
-  id: string;
-  caseId: number;
-  message: string;
-  createdBy: string;
-  createdAt: string;
-  caseName: string | null;
-}
-
 interface Totals {
   ssaCalls: number;
   clientCallsIb: number;
@@ -73,7 +51,6 @@ interface ReportData {
   to: string;
   agents: AgentRow[];
   totals: Totals;
-  dailyBreakdown: DailyRow[];
   recentActivity: ActivityEntry[];
 }
 
@@ -256,115 +233,6 @@ export const Reports = () => {
     />
   );
 
-  // Mini bar chart using divs
-  const DailyChart = () => {
-    if (!data || data.dailyBreakdown.length === 0)
-      return (
-        <p className={`text-xs ${t.textMuted} text-center py-6`}>
-          No daily data for this range.
-        </p>
-      );
-    const maxVal = Math.max(
-      ...data.dailyBreakdown.map(
-        (d) => d.ssa_calls + d.client_calls_ib + d.client_calls_ob,
-      ),
-      1,
-    );
-    const ticks = [0, 0.25, 0.5, 0.75, 1].map((f) => Math.round(maxVal * f));
-    return (
-      <div className="flex gap-2 flex-1 min-h-0">
-        {/* Y-axis labels */}
-        <div className="flex flex-col justify-between py-0.5 shrink-0">
-          {[...ticks].reverse().map((v, i) => (
-            <span
-              key={i}
-              className={`text-[9px] tabular-nums ${t.textMuted} text-right w-6`}
-            >
-              {v}
-            </span>
-          ))}
-        </div>
-        {/* Bars area */}
-        <div className="flex-1 flex flex-col min-h-0">
-          <div className="relative flex items-end gap-1.5 flex-1 min-h-0">
-            {/* Grid lines */}
-            {[0.25, 0.5, 0.75, 1].map((f) => (
-              <div
-                key={f}
-                className={`absolute left-0 right-0 border-t ${dark ? "border-neutral-800/40" : "border-neutral-100"}`}
-                style={{ bottom: `${f * 100}%` }}
-              />
-            ))}
-            {data.dailyBreakdown.map((d, i) => {
-              const total = d.ssa_calls + d.client_calls_ib + d.client_calls_ob;
-              const pct = total > 0 ? Math.max((total / maxVal) * 100, 2) : 0;
-              const ssaPct = total > 0 ? (d.ssa_calls / total) * 100 : 0;
-              const ibPct = total > 0 ? (d.client_calls_ib / total) * 100 : 0;
-              const obPct = total > 0 ? (d.client_calls_ob / total) * 100 : 0;
-              return (
-                <div
-                  key={i}
-                  className="flex-1 h-full flex flex-col justify-end relative z-10"
-                >
-                  {/* Number above bar */}
-                  {total > 0 && (
-                    <div
-                      className={`text-center text-[9px] font-bold ${t.text} mb-0.5`}
-                    >
-                      {total}
-                    </div>
-                  )}
-                  <div
-                    className="w-full flex flex-col-reverse rounded-t overflow-hidden"
-                    style={{ height: `${pct}%` }}
-                  >
-                    <div
-                      className="bg-indigo-500 w-full"
-                      style={{ height: `${ssaPct}%` }}
-                    />
-                    <div
-                      className={`${dark ? "bg-blue-500" : "bg-blue-400"} w-full`}
-                      style={{ height: `${ibPct}%` }}
-                    />
-                    <div
-                      className={`${dark ? "bg-violet-500" : "bg-violet-400"} w-full`}
-                      style={{ height: `${obPct}%` }}
-                    />
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-          {/* X-axis labels */}
-          <div
-            className={`flex gap-1.5 border-t ${dark ? "border-neutral-800/40" : "border-neutral-100"} pt-1 shrink-0`}
-          >
-            {data.dailyBreakdown.map((d, i) => {
-              const dayLabel = new Date(
-                d.date + "T12:00:00",
-              ).toLocaleDateString("en-US", { weekday: "short" });
-              const dateLabel = new Date(
-                d.date + "T12:00:00",
-              ).toLocaleDateString("en-US", { month: "short", day: "numeric" });
-              return (
-                <div key={i} className="flex-1 text-center">
-                  <span className={`text-[9px] font-medium ${t.textSub} block`}>
-                    {dayLabel}
-                  </span>
-                  <span
-                    className={`text-[8px] ${t.textMuted} block leading-none`}
-                  >
-                    {dateLabel}
-                  </span>
-                </div>
-              );
-            })}
-          </div>
-        </div>
-      </div>
-    );
-  };
-
   return (
     <div className="space-y-4">
       {/* Header with date range picker */}
@@ -481,134 +349,6 @@ export const Reports = () => {
 
       {data && !loading && (
         <>
-          {/* Summary cards */}
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-            {[
-              {
-                label: "Total Calls",
-                value: data.totals.totalCalls,
-                icon: Phone,
-                color: "text-indigo-500",
-              },
-              {
-                label: "Activity Entries",
-                value: data.totals.activityCount,
-                icon: MessageSquare,
-                color: "text-blue-500",
-              },
-              {
-                label: "Cases Touched",
-                value: data.totals.casesTouched,
-                icon: FileText,
-                color: "text-violet-500",
-              },
-              {
-                label: "Collected",
-                value: fmtFull(data.totals.collected),
-                icon: DollarSign,
-                color: "text-emerald-500",
-              },
-            ].map((item, i) => (
-              <div key={i} className={`${sectionCard} p-3`}>
-                <div className="flex items-center gap-2">
-                  <item.icon className={`h-3.5 w-3.5 ${item.color}`} />
-                  <p
-                    className={`text-[10px] font-semibold uppercase ${t.textMuted}`}
-                  >
-                    {item.label}
-                  </p>
-                </div>
-                <p className={`text-xl font-bold mt-1 ${t.text}`}>
-                  {item.value}
-                </p>
-              </div>
-            ))}
-          </div>
-
-          {/* Chart + Recent Activity side by side */}
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
-            {/* Daily calls chart */}
-            <div
-              className={`${sectionCard} px-4 pt-4 pb-3 lg:col-span-2 flex flex-col`}
-            >
-              <div className="flex items-center justify-between mb-3">
-                <h4
-                  className={`text-xs font-bold ${t.text} flex items-center gap-2`}
-                >
-                  <TrendingUp className="h-3.5 w-3.5" /> Daily Call Volume
-                </h4>
-                <div className="flex items-center gap-3 text-[10px]">
-                  <span className="flex items-center gap-1">
-                    <span className="w-2 h-2 rounded bg-indigo-500" /> SSA
-                  </span>
-                  <span className="flex items-center gap-1">
-                    <span
-                      className={`w-2 h-2 rounded ${dark ? "bg-blue-500" : "bg-blue-400"}`}
-                    />{" "}
-                    Client IB
-                  </span>
-                  <span className="flex items-center gap-1">
-                    <span
-                      className={`w-2 h-2 rounded ${dark ? "bg-violet-500" : "bg-violet-400"}`}
-                    />{" "}
-                    Client OB
-                  </span>
-                </div>
-              </div>
-              <DailyChart />
-            </div>
-
-            {/* Recent Activity feed */}
-            <div className={`${sectionCard} p-4`}>
-              <h4
-                className={`text-xs font-bold ${t.text} flex items-center gap-2 mb-3`}
-              >
-                <Clock className="h-3.5 w-3.5" /> Recent Activity
-                <span className={`text-[10px] font-normal ${t.textMuted}`}>
-                  ({data.recentActivity.length})
-                </span>
-              </h4>
-              <div className="space-y-2.5 max-h-70 overflow-y-auto pr-1">
-                {data.recentActivity.length === 0 ? (
-                  <p className={`text-xs ${t.textMuted} text-center py-6`}>
-                    No activity in this range.
-                  </p>
-                ) : (
-                  data.recentActivity.slice(0, 20).map((a) => (
-                    <div
-                      key={a.id}
-                      className={`rounded-md p-2 ${dark ? "bg-neutral-800/40" : "bg-neutral-50"}`}
-                    >
-                      <div className="flex items-center gap-2">
-                        <span className={`text-[10px] font-semibold ${t.text}`}>
-                          {a.createdBy}
-                        </span>
-                        {a.caseName && (
-                          <span className={`text-[10px] ${t.textMuted}`}>
-                            on {a.caseName}
-                          </span>
-                        )}
-                      </div>
-                      <p
-                        className={`text-[11px] ${t.textSub} mt-0.5 leading-snug line-clamp-2`}
-                      >
-                        {a.message}
-                      </p>
-                      <p className={`text-[9px] ${t.textMuted} mt-0.5`}>
-                        {new Date(a.createdAt).toLocaleDateString("en-US", {
-                          month: "short",
-                          day: "numeric",
-                          hour: "numeric",
-                          minute: "2-digit",
-                        })}
-                      </p>
-                    </div>
-                  ))
-                )}
-              </div>
-            </div>
-          </div>
-
           {/* Agent table */}
           <div className={sectionCard}>
             <div

--- a/src/components/scoreboard/Scoreboard.tsx
+++ b/src/components/scoreboard/Scoreboard.tsx
@@ -24,6 +24,8 @@ import {
 } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
 import { fmt } from "@/lib/formatters";
+import { ScoreboardSummaryCards } from "./ScoreboardSummaryCards";
+import type { ScoreboardSummary, ScoreboardTeam } from "./ScoreboardSummaryCards";
 
 // ============================================================================
 // Types
@@ -47,39 +49,8 @@ interface AgentScore {
   weekClientCalls: number;
 }
 
-interface TeamScore {
-  team: string;
-  agentCount: number;
-  casesAssigned: number;
-  openCases: number;
-  casesClosed: number;
-  completedWinSheets: number;
-  winSheetsCreated: number;
-  unpaidT2Over60: number;
-  unpaidT16Over60: number;
-  unpaidConcOver60: number;
-  totalCollected: number;
-  feesCollectedInWindow: number;
-  casesFullFee: number;
-  ssaCalls: number;
-  clientCalls: number;
-}
-
-interface Summary {
-  totalCasesAssigned: number;
-  totalOpenCases: number;
-  totalCasesClosed: number;
-  totalCompletedWinSheets: number;
-  totalWinSheetsCreated: number;
-  totalUnpaidT2Over60: number;
-  totalUnpaidT16Over60: number;
-  totalUnpaidConcOver60: number;
-  totalCollected: number;
-  totalFeesCollectedInWindow: number;
-  totalCasesFullFee: number;
-  totalSsaCalls: number;
-  totalClientCalls: number;
-}
+type TeamScore = ScoreboardTeam;
+type Summary = ScoreboardSummary;
 
 interface DailyEntry {
   agent: string;
@@ -629,103 +600,16 @@ export const Scoreboard = () => {
         ) : (
           data && (
             <>
-              {/* Summary cards */}
-              <div
-                className={`grid grid-cols-3 sm:grid-cols-5 lg:grid-cols-9 gap-3 p-4 border-b ${t.borderLight}`}
-              >
-                {[
-                  {
-                    label: "Cases Assigned",
-                    value: filteredSummary.totalCasesAssigned,
-                  },
-                  {
-                    label: "Win Sheets",
-                    value: filteredSummary.totalCompletedWinSheets,
-                  },
-                  { label: "T2 >60d", value: filteredSummary.totalUnpaidT2Over60 },
-                  {
-                    label: "T16 >60d",
-                    value: filteredSummary.totalUnpaidT16Over60,
-                  },
-                  {
-                    label: "Conc >60d",
-                    value: filteredSummary.totalUnpaidConcOver60,
-                  },
-                  {
-                    label: "Collected",
-                    value: fmt(filteredSummary.totalCollected),
-                  },
-                  { label: "Full Fee", value: filteredSummary.totalCasesFullFee },
-                  { label: "SSA Calls", value: filteredSummary.totalSsaCalls },
-                  {
-                    label: "Client Calls",
-                    value: filteredSummary.totalClientCalls,
-                  },
-                ].map((item, i) => (
-                  <div key={i} className={`rounded-lg border p-3 ${t.card}`}>
-                    <p
-                      className={`text-[10px] font-medium ${t.textMuted} uppercase`}
-                    >
-                      {item.label}
-                    </p>
-                    <p className={`text-lg font-bold ${t.text} mt-1`}>
-                      {item.value}
-                    </p>
-                  </div>
-                ))}
+              {/* Summary cards + team breakdown */}
+              <div className={`p-4 border-b ${t.borderLight} space-y-4`}>
+                <ScoreboardSummaryCards
+                  summary={filteredSummary}
+                  teams={data.teams ?? []}
+                  label={windowLabel}
+                  dark={dark}
+                  t={t}
+                />
               </div>
-
-              {/* Team breakdown — only shown when teams data is present */}
-              {data.teams && data.teams.length > 0 && (
-                <div className={`p-4 border-b ${t.borderLight}`}>
-                  <p className={`text-[10px] font-semibold uppercase tracking-wider ${t.textMuted} mb-3`}>
-                    By Team — {windowLabel}
-                  </p>
-                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-                    {data.teams.map((team) => {
-                      const teamColor =
-                        team.team === "T2"
-                          ? dark ? "border-blue-700/50 bg-blue-900/10" : "border-blue-200 bg-blue-50/60"
-                          : team.team === "T16"
-                          ? dark ? "border-purple-700/50 bg-purple-900/10" : "border-purple-200 bg-purple-50/60"
-                          : dark ? "border-teal-700/50 bg-teal-900/10" : "border-teal-200 bg-teal-50/60";
-                      const teamLabel =
-                        team.team === "T2" ? "T2 Team"
-                        : team.team === "T16" ? "T16 Team"
-                        : "Concurrent Team";
-                      const accentText =
-                        team.team === "T2"
-                          ? dark ? "text-blue-400" : "text-blue-700"
-                          : team.team === "T16"
-                          ? dark ? "text-purple-400" : "text-purple-700"
-                          : dark ? "text-teal-400" : "text-teal-700";
-                      return (
-                        <div key={team.team} className={`rounded-lg border p-4 ${teamColor}`}>
-                          <div className="flex items-center justify-between mb-3">
-                            <span className={`text-xs font-bold ${accentText}`}>{teamLabel}</span>
-                            <span className={`text-[10px] ${t.textMuted}`}>{team.agentCount} agent{team.agentCount !== 1 ? "s" : ""}</span>
-                          </div>
-                          <div className="grid grid-cols-3 gap-2">
-                            {[
-                              { label: "Fees Collected", value: fmt(team.feesCollectedInWindow) },
-                              { label: "SSA Calls", value: team.ssaCalls },
-                              { label: "CL Calls", value: team.clientCalls },
-                              { label: "Win Sheets", value: team.winSheetsCreated },
-                              { label: "Cases Closed", value: team.casesClosed },
-                              { label: "Open Cases", value: team.openCases },
-                            ].map((stat) => (
-                              <div key={stat.label}>
-                                <p className={`text-[9px] font-medium uppercase tracking-wide ${t.textMuted}`}>{stat.label}</p>
-                                <p className={`text-sm font-bold ${t.text} mt-0.5`}>{stat.value}</p>
-                              </div>
-                            ))}
-                          </div>
-                        </div>
-                      );
-                    })}
-                  </div>
-                </div>
-              )}
 
               {/* Monitoring filters (client-side, current week) */}
               <div

--- a/src/components/scoreboard/Scoreboard.tsx
+++ b/src/components/scoreboard/Scoreboard.tsx
@@ -608,6 +608,7 @@ export const Scoreboard = () => {
                   label={windowLabel}
                   dark={dark}
                   t={t}
+                  showMiniCards={false}
                 />
               </div>
 

--- a/src/components/scoreboard/ScoreboardSummaryCards.tsx
+++ b/src/components/scoreboard/ScoreboardSummaryCards.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { themeClasses } from "@/lib/theme-classes";
+import { fmt } from "@/lib/formatters";
+
+export interface ScoreboardSummary {
+  totalCasesAssigned: number;
+  totalOpenCases: number;
+  totalCasesClosed: number;
+  totalCompletedWinSheets: number;
+  totalWinSheetsCreated: number;
+  totalUnpaidT2Over60: number;
+  totalUnpaidT16Over60: number;
+  totalUnpaidConcOver60: number;
+  totalCollected: number;
+  totalFeesCollectedInWindow: number;
+  totalCasesFullFee: number;
+  totalSsaCalls: number;
+  totalClientCalls: number;
+}
+
+export interface ScoreboardTeam {
+  team: string;
+  agentCount: number;
+  casesAssigned: number;
+  openCases: number;
+  casesClosed: number;
+  completedWinSheets: number;
+  winSheetsCreated: number;
+  unpaidT2Over60: number;
+  unpaidT16Over60: number;
+  unpaidConcOver60: number;
+  totalCollected: number;
+  feesCollectedInWindow: number;
+  casesFullFee: number;
+  ssaCalls: number;
+  clientCalls: number;
+}
+
+interface ScoreboardSummaryCardsProps {
+  summary: ScoreboardSummary;
+  teams: ScoreboardTeam[];
+  label: string;
+  dark: boolean;
+  t: ReturnType<typeof themeClasses>;
+}
+
+export function ScoreboardSummaryCards({
+  summary,
+  teams,
+  label,
+  dark,
+  t,
+}: ScoreboardSummaryCardsProps) {
+  const stats = [
+    { label: "Cases Assigned", value: summary.totalCasesAssigned },
+    { label: "Win Sheets", value: summary.totalCompletedWinSheets },
+    { label: "T2 >60d", value: summary.totalUnpaidT2Over60 },
+    { label: "T16 >60d", value: summary.totalUnpaidT16Over60 },
+    { label: "Conc >60d", value: summary.totalUnpaidConcOver60 },
+    { label: "Collected", value: fmt(summary.totalCollected) },
+    { label: "Full Fee", value: summary.totalCasesFullFee },
+    { label: "SSA Calls", value: summary.totalSsaCalls },
+    { label: "Client Calls", value: summary.totalClientCalls },
+  ];
+
+  return (
+    <>
+      {/* Summary mini-cards */}
+      <div className={`grid grid-cols-3 sm:grid-cols-5 lg:grid-cols-9 gap-3`}>
+        {stats.map((item) => (
+          <div key={item.label} className={`rounded-lg border p-3 ${t.card}`}>
+            <p className={`text-[10px] font-medium ${t.textMuted} uppercase`}>
+              {item.label}
+            </p>
+            <p className={`text-lg font-bold ${t.text} mt-1`}>{item.value}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Team breakdown */}
+      {teams.length > 0 && (
+        <div>
+          <p className={`text-[10px] font-semibold uppercase tracking-wider ${t.textMuted} mb-3`}>
+            By Team — {label}
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            {teams.map((team) => {
+              const teamColor =
+                team.team === "T2"
+                  ? dark
+                    ? "border-blue-700/50 bg-blue-900/10"
+                    : "border-blue-200 bg-blue-50/60"
+                  : team.team === "T16"
+                    ? dark
+                      ? "border-purple-700/50 bg-purple-900/10"
+                      : "border-purple-200 bg-purple-50/60"
+                    : dark
+                      ? "border-teal-700/50 bg-teal-900/10"
+                      : "border-teal-200 bg-teal-50/60";
+              const teamLabel =
+                team.team === "T2"
+                  ? "T2 Team"
+                  : team.team === "T16"
+                    ? "T16 Team"
+                    : "Concurrent Team";
+              const accentText =
+                team.team === "T2"
+                  ? dark
+                    ? "text-blue-400"
+                    : "text-blue-700"
+                  : team.team === "T16"
+                    ? dark
+                      ? "text-purple-400"
+                      : "text-purple-700"
+                    : dark
+                      ? "text-teal-400"
+                      : "text-teal-700";
+              return (
+                <div key={team.team} className={`rounded-lg border p-4 ${teamColor}`}>
+                  <div className="flex items-center justify-between mb-3">
+                    <span className={`text-xs font-bold ${accentText}`}>
+                      {teamLabel}
+                    </span>
+                    <span className={`text-[10px] ${t.textMuted}`}>
+                      {team.agentCount} agent{team.agentCount !== 1 ? "s" : ""}
+                    </span>
+                  </div>
+                  <div className="grid grid-cols-3 gap-2">
+                    {[
+                      { label: "Fees Collected", value: fmt(team.feesCollectedInWindow) },
+                      { label: "SSA Calls", value: team.ssaCalls },
+                      { label: "CL Calls", value: team.clientCalls },
+                      { label: "Win Sheets", value: team.winSheetsCreated },
+                      { label: "Cases Closed", value: team.casesClosed },
+                      { label: "Open Cases", value: team.openCases },
+                    ].map((stat) => (
+                      <div key={stat.label}>
+                        <p className={`text-[9px] font-medium uppercase tracking-wide ${t.textMuted}`}>
+                          {stat.label}
+                        </p>
+                        <p className={`text-sm font-bold ${t.text} mt-0.5`}>
+                          {stat.value}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/scoreboard/ScoreboardSummaryCards.tsx
+++ b/src/components/scoreboard/ScoreboardSummaryCards.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { themeClasses } from "@/lib/theme-classes";
 import { fmt } from "@/lib/formatters";
 
@@ -69,16 +67,18 @@ export function ScoreboardSummaryCards({
   return (
     <>
       {/* Summary mini-cards */}
-      {showMiniCards && <div className={`grid grid-cols-3 sm:grid-cols-5 lg:grid-cols-9 gap-3`}>
-        {stats.map((item) => (
-          <div key={item.label} className={`rounded-lg border p-3 ${t.card}`}>
-            <p className={`text-[10px] font-medium ${t.textMuted} uppercase`}>
-              {item.label}
-            </p>
-            <p className={`text-lg font-bold ${t.text} mt-1`}>{item.value}</p>
-          </div>
-        ))}
-      </div>}
+      {showMiniCards && (
+        <div className="grid grid-cols-3 sm:grid-cols-5 lg:grid-cols-9 gap-3">
+          {stats.map((item) => (
+            <div key={item.label} className={`rounded-lg border p-3 ${t.card}`}>
+              <p className={`text-[10px] font-medium ${t.textMuted} uppercase`}>
+                {item.label}
+              </p>
+              <p className={`text-lg font-bold ${t.text} mt-1`}>{item.value}</p>
+            </div>
+          ))}
+        </div>
+      )}
 
       {/* Team breakdown */}
       {teams.length > 0 && (

--- a/src/components/scoreboard/ScoreboardSummaryCards.tsx
+++ b/src/components/scoreboard/ScoreboardSummaryCards.tsx
@@ -43,6 +43,7 @@ interface ScoreboardSummaryCardsProps {
   label: string;
   dark: boolean;
   t: ReturnType<typeof themeClasses>;
+  showMiniCards?: boolean;
 }
 
 export function ScoreboardSummaryCards({
@@ -51,6 +52,7 @@ export function ScoreboardSummaryCards({
   label,
   dark,
   t,
+  showMiniCards = true,
 }: ScoreboardSummaryCardsProps) {
   const stats = [
     { label: "Cases Assigned", value: summary.totalCasesAssigned },
@@ -67,7 +69,7 @@ export function ScoreboardSummaryCards({
   return (
     <>
       {/* Summary mini-cards */}
-      <div className={`grid grid-cols-3 sm:grid-cols-5 lg:grid-cols-9 gap-3`}>
+      {showMiniCards && <div className={`grid grid-cols-3 sm:grid-cols-5 lg:grid-cols-9 gap-3`}>
         {stats.map((item) => (
           <div key={item.label} className={`rounded-lg border p-3 ${t.card}`}>
             <p className={`text-[10px] font-medium ${t.textMuted} uppercase`}>
@@ -76,7 +78,7 @@ export function ScoreboardSummaryCards({
             <p className={`text-lg font-bold ${t.text} mt-1`}>{item.value}</p>
           </div>
         ))}
-      </div>
+      </div>}
 
       {/* Team breakdown */}
       {teams.length > 0 && (

--- a/src/lib/access/pages.ts
+++ b/src/lib/access/pages.ts
@@ -8,6 +8,7 @@
 
 export const PAGES = [
   { key: "overview", label: "Overview", path: "/" },
+  { key: "master_fees", label: "Master Fees", path: "/master-fees" },
   { key: "fees_closed", label: "Fees Closed", path: "/fees-closed" },
   { key: "scoreboard", label: "Scoreboard", path: "/scoreboard" },
   { key: "chronicle", label: "Chronicle Sync", path: "/chronicle" },

--- a/src/lib/access/role-defaults.ts
+++ b/src/lib/access/role-defaults.ts
@@ -23,7 +23,7 @@ export const ROLE_PAGE_DEFAULTS: Record<AccessRole, PageKey[]> = {
   // Everything operational except user management + app settings.
   lead: PAGE_KEYS.filter((k) => k !== "admin" && k !== "settings" && k !== "archive"),
   // Front-line collections pages only.
-  member: ["overview", "fees_closed", "scoreboard", "reports", "notifications"],
+  member: ["overview", "master_fees", "fees_closed", "scoreboard", "reports", "notifications"],
 };
 
 export const rolePageDefaults = (role: string | null | undefined): PageKey[] =>

--- a/src/lib/auth-helpers.ts
+++ b/src/lib/auth-helpers.ts
@@ -48,8 +48,11 @@ export async function requireCapability(
   const session = await auth();
   if (!session?.user) return { ok: false, error: "Unauthenticated" };
 
+  const rawCaps = session.user.capabilities;
   const caps =
-    session.user.capabilities ?? roleCapabilityDefaults(session.user.role);
+    rawCaps && rawCaps.length > 0
+      ? rawCaps
+      : roleCapabilityDefaults(session.user.role);
   if (!hasCapability(caps, capability)) {
     return { ok: false, error: "Forbidden" };
   }


### PR DESCRIPTION
## Summary
- Extracts scoreboard summary mini-cards into shared `ScoreboardSummaryCards` component and Recent Activity feed into `RecentActivityFeed` component
- Overview page now fetches and renders current-week scoreboard summary cards and last-7-days recent activity feed
- Scoreboard page retains only the team breakdown (mini-cards removed, now live on Overview)
- Reports page trimmed: 4 summary cards, Daily Call Volume chart, and Recent Activity panel removed