### PR TITLE
feat: audit logs tab on notifications, remove call columns from agent tracking

### DIFF
--- a/src/app/(dashboard)/notifications/page.tsx
+++ b/src/app/(dashboard)/notifications/page.tsx
@@ -15,8 +15,10 @@ import {
   RefreshCw,
   ChevronRight,
   Eye,
+  ClipboardList,
 } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
+import { AuditLogTab } from "@/components/notifications/AuditLogTab";
 
 // ============================================================================
 // Types
@@ -36,6 +38,7 @@ interface Notification {
 }
 
 type FilterType = "all" | Notification["type"];
+type PageTab = "notifications" | "audit_logs";
 
 const TYPE_META: Record<
   Notification["type"],
@@ -84,6 +87,11 @@ const FILTER_TABS: { key: FilterType; label: string }[] = [
   { key: "case_assigned", label: "Assignments" },
 ];
 
+const PAGE_TABS: { key: PageTab; label: string; icon: React.ElementType }[] = [
+  { key: "notifications", label: "Notifications", icon: Bell },
+  { key: "audit_logs",    label: "Audit Logs",    icon: ClipboardList },
+];
+
 // ============================================================================
 // Helpers
 // ============================================================================
@@ -121,6 +129,7 @@ export default function NotificationsPage() {
   const [error, setError] = useState<string | null>(null);
   const [filter, setFilter] = useState<FilterType>("all");
   const [markingAll, setMarkingAll] = useState(false);
+  const [pageTab, setPageTab] = useState<PageTab>("notifications");
 
   const fetchAbortRef = useRef<AbortController | null>(null);
 
@@ -230,6 +239,38 @@ export default function NotificationsPage() {
 
   return (
     <div className="space-y-4">
+      {/* Page-level tab switcher */}
+      <div className={`flex gap-1 p-1 rounded-lg border w-fit ${dark ? "bg-neutral-900 border-neutral-800" : "bg-neutral-100/60 border-neutral-200"}`}>
+        {PAGE_TABS.map(({ key, label, icon: Icon }) => (
+          <button
+            key={key}
+            onClick={() => setPageTab(key)}
+            className={`h-8 px-3 rounded-md text-xs font-medium flex items-center gap-1.5 transition-colors ${
+              pageTab === key
+                ? dark
+                  ? "bg-neutral-800 text-neutral-100"
+                  : "bg-white text-neutral-900 shadow-sm"
+                : dark
+                  ? "text-neutral-400 hover:text-neutral-200"
+                  : "text-neutral-500 hover:text-neutral-700"
+            }`}
+          >
+            <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+            {label}
+            {key === "notifications" && unreadCount > 0 && (
+              <span className="min-w-4 h-4 px-1 rounded-full bg-red-500 text-white text-[9px] font-bold flex items-center justify-center">
+                {unreadCount > 99 ? "99+" : unreadCount}
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      {/* Audit Logs tab */}
+      {pageTab === "audit_logs" && <AuditLogTab dark={dark} t={t} />}
+
+      {/* Notifications tab */}
+      {pageTab === "notifications" && <>
       {/* Header */}
       <div className={`rounded-xl border ${t.card}`}>
         <div className="p-4 flex flex-col sm:flex-row sm:items-center justify-between gap-3">
@@ -469,6 +510,7 @@ export default function NotificationsPage() {
           })}
         </div>
       )}
+      </>}
     </div>
   );
 }

--- a/src/components/notifications/AuditLogTab.tsx
+++ b/src/components/notifications/AuditLogTab.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useState, useEffect, useRef, Fragment } from "react";
+import { ChevronLeft, ChevronRight, RefreshCw, ClipboardList, AlertCircle } from "lucide-react";
+import { themeClasses } from "@/lib/theme-classes";
+
+interface DailyMetricRow {
+  agent: string;
+  date: string;
+  ssaCalls: number;
+  clientCallsIb: number;
+  clientCallsOb: number;
+  winSheetsCreated: number;
+  notes: string | null;
+}
+
+interface AuditLogTabProps {
+  dark: boolean;
+  t: ReturnType<typeof themeClasses>;
+}
+
+const getMonday = (offset = 0): string => {
+  const d = new Date();
+  const day = d.getDay();
+  d.setDate(d.getDate() - day + (day === 0 ? -6 : 1) + offset * 7);
+  return d.toISOString().split("T")[0];
+};
+
+const formatWeekLabel = (monday: string): string => {
+  const start = new Date(monday + "T00:00:00");
+  const end = new Date(monday + "T00:00:00");
+  end.setDate(end.getDate() + 4);
+  const opts: Intl.DateTimeFormatOptions = { month: "short", day: "numeric" };
+  return `${start.toLocaleDateString("en-US", opts)} – ${end.toLocaleDateString("en-US", { ...opts, year: "numeric" })}`;
+};
+
+const fmtDate = (iso: string): string =>
+  new Date(`${iso}T00:00:00`).toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+
+const thBase = "px-3 py-2 text-[11px] font-semibold uppercase tracking-wide";
+const tdBase = "px-3 py-2 text-xs";
+
+export function AuditLogTab({ dark, t }: AuditLogTabProps) {
+  const [weekOffset, setWeekOffset] = useState(0);
+  const [rows, setRows] = useState<DailyMetricRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const monday = getMonday(weekOffset);
+
+  useEffect(() => {
+    let cancelled = false;
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setLoading(true);
+    setError(null);
+
+    fetch(`/api/daily-metrics?week=${monday}`, { signal: controller.signal })
+      .then((res) => {
+        if (!res.ok) throw new Error(`Failed to load audit log (${res.status})`);
+        return res.json();
+      })
+      .then((json) => {
+        if (cancelled) return;
+        setRows(json.data ?? []);
+      })
+      .catch((err) => {
+        if (cancelled || (err as Error).name === "AbortError") return;
+        setError((err as Error).message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+      abortRef.current?.abort();
+    };
+  }, [monday]);
+
+  const byDate = rows.reduce<Record<string, DailyMetricRow[]>>((acc, r) => {
+    (acc[r.date] ??= []).push(r);
+    return acc;
+  }, {});
+  const dates = Object.keys(byDate).sort((a, b) => b.localeCompare(a));
+
+  const rowDivide = dark ? "border-neutral-800/40" : "border-neutral-100";
+  const rowHover  = dark ? "hover:bg-neutral-800/30" : "hover:bg-neutral-50";
+  const dateBg    = dark ? "bg-neutral-800/60" : "bg-neutral-50";
+
+  return (
+    <div className={`rounded-xl border ${t.card}`}>
+      {/* Header */}
+      <div className={`p-4 flex flex-col sm:flex-row sm:items-center justify-between gap-3 border-b ${t.borderLight}`}>
+        <div className="flex items-center gap-3">
+          <div className={`w-10 h-10 rounded-lg flex items-center justify-center ${dark ? "bg-indigo-900/40" : "bg-indigo-50"}`}>
+            <ClipboardList className={`h-5 w-5 ${dark ? "text-indigo-400" : "text-indigo-600"}`} aria-hidden="true" />
+          </div>
+          <div>
+            <h3 className={`text-sm font-bold ${t.text}`}>Audit Log</h3>
+            <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
+              Daily agent activity — {formatWeekLabel(monday)}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={() => setWeekOffset((v) => v - 1)}
+            className={`h-8 w-8 rounded-md flex items-center justify-center transition-colors ${t.hover} ${t.textSub}`}
+            aria-label="Previous week"
+          >
+            <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+          </button>
+          <span className={`text-[11px] font-medium ${t.textSub} whitespace-nowrap px-2`}>
+            {formatWeekLabel(monday)}
+          </span>
+          <button
+            onClick={() => setWeekOffset((v) => v + 1)}
+            disabled={weekOffset >= 0}
+            className={`h-8 w-8 rounded-md flex items-center justify-center transition-colors ${t.hover} ${t.textSub} disabled:opacity-40`}
+            aria-label="Next week"
+          >
+            <ChevronRight className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div
+          className={`m-4 rounded-lg border p-3 flex items-center gap-2 text-xs ${dark ? "bg-red-900/20 border-red-800 text-red-400" : "bg-red-50 border-red-200 text-red-700"}`}
+          role="alert"
+        >
+          <AlertCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
+          {error}
+        </div>
+      )}
+
+      {/* Loading */}
+      {loading && (
+        <div className="flex items-center justify-center py-16">
+          <RefreshCw className={`h-5 w-5 animate-spin ${t.textMuted}`} aria-hidden="true" />
+          <span className={`ml-2 text-sm ${t.textSub}`}>Loading audit log...</span>
+        </div>
+      )}
+
+      {/* Empty */}
+      {!loading && !error && dates.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-16">
+          <ClipboardList className={`h-8 w-8 ${t.textMuted} mb-3`} aria-hidden="true" />
+          <p className={`text-sm font-medium ${t.text}`}>No activity logged for this week</p>
+          <p className={`text-xs ${t.textMuted} mt-1`}>
+            Daily call entries appear here once agents log their activity in Reports.
+          </p>
+        </div>
+      )}
+
+      {/* Table */}
+      {!loading && !error && dates.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-150">
+            <thead>
+              <tr className={`border-b ${t.borderLight}`}>
+                <th className={`${thBase} ${t.textSub} text-left`}>Agent</th>
+                <th className={`${thBase} ${t.textSub} text-right`}>SSA Calls</th>
+                <th className={`${thBase} ${t.textSub} text-right`}>Client IB</th>
+                <th className={`${thBase} ${t.textSub} text-right`}>Client OB</th>
+                <th className={`${thBase} ${t.textSub} text-right`}>Win Sheets</th>
+                <th className={`${thBase} ${t.textSub} text-left`}>Notes</th>
+              </tr>
+            </thead>
+            <tbody>
+              {dates.map((date) => (
+                <Fragment key={date}>
+                  <tr className={dateBg}>
+                    <td colSpan={6} className={`${tdBase} font-semibold ${t.textSub}`}>
+                      {fmtDate(date)}
+                    </td>
+                  </tr>
+                  {byDate[date]
+                    .slice()
+                    .sort((a, b) => a.agent.localeCompare(b.agent))
+                    .map((row) => (
+                      <tr
+                        key={`${date}-${row.agent}`}
+                        className={`border-b ${rowDivide} ${rowHover} transition-colors`}
+                      >
+                        <td className={`${tdBase} ${t.text} font-medium pl-6`}>{row.agent}</td>
+                        <td className={`${tdBase} text-right ${row.ssaCalls > 0 ? t.text : t.textMuted}`}>
+                          {row.ssaCalls || "—"}
+                        </td>
+                        <td className={`${tdBase} text-right ${row.clientCallsIb > 0 ? t.text : t.textMuted}`}>
+                          {row.clientCallsIb || "—"}
+                        </td>
+                        <td className={`${tdBase} text-right ${row.clientCallsOb > 0 ? t.text : t.textMuted}`}>
+                          {row.clientCallsOb || "—"}
+                        </td>
+                        <td className={`${tdBase} text-right ${row.winSheetsCreated > 0 ? t.text : t.textMuted}`}>
+                          {row.winSheetsCreated || "—"}
+                        </td>
+                        <td className={`${tdBase} max-w-64 truncate ${row.notes ? t.textSub : t.textMuted}`}>
+                          {row.notes || "—"}
+                        </td>
+                      </tr>
+                    ))}
+                </Fragment>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -76,13 +76,12 @@ interface CellValues {
   winSheetsCreated: string;
 }
 
-type MetricFocus = "all" | "aging" | "calls" | "fees";
+type MetricFocus = "all" | "aging" | "fees";
 
 const FOCUS_OPTIONS: { value: MetricFocus; label: string }[] = [
-  { value: "all",    label: "All metrics"  },
-  { value: "aging",  label: "Aging (>60d)" },
-  { value: "calls",  label: "Calls"        },
-  { value: "fees",   label: "Fees"         },
+  { value: "all",   label: "All metrics"  },
+  { value: "aging", label: "Aging (>60d)" },
+  { value: "fees",  label: "Fees"         },
 ];
 
 const COL_FOCUS: Record<string, MetricFocus[]> = {
@@ -93,8 +92,6 @@ const COL_FOCUS: Record<string, MetricFocus[]> = {
   conc:      ["aging"],
   collected: ["fees"],
   fullfee:   ["fees"],
-  ssa:       ["calls"],
-  client:    ["calls"],
 };
 
 type DateMode = "week" | "month" | "range";
@@ -309,8 +306,6 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
     unpaidConcOver90:   filteredAgents.reduce((s, a) => s + a.unpaidConcOver90, 0),
     totalCollected:     filteredAgents.reduce((s, a) => s + a.totalCollected, 0),
     casesFullFee:       filteredAgents.reduce((s, a) => s + a.casesFullFee, 0),
-    weekSsaCalls:       filteredAgents.reduce((s, a) => s + a.weekSsaCalls, 0),
-    weekClientCalls:    filteredAgents.reduce((s, a) => s + a.weekClientCalls, 0),
   }), [filteredAgents]);
 
   const getCell = (agent: string, date: string): CellValues =>
@@ -642,8 +637,6 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                     )}
                     {showCol("collected") && <th className={`${thBase} ${t.textSub} text-right`}>Collected</th>}
                     {showCol("fullfee")   && <th className={`${thBase} ${t.textSub} text-right`}>Full Fee</th>}
-                    {showCol("ssa")    && <th className={`${thBase} ${t.textSub} text-right`}>SSA Calls</th>}
-                    {showCol("client") && <th className={`${thBase} ${t.textSub} text-right`}>Client Calls</th>}
                   </tr>
                 </thead>
                 <tbody>
@@ -667,8 +660,6 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                         </td>
                       )}
                       {showCol("fullfee") && <td className={`${tdBase} text-right ${t.text}`}>{a.casesFullFee}</td>}
-                      {showCol("ssa")    && <td className={`${tdBase} text-right ${a.weekSsaCalls    > 0 ? t.text : t.textMuted}`}>{a.weekSsaCalls    || "—"}</td>}
-                      {showCol("client") && <td className={`${tdBase} text-right ${a.weekClientCalls > 0 ? t.text : t.textMuted}`}>{a.weekClientCalls || "—"}</td>}
                     </tr>
                   ))}
                 </tbody>
@@ -682,8 +673,6 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                     {showCol("conc") && <td className={`${tdBase} text-right font-bold ${dark ? "text-red-400" : "text-red-600"}`}>{concDays === 60 ? filteredTotals.unpaidConcOver60 : filteredTotals.unpaidConcOver90}</td>}
                     {showCol("collected") && <td className={`${tdBase} text-right font-bold text-emerald-500`}>{fmt(filteredTotals.totalCollected)}</td>}
                     {showCol("fullfee")   && <td className={`${tdBase} text-right font-bold ${t.text}`}>{filteredTotals.casesFullFee}</td>}
-                    {showCol("ssa")    && <td className={`${tdBase} text-right font-bold ${t.text}`}>{filteredTotals.weekSsaCalls}</td>}
-                    {showCol("client") && <td className={`${tdBase} text-right font-bold ${t.text}`}>{filteredTotals.weekClientCalls}</td>}
                   </tr>
                 </tfoot>
               </table>


### PR DESCRIPTION
## Summary

- **New Audit Logs tab** on the Notifications page — page-level pill switcher toggles between Notifications and Audit Logs; unread badge persists on the Notifications tab
- **AuditLogTab component** fetches `/api/daily-metrics?week=...`; week navigation (prev/next); table grouped by date (most recent first), sorted by agent within each day; shows Agent, SSA Calls, Client IB, Client OB, Win Sheets, Notes
- **ScoreboardTracker cleanup** — SSA Calls and Client Calls columns removed from the agent tracking table; "Calls" option removed from the metric focus filter (no longer relevant)
- Daily call entry panel ("Log Calls" form) in Reports is unchanged — data entry stays there

## Files changed

| File | Change |
|------|--------|
| `src/components/notifications/AuditLogTab.tsx` | New component — week-navigable audit log table |
| `src/app/(dashboard)/notifications/page.tsx` | Page-level tab switcher; wires in AuditLogTab |
| `src/components/reports/ScoreboardTracker.tsx` | Remove SSA/Client Calls columns and Calls focus option |