### PR TITLE
feat: reports tracker overhaul — team filter, 60/90d toggle, fee_petitions auto-insert

### DIFF
--- a/src/app/api/cases/route.ts
+++ b/src/app/api/cases/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { db } from "@/lib/db";
-import { cases, feeRecords, activityLog, userDetails } from "@/lib/db/schema";
+import { cases, feeRecords, activityLog, userDetails, feePetitions } from "@/lib/db/schema";
 import { eq, ilike, sql, desc } from "drizzle-orm";
 import { requireCapability, guardStatus } from "@/lib/auth-helpers";
 
@@ -336,6 +336,10 @@ export const POST = async (req: NextRequest) => {
       assignedTo: input.assignedTo,
       winSheetStatus: input.winSheetStatus ?? "not_started",
     });
+
+    if (input.levelWon === "FEE_PETITION") {
+      await db.insert(feePetitions).values({ caseId: input.clientId }).onConflictDoNothing();
+    }
 
     // Best-effort: persist the Chronicle id so the case deep-links to Chronicle.
     // onConflictDoNothing guards the case_id unique key; the .catch swallows a

--- a/src/app/api/scoreboard/route.ts
+++ b/src/app/api/scoreboard/route.ts
@@ -105,6 +105,33 @@ export const GET = async (req: NextRequest) => {
          AND c.approval_date IS NOT NULL
          AND c.approval_date < CURRENT_DATE - INTERVAL '60 days') AS unpaid_conc_over_60,
 
+        -- Unpaid T2 cases over 90 days
+        (SELECT COUNT(*) FROM cases c
+         JOIN fee_records fr ON fr.case_id = c.client_id
+         WHERE fr.assigned_to = tm.name
+         AND c.claim_type_label = 'T2'
+         AND fr.t2_pending > 0
+         AND c.approval_date IS NOT NULL
+         AND c.approval_date < CURRENT_DATE - INTERVAL '90 days') AS unpaid_t2_over_90,
+
+        -- Unpaid T16 cases over 90 days
+        (SELECT COUNT(*) FROM cases c
+         JOIN fee_records fr ON fr.case_id = c.client_id
+         WHERE fr.assigned_to = tm.name
+         AND c.claim_type_label = 'T16'
+         AND fr.t16_pending > 0
+         AND c.approval_date IS NOT NULL
+         AND c.approval_date < CURRENT_DATE - INTERVAL '90 days') AS unpaid_t16_over_90,
+
+        -- Unpaid concurrent cases over 90 days
+        (SELECT COUNT(*) FROM cases c
+         JOIN fee_records fr ON fr.case_id = c.client_id
+         WHERE fr.assigned_to = tm.name
+         AND c.claim_type_label = 'T2_T16'
+         AND (fr.t2_pending > 0 OR fr.t16_pending > 0)
+         AND c.approval_date IS NOT NULL
+         AND c.approval_date < CURRENT_DATE - INTERVAL '90 days') AS unpaid_conc_over_90,
+
         -- Total fees collected (all time for this agent)
         COALESCE((SELECT SUM(fr.total_fees_paid::numeric) FROM fee_records fr WHERE fr.assigned_to = tm.name), 0) AS total_collected,
 
@@ -173,6 +200,9 @@ export const GET = async (req: NextRequest) => {
         unpaidT2Over60: Number(r.unpaid_t2_over_60),
         unpaidT16Over60: Number(r.unpaid_t16_over_60),
         unpaidConcOver60: Number(r.unpaid_conc_over_60),
+        unpaidT2Over90: Number(r.unpaid_t2_over_90),
+        unpaidT16Over90: Number(r.unpaid_t16_over_90),
+        unpaidConcOver90: Number(r.unpaid_conc_over_90),
         totalCollected: Number(r.total_collected),
         feesCollectedInWindow: Number(r.fees_collected_in_window),
         casesFullFee: Number(r.cases_full_fee),
@@ -191,6 +221,9 @@ export const GET = async (req: NextRequest) => {
       totalUnpaidT2Over60: agents.reduce((s, a) => s + a.unpaidT2Over60, 0),
       totalUnpaidT16Over60: agents.reduce((s, a) => s + a.unpaidT16Over60, 0),
       totalUnpaidConcOver60: agents.reduce((s, a) => s + a.unpaidConcOver60, 0),
+      totalUnpaidT2Over90: agents.reduce((s, a) => s + a.unpaidT2Over90, 0),
+      totalUnpaidT16Over90: agents.reduce((s, a) => s + a.unpaidT16Over90, 0),
+      totalUnpaidConcOver90: agents.reduce((s, a) => s + a.unpaidConcOver90, 0),
       totalCollected: agents.reduce((s, a) => s + a.totalCollected, 0),
       totalFeesCollectedInWindow: agents.reduce((s, a) => s + a.feesCollectedInWindow, 0),
       totalCasesFullFee: agents.reduce((s, a) => s + a.casesFullFee, 0),

--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -41,6 +41,9 @@ interface AgentScore {
   unpaidT2Over60: number;
   unpaidT16Over60: number;
   unpaidConcOver60: number;
+  unpaidT2Over90: number;
+  unpaidT16Over90: number;
+  unpaidConcOver90: number;
   totalCollected: number;
   feesCollectedInWindow: number;
   casesFullFee: number;
@@ -144,8 +147,10 @@ const fmtRangeDate = (iso: string): string =>
 const cellKey = (agent: string, date: string): CellKey => `${agent}|${date}`;
 const EMPTY_CELL: CellValues = { ssaCalls: "", clientCallsIb: "", clientCallsOb: "", winSheetsCreated: "" };
 
-const hasOverdue = (a: AgentScore) =>
-  a.unpaidT2Over60 + a.unpaidT16Over60 + a.unpaidConcOver60 > 0;
+const hasOverdue = (a: AgentScore, t2d: 60 | 90, t16d: 60 | 90, concd: 60 | 90) =>
+  (t2d === 60 ? a.unpaidT2Over60 : a.unpaidT2Over90) +
+  (t16d === 60 ? a.unpaidT16Over60 : a.unpaidT16Over90) +
+  (concd === 60 ? a.unpaidConcOver60 : a.unpaidConcOver90) > 0;
 
 // ---------- component ----------
 
@@ -161,6 +166,10 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
   const [error, setError] = useState<string | null>(null);
 
   const [agentSearch, setAgentSearch] = useState("");
+  const [teamFilter, setTeamFilter] = useState("all");
+  const [t2Days, setT2Days] = useState<60 | 90>(60);
+  const [t16Days, setT16Days] = useState<60 | 90>(60);
+  const [concDays, setConcDays] = useState<60 | 90>(60);
   const [needsAttention, setNeedsAttention] = useState(false);
   const [metricFocus, setMetricFocus] = useState<MetricFocus>("all");
 
@@ -235,7 +244,12 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
       const json = await res.json();
       if (cancelledRef.current) return;
       setData({
-        agents: json.agents ?? [],
+        agents: (json.agents ?? []).map((a: AgentScore) => ({
+          ...a,
+          unpaidT2Over90:   a.unpaidT2Over90   ?? 0,
+          unpaidT16Over90:  a.unpaidT16Over90  ?? 0,
+          unpaidConcOver90: a.unpaidConcOver90 ?? 0,
+        })),
         daily: json.daily ?? [],
         summary: json.summary ?? null,
         teams: json.teams ?? [],
@@ -278,10 +292,11 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
     const q = agentSearch.trim().toLowerCase();
     return (data?.agents ?? []).filter((a) => {
       if (q && !a.agent.toLowerCase().includes(q)) return false;
-      if (needsAttention && !hasOverdue(a)) return false;
+      if (teamFilter !== "all" && a.team !== teamFilter) return false;
+      if (needsAttention && !hasOverdue(a, t2Days, t16Days, concDays)) return false;
       return true;
     });
-  }, [data, agentSearch, needsAttention]);
+  }, [data, agentSearch, teamFilter, t2Days, t16Days, concDays, needsAttention]);
 
   const filteredTotals = useMemo(() => ({
     casesAssigned:      filteredAgents.reduce((s, a) => s + a.casesAssigned, 0),
@@ -289,6 +304,9 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
     unpaidT2Over60:     filteredAgents.reduce((s, a) => s + a.unpaidT2Over60, 0),
     unpaidT16Over60:    filteredAgents.reduce((s, a) => s + a.unpaidT16Over60, 0),
     unpaidConcOver60:   filteredAgents.reduce((s, a) => s + a.unpaidConcOver60, 0),
+    unpaidT2Over90:     filteredAgents.reduce((s, a) => s + a.unpaidT2Over90, 0),
+    unpaidT16Over90:    filteredAgents.reduce((s, a) => s + a.unpaidT16Over90, 0),
+    unpaidConcOver90:   filteredAgents.reduce((s, a) => s + a.unpaidConcOver90, 0),
     totalCollected:     filteredAgents.reduce((s, a) => s + a.totalCollected, 0),
     casesFullFee:       filteredAgents.reduce((s, a) => s + a.casesFullFee, 0),
     weekSsaCalls:       filteredAgents.reduce((s, a) => s + a.weekSsaCalls, 0),
@@ -536,6 +554,17 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                 />
               </div>
               <select
+                value={teamFilter}
+                onChange={(e) => setTeamFilter(e.target.value)}
+                aria-label="Team filter"
+                className={`h-8 px-2 rounded-md border text-xs outline-none cursor-pointer ${t.inputBg}`}
+              >
+                <option value="all">All Teams</option>
+                <option value="T2">T2</option>
+                <option value="T16">T16</option>
+                <option value="Concurrent">Concurrent</option>
+              </select>
+              <select
                 value={metricFocus}
                 onChange={(e) => setMetricFocus(e.target.value as MetricFocus)}
                 aria-label="Metric focus"
@@ -572,9 +601,45 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                     <th className={`${thBase} ${t.textSub} text-left`}>Agent</th>
                     {showCol("cases")     && <th className={`${thBase} ${t.textSub} text-right`}>Cases</th>}
                     {showCol("winsheets") && <th className={`${thBase} ${t.textSub} text-right`}>Win Sheets</th>}
-                    {showCol("t2")   && <th className={`${thBase} text-right ${dark ? "text-red-400" : "text-red-600"}`}>T2 &gt;60d</th>}
-                    {showCol("t16")  && <th className={`${thBase} text-right ${dark ? "text-red-400" : "text-red-600"}`}>T16 &gt;60d</th>}
-                    {showCol("conc") && <th className={`${thBase} text-right ${dark ? "text-red-400" : "text-red-600"}`}>Conc &gt;60d</th>}
+                    {showCol("t2") && (
+                      <th className={`${thBase} text-right`}>
+                        <button
+                          onClick={() => setT2Days((v) => v === 60 ? 90 : 60)}
+                          aria-pressed={t2Days === 90}
+                          aria-label={`T2 aging threshold, currently ${t2Days} days`}
+                          className={`ml-auto flex items-center gap-0.5 transition-colors ${t2Days === 90 ? (dark ? "text-violet-400" : "text-violet-600") : (dark ? "text-red-400" : "text-red-600")}`}
+                          title="Toggle 60d / 90d threshold"
+                        >
+                          T2 &gt;{t2Days}d
+                        </button>
+                      </th>
+                    )}
+                    {showCol("t16") && (
+                      <th className={`${thBase} text-right`}>
+                        <button
+                          onClick={() => setT16Days((v) => v === 60 ? 90 : 60)}
+                          aria-pressed={t16Days === 90}
+                          aria-label={`T16 aging threshold, currently ${t16Days} days`}
+                          className={`ml-auto flex items-center gap-0.5 transition-colors ${t16Days === 90 ? (dark ? "text-violet-400" : "text-violet-600") : (dark ? "text-red-400" : "text-red-600")}`}
+                          title="Toggle 60d / 90d threshold"
+                        >
+                          T16 &gt;{t16Days}d
+                        </button>
+                      </th>
+                    )}
+                    {showCol("conc") && (
+                      <th className={`${thBase} text-right`}>
+                        <button
+                          onClick={() => setConcDays((v) => v === 60 ? 90 : 60)}
+                          aria-pressed={concDays === 90}
+                          aria-label={`Concurrent aging threshold, currently ${concDays} days`}
+                          className={`ml-auto flex items-center gap-0.5 transition-colors ${concDays === 90 ? (dark ? "text-violet-400" : "text-violet-600") : (dark ? "text-red-400" : "text-red-600")}`}
+                          title="Toggle 60d / 90d threshold"
+                        >
+                          Conc &gt;{concDays}d
+                        </button>
+                      </th>
+                    )}
                     {showCol("collected") && <th className={`${thBase} ${t.textSub} text-right`}>Collected</th>}
                     {showCol("fullfee")   && <th className={`${thBase} ${t.textSub} text-right`}>Full Fee</th>}
                     {showCol("ssa")    && <th className={`${thBase} ${t.textSub} text-right`}>SSA Calls</th>}
@@ -593,9 +658,9 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                       <td className={`${tdBase} ${t.text} font-semibold`}>{a.agent}</td>
                       {showCol("cases")     && <td className={`${tdBase} text-right ${t.text}`}>{a.casesAssigned}</td>}
                       {showCol("winsheets") && <td className={`${tdBase} text-right ${t.text}`}>{a.completedWinSheets}</td>}
-                      {showCol("t2")  && <td className={`${tdBase} text-right ${a.unpaidT2Over60  > 0 ? (dark ? "text-red-400 font-medium" : "text-red-600 font-medium") : t.textMuted}`}>{a.unpaidT2Over60}</td>}
-                      {showCol("t16") && <td className={`${tdBase} text-right ${a.unpaidT16Over60 > 0 ? (dark ? "text-red-400 font-medium" : "text-red-600 font-medium") : t.textMuted}`}>{a.unpaidT16Over60}</td>}
-                      {showCol("conc") && <td className={`${tdBase} text-right ${a.unpaidConcOver60 > 0 ? (dark ? "text-red-400 font-medium" : "text-red-600 font-medium") : t.textMuted}`}>{a.unpaidConcOver60}</td>}
+                      {showCol("t2")  && <td className={`${tdBase} text-right ${(t2Days   === 60 ? a.unpaidT2Over60   : a.unpaidT2Over90)   > 0 ? (dark ? "text-red-400 font-medium" : "text-red-600 font-medium") : t.textMuted}`}>{t2Days   === 60 ? a.unpaidT2Over60   : a.unpaidT2Over90}</td>}
+                      {showCol("t16") && <td className={`${tdBase} text-right ${(t16Days  === 60 ? a.unpaidT16Over60  : a.unpaidT16Over90)  > 0 ? (dark ? "text-red-400 font-medium" : "text-red-600 font-medium") : t.textMuted}`}>{t16Days  === 60 ? a.unpaidT16Over60  : a.unpaidT16Over90}</td>}
+                      {showCol("conc") && <td className={`${tdBase} text-right ${(concDays === 60 ? a.unpaidConcOver60 : a.unpaidConcOver90) > 0 ? (dark ? "text-red-400 font-medium" : "text-red-600 font-medium") : t.textMuted}`}>{concDays === 60 ? a.unpaidConcOver60 : a.unpaidConcOver90}</td>}
                       {showCol("collected") && (
                         <td className={`${tdBase} text-right font-semibold ${a.totalCollected > 0 ? "text-emerald-500" : t.textMuted}`}>
                           {a.totalCollected > 0 ? fmt(a.totalCollected) : "—"}
@@ -612,9 +677,9 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                     <td className={`${tdBase} font-bold ${t.text}`}>TOTAL</td>
                     {showCol("cases")     && <td className={`${tdBase} text-right font-bold ${t.text}`}>{filteredTotals.casesAssigned}</td>}
                     {showCol("winsheets") && <td className={`${tdBase} text-right font-bold ${t.text}`}>{filteredTotals.completedWinSheets}</td>}
-                    {showCol("t2")   && <td className={`${tdBase} text-right font-bold ${dark ? "text-red-400" : "text-red-600"}`}>{filteredTotals.unpaidT2Over60}</td>}
-                    {showCol("t16")  && <td className={`${tdBase} text-right font-bold ${dark ? "text-red-400" : "text-red-600"}`}>{filteredTotals.unpaidT16Over60}</td>}
-                    {showCol("conc") && <td className={`${tdBase} text-right font-bold ${dark ? "text-red-400" : "text-red-600"}`}>{filteredTotals.unpaidConcOver60}</td>}
+                    {showCol("t2")   && <td className={`${tdBase} text-right font-bold ${dark ? "text-red-400" : "text-red-600"}`}>{t2Days   === 60 ? filteredTotals.unpaidT2Over60   : filteredTotals.unpaidT2Over90}</td>}
+                    {showCol("t16")  && <td className={`${tdBase} text-right font-bold ${dark ? "text-red-400" : "text-red-600"}`}>{t16Days  === 60 ? filteredTotals.unpaidT16Over60  : filteredTotals.unpaidT16Over90}</td>}
+                    {showCol("conc") && <td className={`${tdBase} text-right font-bold ${dark ? "text-red-400" : "text-red-600"}`}>{concDays === 60 ? filteredTotals.unpaidConcOver60 : filteredTotals.unpaidConcOver90}</td>}
                     {showCol("collected") && <td className={`${tdBase} text-right font-bold text-emerald-500`}>{fmt(filteredTotals.totalCollected)}</td>}
                     {showCol("fullfee")   && <td className={`${tdBase} text-right font-bold ${t.text}`}>{filteredTotals.casesFullFee}</td>}
                     {showCol("ssa")    && <td className={`${tdBase} text-right font-bold ${t.text}`}>{filteredTotals.weekSsaCalls}</td>}

--- a/src/components/scoreboard/ScoreboardSummaryCards.tsx
+++ b/src/components/scoreboard/ScoreboardSummaryCards.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useState } from "react";
 import { themeClasses } from "@/lib/theme-classes";
 import { fmt } from "@/lib/formatters";
 
@@ -10,6 +13,9 @@ export interface ScoreboardSummary {
   totalUnpaidT2Over60: number;
   totalUnpaidT16Over60: number;
   totalUnpaidConcOver60: number;
+  totalUnpaidT2Over90: number;
+  totalUnpaidT16Over90: number;
+  totalUnpaidConcOver90: number;
   totalCollected: number;
   totalFeesCollectedInWindow: number;
   totalCasesFullFee: number;
@@ -52,12 +58,31 @@ export function ScoreboardSummaryCards({
   t,
   showMiniCards = true,
 }: ScoreboardSummaryCardsProps) {
-  const stats = [
+  const [t2Days, setT2Days] = useState<60 | 90>(60);
+  const [t16Days, setT16Days] = useState<60 | 90>(60);
+  const [concDays, setConcDays] = useState<60 | 90>(60);
+
+  const stats: { label: string; value: string | number; onClick?: () => void; toggled?: boolean }[] = [
     { label: "Cases Assigned", value: summary.totalCasesAssigned },
     { label: "Win Sheets", value: summary.totalCompletedWinSheets },
-    { label: "T2 >60d", value: summary.totalUnpaidT2Over60 },
-    { label: "T16 >60d", value: summary.totalUnpaidT16Over60 },
-    { label: "Conc >60d", value: summary.totalUnpaidConcOver60 },
+    {
+      label: `T2 >${t2Days}D`,
+      value: t2Days === 60 ? summary.totalUnpaidT2Over60 : summary.totalUnpaidT2Over90,
+      onClick: () => setT2Days((v) => v === 60 ? 90 : 60),
+      toggled: t2Days === 90,
+    },
+    {
+      label: `T16 >${t16Days}D`,
+      value: t16Days === 60 ? summary.totalUnpaidT16Over60 : summary.totalUnpaidT16Over90,
+      onClick: () => setT16Days((v) => v === 60 ? 90 : 60),
+      toggled: t16Days === 90,
+    },
+    {
+      label: `CONC >${concDays}D`,
+      value: concDays === 60 ? summary.totalUnpaidConcOver60 : summary.totalUnpaidConcOver90,
+      onClick: () => setConcDays((v) => v === 60 ? 90 : 60),
+      toggled: concDays === 90,
+    },
     { label: "Collected", value: fmt(summary.totalCollected) },
     { label: "Full Fee", value: summary.totalCasesFullFee },
     { label: "SSA Calls", value: summary.totalSsaCalls },
@@ -69,14 +94,38 @@ export function ScoreboardSummaryCards({
       {/* Summary mini-cards */}
       {showMiniCards && (
         <div className="grid grid-cols-3 sm:grid-cols-5 lg:grid-cols-9 gap-3">
-          {stats.map((item) => (
-            <div key={item.label} className={`rounded-lg border p-3 ${t.card}`}>
-              <p className={`text-[10px] font-medium ${t.textMuted} uppercase`}>
-                {item.label}
-              </p>
-              <p className={`text-lg font-bold ${t.text} mt-1`}>{item.value}</p>
-            </div>
-          ))}
+          {stats.map((item) =>
+            item.onClick ? (
+              <button
+                key={item.label}
+                onClick={item.onClick}
+                aria-pressed={item.toggled}
+                aria-label={`${item.label} aging threshold — click to toggle`}
+                title="Toggle 60D / 90D threshold"
+                className={`rounded-lg border p-3 text-left transition-colors ${
+                  item.toggled
+                    ? dark
+                      ? "bg-violet-900/20 border-violet-700/60"
+                      : "bg-violet-50 border-violet-300"
+                    : t.card
+                }`}
+              >
+                <p className={`text-[10px] font-medium uppercase ${item.toggled ? (dark ? "text-violet-400" : "text-violet-600") : t.textMuted}`}>
+                  {item.label}
+                </p>
+                <p className={`text-lg font-bold mt-1 ${item.toggled ? (dark ? "text-violet-300" : "text-violet-700") : t.text}`}>
+                  {item.value}
+                </p>
+              </button>
+            ) : (
+              <div key={item.label} className={`rounded-lg border p-3 ${t.card}`}>
+                <p className={`text-[10px] font-medium ${t.textMuted} uppercase`}>
+                  {item.label}
+                </p>
+                <p className={`text-lg font-bold ${t.text} mt-1`}>{item.value}</p>
+              </div>
+            )
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary

- **Team filter** on the Reports tracker — filter agent rows by All Teams / T2 / T16 / Concurrent
- **Per-column 60D/90D aging toggle** on T2/T16/Conc column headers in the Reports tracker and the Overview mini-cards — click a column header or card to switch between >60D and >90D threshold; turns violet when at 90D
- **Scoreboard API** now always returns both 60D and 90D aging counts in a single response (no double-fetch)
- **Fee Petitions auto-insert** — when a case is manually created with `levelWon = FEE_PETITION`, a row is automatically added to `fee_petitions` via `onConflictDoNothing()`
- **A11y** — `aria-label` added to all aging threshold toggle buttons; IIFE body cells replaced with inline ternaries to match surrounding JSX style

## Files changed

| File | Change |
|------|--------|
| `src/app/api/scoreboard/route.ts` | Add 3 new 90D aging subqueries; map + aggregate both thresholds |
| `src/app/api/cases/route.ts` | Auto-insert `fee_petitions` row on `FEE_PETITION` case creation |
| `src/components/reports/ScoreboardTracker.tsx` | Team filter dropdown; per-column `t2Days`/`t16Days`/`concDays` toggle state; `aria-label` on header buttons |
| `src/components/scoreboard/ScoreboardSummaryCards.tsx` | `"use client"` + `useState`; T2/T16/CONC cards now toggleable; `aria-label` on toggle buttons |