### PR TITLE
feat: add unpaid aging filter to master fees and fee petitions

### DIFF
--- a/src/app/(dashboard)/master-fees/page.tsx
+++ b/src/app/(dashboard)/master-fees/page.tsx
@@ -1,11 +1,20 @@
 "use client";
 
+import { useState } from "react";
 import { useTheme } from "next-themes";
 import { FeeRecordsTable } from "@/components/cases/FeeRecordsTable";
 import { useDashboard } from "@/hooks/useDashboard";
 import { useDateRange } from "@/lib/date-range-context";
 import { themeClasses } from "@/lib/theme-classes";
 import { RefreshCw, AlertCircle } from "lucide-react";
+
+type AgingFilter = "all" | "unpaid_60" | "unpaid_90";
+
+const AGING_OPTIONS: { value: AgingFilter; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "unpaid_60", label: "Unpaid >60d" },
+  { value: "unpaid_90", label: "Unpaid >90d" },
+];
 
 export default function MasterFeesPage() {
   const {
@@ -20,6 +29,8 @@ export default function MasterFeesPage() {
   const { resolvedTheme } = useTheme();
   const dark = resolvedTheme === "dark";
   const t = themeClasses(dark);
+
+  const [agingFilter, setAgingFilter] = useState<AgingFilter>("all");
 
   if (error) {
     return (
@@ -47,13 +58,53 @@ export default function MasterFeesPage() {
 
   const nonPetitionCases = cases.filter((c) => c.level !== "FEE_PETITION");
 
+  const displayCases =
+    agingFilter === "all"
+      ? nonPetitionCases
+      : nonPetitionCases.filter(
+          (c) =>
+            c.paid === 0 &&
+            c.daysAfterApproval != null &&
+            c.daysAfterApproval > (agingFilter === "unpaid_60" ? 60 : 90),
+        );
+
+  const presetBase = `px-3 py-1 rounded-full text-[11px] font-medium border transition-colors`;
+  const presetActive = dark
+    ? "bg-amber-700 border-amber-600 text-white"
+    : "bg-amber-100 border-amber-400 text-amber-800";
+  const presetInactive = dark
+    ? "border-neutral-700 text-neutral-400 hover:border-neutral-500"
+    : "border-neutral-200 text-neutral-500 hover:border-neutral-400";
+
   return (
-    <FeeRecordsTable
-      cases={nonPetitionCases}
-      dateRange={dateRange}
-      onImported={refresh}
-      approvedByOptions={approvedByOptions}
-      dropdownOptions={dropdownOptions}
-    />
+    <div className="space-y-3">
+      <div className={`rounded-xl border ${t.card} px-4 py-2.5 flex items-center gap-2 flex-wrap`}>
+        <span className={`text-[10px] font-semibold uppercase tracking-wider ${t.textMuted} shrink-0`}>
+          Aging:
+        </span>
+        {AGING_OPTIONS.map(({ value, label }) => (
+          <button
+            key={value}
+            onClick={() => setAgingFilter(value)}
+            aria-pressed={agingFilter === value}
+            className={`${presetBase} ${agingFilter === value ? presetActive : presetInactive}`}
+          >
+            {label}
+          </button>
+        ))}
+        {agingFilter !== "all" && (
+          <span className={`ml-auto text-[11px] ${t.textMuted}`}>
+            {displayCases.length} case{displayCases.length !== 1 ? "s" : ""}
+          </span>
+        )}
+      </div>
+      <FeeRecordsTable
+        cases={displayCases}
+        dateRange={dateRange}
+        onImported={refresh}
+        approvedByOptions={approvedByOptions}
+        dropdownOptions={dropdownOptions}
+      />
+    </div>
   );
 }

--- a/src/app/api/fee-petitions/route.ts
+++ b/src/app/api/fee-petitions/route.ts
@@ -19,7 +19,7 @@ const getMissingClause = (key: string | null) => {
   }
 };
 
-// GET /api/fee-petitions?page=&limit=&search=&sort=&dir=&status=&touched=&missing=
+// GET /api/fee-petitions?page=&limit=&search=&sort=&dir=&status=&touched=&missing=&aging=
 // Lists cases at FEE_PETITION level with checklist state and aggregate stats
 export const GET = async (req: NextRequest) => {
   try {
@@ -28,6 +28,7 @@ export const GET = async (req: NextRequest) => {
     const status = searchParams.get("status"); // "complete" | "incomplete"
     const touched = searchParams.get("touched"); // "none" = no fee_petitions row yet
     const missing = searchParams.get("missing"); // checkbox key to filter by
+    const aging = searchParams.get("aging"); // "unpaid_60" | "unpaid_90"
     const sortParam = searchParams.get("sort");
     const sort: SortKey = SORT_KEYS.includes(sortParam as SortKey)
       ? (sortParam as SortKey)
@@ -74,6 +75,12 @@ export const GET = async (req: NextRequest) => {
 
     const touchedClause = touched === "none" ? sql`AND ${feePetitions.updatedAt} IS NULL` : sql``;
     const missingClause = getMissingClause(missing);
+    const agingClause =
+      aging === "unpaid_60"
+        ? sql`AND COALESCE(${feeRecords.totalFeesPaid}, 0) = 0 AND ${cases.approvalDate} IS NOT NULL AND (CURRENT_DATE - ${cases.approvalDate}::date) > 60`
+        : aging === "unpaid_90"
+          ? sql`AND COALESCE(${feeRecords.totalFeesPaid}, 0) = 0 AND ${cases.approvalDate} IS NOT NULL AND (CURRENT_DATE - ${cases.approvalDate}::date) > 90`
+          : sql``;
 
     // Accept both the legacy enum value and the worksheet-direct label
     // saved via the dashboard dropdown (column C in the master sheet uses
@@ -84,6 +91,7 @@ export const GET = async (req: NextRequest) => {
       ${statusClause}
       ${touchedClause}
       ${missingClause}
+      ${agingClause}
     `;
 
     // Single aggregate for stats + count

--- a/src/components/fee-petitions/FeePetitions.tsx
+++ b/src/components/fee-petitions/FeePetitions.tsx
@@ -55,6 +55,7 @@ type SortDir = "asc" | "desc";
 type StatusFilter = "all" | "complete" | "incomplete";
 type TouchedFilter = "" | "none";
 type MissingFilter = "" | CheckboxKey;
+type AgingFilter = "" | "unpaid_60" | "unpaid_90";
 
 // ---------- helpers ----------
 const PAGE_SIZE_OPTIONS = [25, 50, 100, 200];
@@ -80,6 +81,7 @@ const DEFAULTS = {
   status: "all" as StatusFilter,
   touched: "" as TouchedFilter,
   missing: "" as MissingFilter,
+  aging: "" as AgingFilter,
   sort: "approvalDate" as SortKey,
   dir: "desc" as SortDir,
   page: 1,
@@ -122,6 +124,7 @@ export const FeePetitions = () => {
       : DEFAULTS.status) as StatusFilter,
     touched: (urlParams.get("touched") === "none" ? "none" : "") as TouchedFilter,
     missing: (CHECKBOX_KEYS.includes(urlParams.get("missing") as CheckboxKey) ? urlParams.get("missing") : "") as MissingFilter,
+    aging: (["unpaid_60", "unpaid_90"].includes(urlParams.get("aging") ?? "") ? urlParams.get("aging") : "") as AgingFilter,
     sort: (SORT_KEYS.includes(urlParams.get("sort") as SortKey)
       ? (urlParams.get("sort") as SortKey)
       : DEFAULTS.sort) as SortKey,
@@ -148,6 +151,7 @@ export const FeePetitions = () => {
   const [statusFilter, setStatusFilter] = useState<StatusFilter>(initialState.status);
   const [touchedFilter, setTouchedFilter] = useState<TouchedFilter>(initialState.touched);
   const [missingFilter, setMissingFilter] = useState<MissingFilter>(initialState.missing);
+  const [agingFilter, setAgingFilter] = useState<AgingFilter>(initialState.aging);
   const [sortKey, setSortKey] = useState<SortKey>(initialState.sort);
   const [sortDir, setSortDir] = useState<SortDir>(initialState.dir);
 
@@ -176,6 +180,7 @@ export const FeePetitions = () => {
     if (statusFilter !== DEFAULTS.status) params.set("status", statusFilter);
     if (touchedFilter) params.set("touched", touchedFilter);
     if (missingFilter) params.set("missing", missingFilter);
+    if (agingFilter) params.set("aging", agingFilter);
     if (sortKey !== DEFAULTS.sort) params.set("sort", sortKey);
     if (sortDir !== DEFAULTS.dir) params.set("dir", sortDir);
     if (page !== DEFAULTS.page) params.set("page", String(page));
@@ -190,7 +195,7 @@ export const FeePetitions = () => {
       { scroll: false },
     );
     urlMethodRef.current = "replace";
-  }, [appliedSearch, statusFilter, touchedFilter, missingFilter, sortKey, sortDir, page, pageSize, pathname, router, urlParams]);
+  }, [appliedSearch, statusFilter, touchedFilter, missingFilter, agingFilter, sortKey, sortDir, page, pageSize, pathname, router, urlParams]);
 
   // Sync URL → state (back/forward)
   useEffect(() => {
@@ -202,6 +207,8 @@ export const FeePetitions = () => {
     const urlTouched = (urlParams.get("touched") === "none" ? "none" : "") as TouchedFilter;
     const urlMissingRaw = urlParams.get("missing");
     const urlMissing = (CHECKBOX_KEYS.includes(urlMissingRaw as CheckboxKey) ? urlMissingRaw : "") as MissingFilter;
+    const urlAgingRaw = urlParams.get("aging") ?? "";
+    const urlAging = (["unpaid_60", "unpaid_90"].includes(urlAgingRaw) ? urlAgingRaw : "") as AgingFilter;
     const urlSortRaw = urlParams.get("sort") as SortKey | null;
     const urlSort = SORT_KEYS.includes(urlSortRaw as SortKey)
       ? (urlSortRaw as SortKey)
@@ -215,6 +222,7 @@ export const FeePetitions = () => {
     if (urlStatus !== statusFilter) setStatusFilter(urlStatus);
     if (urlTouched !== touchedFilter) setTouchedFilter(urlTouched);
     if (urlMissing !== missingFilter) setMissingFilter(urlMissing);
+    if (urlAging !== agingFilter) setAgingFilter(urlAging);
     if (urlSort !== sortKey) setSortKey(urlSort);
     if (urlDir !== sortDir) setSortDir(urlDir);
     if (urlPage !== page) setPage(urlPage);
@@ -271,6 +279,7 @@ export const FeePetitions = () => {
       if (statusFilter !== "all") params.set("status", statusFilter);
       if (touchedFilter) params.set("touched", touchedFilter);
       if (missingFilter) params.set("missing", missingFilter);
+      if (agingFilter) params.set("aging", agingFilter);
       params.set("sort", sortKey);
       params.set("dir", sortDir);
       const res = await fetch(`/api/fee-petitions?${params.toString()}`, {
@@ -296,7 +305,7 @@ export const FeePetitions = () => {
     } finally {
       if (fetchAbortRef.current === controller) setLoading(false);
     }
-  }, [page, pageSize, appliedSearch, statusFilter, touchedFilter, missingFilter, sortKey, sortDir]);
+  }, [page, pageSize, appliedSearch, statusFilter, touchedFilter, missingFilter, agingFilter, sortKey, sortDir]);
 
   useEffect(() => {
     fetchPetitions();
@@ -316,7 +325,8 @@ export const FeePetitions = () => {
     appliedSearch !== DEFAULTS.search ||
     statusFilter !== DEFAULTS.status ||
     touchedFilter !== DEFAULTS.touched ||
-    missingFilter !== DEFAULTS.missing;
+    missingFilter !== DEFAULTS.missing ||
+    agingFilter !== DEFAULTS.aging;
 
   const clearAllFilters = () => {
     urlMethodRef.current = "push";
@@ -325,6 +335,7 @@ export const FeePetitions = () => {
     setStatusFilter(DEFAULTS.status);
     setTouchedFilter(DEFAULTS.touched);
     setMissingFilter(DEFAULTS.missing);
+    setAgingFilter(DEFAULTS.aging);
     setPage(1);
   };
 
@@ -623,6 +634,7 @@ export const FeePetitions = () => {
         if (statusFilter !== "all") params.set("status", statusFilter);
         if (touchedFilter) params.set("touched", touchedFilter);
         if (missingFilter) params.set("missing", missingFilter);
+        if (agingFilter) params.set("aging", agingFilter);
         params.set("sort", sortKey);
         params.set("dir", sortDir);
         const res = await fetch(`/api/fee-petitions?${params.toString()}`);
@@ -967,6 +979,20 @@ export const FeePetitions = () => {
           >
             Never Touched
           </button>
+          <button
+            onClick={() => { urlMethodRef.current = "push"; setAgingFilter((v) => (v === "unpaid_60" ? "" : "unpaid_60")); setPage(1); }}
+            aria-pressed={agingFilter === "unpaid_60"}
+            className={`${presetBase} ${agingFilter === "unpaid_60" ? presetActive : t.outlineBtn}`}
+          >
+            Unpaid &gt;60d
+          </button>
+          <button
+            onClick={() => { urlMethodRef.current = "push"; setAgingFilter((v) => (v === "unpaid_90" ? "" : "unpaid_90")); setPage(1); }}
+            aria-pressed={agingFilter === "unpaid_90"}
+            className={`${presetBase} ${agingFilter === "unpaid_90" ? presetActive : t.outlineBtn}`}
+          >
+            Unpaid &gt;90d
+          </button>
         </div>
 
         {/* Active filter chips */}
@@ -1000,6 +1026,14 @@ export const FeePetitions = () => {
               <span className={chipBase}>
                 Missing: {CHECKBOX_COLUMNS.find((c) => c.key === missingFilter)?.label}
                 <button aria-label="Clear missing filter" onClick={() => { urlMethodRef.current = "push"; setMissingFilter(""); setPage(1); }} className="ml-0.5 hover:opacity-70">
+                  <X aria-hidden="true" className="h-3 w-3" />
+                </button>
+              </span>
+            )}
+            {agingFilter && (
+              <span className={chipBase}>
+                {agingFilter === "unpaid_60" ? "Unpaid >60d" : "Unpaid >90d"}
+                <button aria-label="Clear aging filter" onClick={() => { urlMethodRef.current = "push"; setAgingFilter(""); setPage(1); }} className="ml-0.5 hover:opacity-70">
                   <X aria-hidden="true" className="h-3 w-3" />
                 </button>
               </span>


### PR DESCRIPTION
## Summary

- **Master Fees**: client-side aging filter above the table — All / Unpaid >60d / Unpaid >90d pills; filters `daysAfterApproval` from the already-loaded `useDashboard` cases; shows result count when active
- **Fee Petitions**: server-side aging filter — `aging` query param added to `GET /api/fee-petitions`; SQL clause filters `totalFeesPaid = 0 AND days_since_approval > 60/90`; quick-filter pills in the header; URL-synced with back/forward support; included in CSV export
- **Fees Closed**: "All / Fee Petitions" level filter pill in the header card; client-side, no additional fetch
- **Fee Petitions table**: sticky "Fee Amount" column (`totalFeesExpected`) pinned next to Claimant at `left-[200px]`; column widths (`w-10`, `w-40`, `w-24`) pinned to keep sticky offsets predictable
- **Fees Closed Trigger** (`fees_closed_trigger`): new `varchar(50)` on `fee_records` (migration 0024); fires `AcknowledgeAndCloseDialog` when set to "Closed"; wired in `FeeRecordsTable`, `CaseDetailData`, and both case API routes