### PR TITLE
feat: inbound calls page, sidebar reorganization, nav overhaul

### DIFF
--- a/drizzle/0025_add_inbound_call_tables.sql
+++ b/drizzle/0025_add_inbound_call_tables.sql
@@ -1,0 +1,25 @@
+CREATE TABLE "inbound_call_poc" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"week_start" date NOT NULL,
+	"day_of_week" integer NOT NULL,
+	"poc_name" varchar(200) NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "uq_inbound_call_poc_week_day_name" UNIQUE("week_start","day_of_week","poc_name")
+);
+--> statement-breakpoint
+CREATE TABLE "inbound_call_records" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"week_start" date NOT NULL,
+	"call_date" date NOT NULL,
+	"number" varchar(50),
+	"transcript" text,
+	"case_link" varchar(500),
+	"specialist_assigned" varchar(200),
+	"called_back_resolved" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "idx_inbound_call_poc_week" ON "inbound_call_poc" USING btree ("week_start");--> statement-breakpoint
+CREATE INDEX "idx_inbound_call_records_week" ON "inbound_call_records" USING btree ("week_start");--> statement-breakpoint
+CREATE INDEX "idx_inbound_call_records_date" ON "inbound_call_records" USING btree ("call_date");

--- a/drizzle/meta/0025_snapshot.json
+++ b/drizzle/meta/0025_snapshot.json
@@ -1,0 +1,3252 @@
+{
+  "id": "ace6120b-b320-44ea-a1c6-ff3a01060665",
+  "prevId": "a1983399-302f-429f-819d-d9ef20a6cffa",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_log": {
+      "name": "activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_record_id": {
+          "name": "fee_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_activity_log_case_id": {
+          "name": "idx_activity_log_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_log_created_at": {
+          "name": "idx_activity_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_log_case_id_cases_client_id_fk": {
+          "name": "activity_log_case_id_cases_client_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_log_fee_record_id_fee_records_id_fk": {
+          "name": "activity_log_fee_record_id_fee_records_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "fee_records",
+          "columnsFrom": [
+            "fee_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_activity_log": {
+      "name": "admin_activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_email": {
+          "name": "target_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_admin_activity_created_at": {
+          "name": "idx_admin_activity_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_activity_log_actor_id_users_id_fk": {
+          "name": "admin_activity_log_actor_id_users_id_fk",
+          "tableFrom": "admin_activity_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "admin_activity_log_target_user_id_users_id_fk": {
+          "name": "admin_activity_log_target_user_id_users_id_fk",
+          "tableFrom": "admin_activity_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_settings": {
+      "name": "app_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approved_by_options": {
+      "name": "approved_by_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "approved_by_options_name_unique": {
+          "name": "approved_by_options_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.case_archive": {
+      "name": "case_archive",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "original_client_id": {
+          "name": "original_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "case_name": {
+          "name": "case_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_link": {
+          "name": "case_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_date": {
+          "name": "approval_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_source": {
+          "name": "archived_source",
+          "type": "archived_source_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_by": {
+          "name": "archived_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_snapshot": {
+          "name": "case_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_record_snapshot": {
+          "name": "fee_record_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_snapshots": {
+          "name": "related_snapshots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_case_archive_client_id": {
+          "name": "idx_case_archive_client_id",
+          "columns": [
+            {
+              "expression": "original_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_case_archive_source": {
+          "name": "idx_case_archive_source",
+          "columns": [
+            {
+              "expression": "archived_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_case_archive_archived_at": {
+          "name": "idx_case_archive_archived_at",
+          "columns": [
+            {
+              "expression": "archived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cases": {
+      "name": "cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dob": {
+          "name": "dob",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last4_ssn": {
+          "name": "last4_ssn",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_type": {
+          "name": "claim_type",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "claim_type_label": {
+          "name": "claim_type_label",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level_won": {
+          "name": "level_won",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "t2_decision": {
+          "name": "t2_decision",
+          "type": "decision_outcome_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'unknown'"
+        },
+        "t16_decision": {
+          "name": "t16_decision",
+          "type": "decision_outcome_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'unknown'"
+        },
+        "application_date": {
+          "name": "application_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alleged_onset_date": {
+          "name": "alleged_onset_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_date": {
+          "name": "approval_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_date": {
+          "name": "closure_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_held_date": {
+          "name": "hearing_held_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_scheduled_date": {
+          "name": "hearing_scheduled_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_scheduled_datetime": {
+          "name": "hearing_scheduled_datetime",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_timezone": {
+          "name": "hearing_timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "office_with_jurisdiction": {
+          "name": "office_with_jurisdiction",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alj_first_name": {
+          "name": "alj_first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alj_last_name": {
+          "name": "alj_last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimant_location": {
+          "name": "claimant_location",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representative_location": {
+          "name": "representative_location",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_expert": {
+          "name": "medical_expert",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vocational_expert": {
+          "name": "vocational_expert",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_file_link": {
+          "name": "all_file_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exhibits_file_link": {
+          "name": "exhibits_file_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_file_updated_at": {
+          "name": "all_file_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exhibits_file_updated_at": {
+          "name": "exhibits_file_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_ssn": {
+          "name": "full_ssn",
+          "type": "varchar(11)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_diagnosis": {
+          "name": "primary_diagnosis",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_diagnosis_code": {
+          "name": "primary_diagnosis_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secondary_diagnosis": {
+          "name": "secondary_diagnosis",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secondary_diagnosis_code": {
+          "name": "secondary_diagnosis_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allegations": {
+          "name": "allegations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blind_dli": {
+          "name": "blind_dli",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firm_name": {
+          "name": "firm_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firm_ein": {
+          "name": "firm_ein",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hearing_office": {
+          "name": "hearing_office",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representatives": {
+          "name": "representatives",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_history": {
+          "name": "decision_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_type": {
+          "name": "report_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expedited_case": {
+          "name": "expedited_case",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_of_case": {
+          "name": "status_of_case",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_date": {
+          "name": "status_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_date": {
+          "name": "request_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_date": {
+          "name": "receipt_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_date_assigned": {
+          "name": "first_date_assigned",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_fqr_starts": {
+          "name": "date_fqr_starts",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_insured": {
+          "name": "last_insured",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_created_at": {
+          "name": "source_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_updated_at": {
+          "name": "source_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ere_session_date": {
+          "name": "last_ere_session_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status_report_date": {
+          "name": "last_status_report_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documents_last_added_at": {
+          "name": "documents_last_added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invalid_ssn": {
+          "name": "invalid_ssn",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ssn_encrypted": {
+          "name": "ssn_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_link": {
+          "name": "case_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_pulled_at": {
+          "name": "last_pulled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_cases_client_id": {
+          "name": "idx_cases_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_external_id": {
+          "name": "idx_cases_external_id",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_claim_type_label": {
+          "name": "idx_cases_claim_type_label",
+          "columns": [
+            {
+              "expression": "claim_type_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_approval_date": {
+          "name": "idx_cases_approval_date",
+          "columns": [
+            {
+              "expression": "approval_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cases_last_name": {
+          "name": "idx_cases_last_name",
+          "columns": [
+            {
+              "expression": "last_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cases_client_id_unique": {
+          "name": "cases_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chronicle_documents": {
+      "name": "chronicle_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mycase_client_id": {
+          "name": "mycase_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chronicle_client_id": {
+          "name": "chronicle_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chronicle_document_id": {
+          "name": "chronicle_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_name": {
+          "name": "document_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_category": {
+          "name": "document_category",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_document": {
+          "name": "raw_document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chronicle_documents_case_id": {
+          "name": "idx_chronicle_documents_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chronicle_documents_case_id_cases_client_id_fk": {
+          "name": "chronicle_documents_case_id_cases_client_id_fk",
+          "tableFrom": "chronicle_documents",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chronicle_documents_case_id_chronicle_document_id_unique": {
+          "name": "chronicle_documents_case_id_chronicle_document_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id",
+            "chronicle_document_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_metrics": {
+      "name": "daily_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_date": {
+          "name": "metric_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ssa_calls": {
+          "name": "ssa_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "client_calls_ib": {
+          "name": "client_calls_ib",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "client_calls_ob": {
+          "name": "client_calls_ob",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "win_sheets_created": {
+          "name": "win_sheets_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_metrics_agent": {
+          "name": "idx_daily_metrics_agent",
+          "columns": [
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_metrics_date": {
+          "name": "idx_daily_metrics_date",
+          "columns": [
+            {
+              "expression": "metric_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_metrics_agent_name_team_members_name_fk": {
+          "name": "daily_metrics_agent_name_team_members_name_fk",
+          "tableFrom": "daily_metrics",
+          "tableTo": "team_members",
+          "columnsFrom": [
+            "agent_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dropdown_options": {
+      "name": "dropdown_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(150)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_dropdown_options_category_name": {
+          "name": "uq_dropdown_options_category_name",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dropdown_options_category": {
+          "name": "idx_dropdown_options_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_cap_history": {
+      "name": "fee_cap_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cap_amount": {
+          "name": "cap_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fee_cap_history_effective_date_unique": {
+          "name": "fee_cap_history_effective_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "effective_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_petitions": {
+      "name": "fee_petitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "noa": {
+          "name": "noa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "time_delineation": {
+          "name": "time_delineation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "fee_petition_doc": {
+          "name": "fee_petition_doc",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ltr_to_clmt": {
+          "name": "ltr_to_clmt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ltr_to_clmt_with_signature": {
+          "name": "ltr_to_clmt_with_signature",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ltr_to_alj": {
+          "name": "ltr_to_alj",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "fax_conf_fee_pet": {
+          "name": "fax_conf_fee_pet",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "update_note": {
+          "name": "update_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fee_petitions_case_id": {
+          "name": "idx_fee_petitions_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fee_petitions_case_id_cases_client_id_fk": {
+          "name": "fee_petitions_case_id_cases_client_id_fk",
+          "tableFrom": "fee_petitions",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fee_petitions_case_id_unique": {
+          "name": "fee_petitions_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fee_records": {
+      "name": "fee_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "win_sheet_status": {
+          "name": "win_sheet_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'not_started'"
+        },
+        "win_sheet_link": {
+          "name": "win_sheet_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "win_sheet_link_text": {
+          "name": "win_sheet_link_text",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_status": {
+          "name": "case_status",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fees_confirmation": {
+          "name": "fees_confirmation",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fees_closed_trigger": {
+          "name": "fees_closed_trigger",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_assigned_to_agent": {
+          "name": "date_assigned_to_agent",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "t16_retro": {
+          "name": "t16_retro",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_fee_due": {
+          "name": "t16_fee_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_fee_received": {
+          "name": "t16_fee_received",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_pending": {
+          "name": "t16_pending",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t16_fee_received_date": {
+          "name": "t16_fee_received_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "t2_retro": {
+          "name": "t2_retro",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_fee_due": {
+          "name": "t2_fee_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_fee_received": {
+          "name": "t2_fee_received",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_pending": {
+          "name": "t2_pending",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "t2_fee_received_date": {
+          "name": "t2_fee_received_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aux_retro": {
+          "name": "aux_retro",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_fee_due": {
+          "name": "aux_fee_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_fee_received": {
+          "name": "aux_fee_received",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_pending": {
+          "name": "aux_pending",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "aux_fee_received_date": {
+          "name": "aux_fee_received_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_retro_due": {
+          "name": "total_retro_due",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "total_fees_expected": {
+          "name": "total_fees_expected",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "total_fees_paid": {
+          "name": "total_fees_paid",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "pif_ready_to_close": {
+          "name": "pif_ready_to_close",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_closed": {
+          "name": "is_closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "marked_overpaid": {
+          "name": "marked_overpaid",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_method": {
+          "name": "fee_method",
+          "type": "fee_method_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'fee_agreement'"
+        },
+        "applicable_fee_cap": {
+          "name": "applicable_fee_cap",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'9200'"
+        },
+        "fee_cap_applied": {
+          "name": "fee_cap_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "fee_computed": {
+          "name": "fee_computed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "fee_computed_at": {
+          "name": "fee_computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "days_after_approval": {
+          "name": "days_after_approval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_category": {
+          "name": "approval_category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fees_status": {
+          "name": "fees_status",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "week_assigned_to_agent": {
+          "name": "week_assigned_to_agent",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "month_assigned_to_agent": {
+          "name": "month_assigned_to_agent",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "sync_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'not_synced'"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mycase_record_id": {
+          "name": "mycase_record_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fee_records_case_id": {
+          "name": "idx_fee_records_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_assigned_to": {
+          "name": "idx_fee_records_assigned_to",
+          "columns": [
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_win_sheet_status": {
+          "name": "idx_fee_records_win_sheet_status",
+          "columns": [
+            {
+              "expression": "win_sheet_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_sync_status": {
+          "name": "idx_fee_records_sync_status",
+          "columns": [
+            {
+              "expression": "sync_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_pif": {
+          "name": "idx_fee_records_pif",
+          "columns": [
+            {
+              "expression": "pif_ready_to_close",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fee_records_is_closed": {
+          "name": "idx_fee_records_is_closed",
+          "columns": [
+            {
+              "expression": "is_closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fee_records_case_id_cases_client_id_fk": {
+          "name": "fee_records_case_id_cases_client_id_fk",
+          "tableFrom": "fee_records",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fee_records_case_id_unique": {
+          "name": "fee_records_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbound_call_poc": {
+      "name": "inbound_call_poc",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "week_start": {
+          "name": "week_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poc_name": {
+          "name": "poc_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_inbound_call_poc_week": {
+          "name": "idx_inbound_call_poc_week",
+          "columns": [
+            {
+              "expression": "week_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_inbound_call_poc_week_day_name": {
+          "name": "uq_inbound_call_poc_week_day_name",
+          "nullsNotDistinct": false,
+          "columns": [
+            "week_start",
+            "day_of_week",
+            "poc_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbound_call_records": {
+      "name": "inbound_call_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "week_start": {
+          "name": "week_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "call_date": {
+          "name": "call_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript": {
+          "name": "transcript",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_link": {
+          "name": "case_link",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specialist_assigned": {
+          "name": "specialist_assigned",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "called_back_resolved": {
+          "name": "called_back_resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_inbound_call_records_week": {
+          "name": "idx_inbound_call_records_week",
+          "columns": [
+            {
+              "expression": "week_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbound_call_records_date": {
+          "name": "idx_inbound_call_records_date",
+          "columns": [
+            {
+              "expression": "call_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mycase_sync_tags": {
+      "name": "mycase_sync_tags",
+      "schema": "",
+      "columns": {
+        "mycase_case_id": {
+          "name": "mycase_case_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewed'"
+        },
+        "tagged_at": {
+          "name": "tagged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "tagged_by": {
+          "name": "tagged_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mycase_notice_documents": {
+      "name": "mycase_notice_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mycase_client_id": {
+          "name": "mycase_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mycase_document_id": {
+          "name": "mycase_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_name": {
+          "name": "document_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_pattern": {
+          "name": "matched_pattern",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_document": {
+          "name": "raw_document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mycase_notice_documents_case_id": {
+          "name": "idx_mycase_notice_documents_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mycase_notice_documents_case_id_cases_client_id_fk": {
+          "name": "mycase_notice_documents_case_id_cases_client_id_fk",
+          "tableFrom": "mycase_notice_documents",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mycase_notice_documents_case_id_mycase_document_id_unique": {
+          "name": "mycase_notice_documents_case_id_mycase_document_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id",
+            "mycase_document_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "notification_severity_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notifications_type": {
+          "name": "idx_notifications_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_is_read": {
+          "name": "idx_notifications_is_read",
+          "columns": [
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_created_at": {
+          "name": "idx_notifications_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_agent": {
+          "name": "idx_notifications_agent",
+          "columns": [
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_case_id_cases_client_id_fk": {
+          "name": "notifications_case_id_cases_client_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.overpaid_cases": {
+      "name": "overpaid_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "op_ltr_date": {
+          "name": "op_ltr_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "op_ltr_received": {
+          "name": "op_ltr_received",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overpaid_amount": {
+          "name": "overpaid_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checks_cleared": {
+          "name": "checks_cleared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "checks_cleared_at": {
+          "name": "checks_cleared_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "update_note": {
+          "name": "update_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_overpaid_cases_case_id": {
+          "name": "idx_overpaid_cases_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "overpaid_cases_case_id_cases_client_id_fk": {
+          "name": "overpaid_cases_case_id_cases_client_id_fk",
+          "tableFrom": "overpaid_cases",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "overpaid_cases_case_id_unique": {
+          "name": "overpaid_cases_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pull_logs": {
+      "name": "pull_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_records_pulled": {
+          "name": "total_records_pulled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "new_cases": {
+          "name": "new_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_cases": {
+          "name": "updated_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "errors": {
+          "name": "errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_at": {
+          "name": "triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_logs": {
+      "name": "sync_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cases": {
+          "name": "total_cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "case_ids": {
+          "name": "case_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_at": {
+          "name": "triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_sync_logs_triggered_at": {
+          "name": "idx_sync_logs_triggered_at",
+          "columns": [
+            {
+              "expression": "triggered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'collections_specialist'"
+        },
+        "team": {
+          "name": "team",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_members_name_unique": {
+          "name": "team_members_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_access_overrides": {
+      "name": "user_access_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overrides": {
+          "name": "overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_access_overrides_user_id_users_id_fk": {
+          "name": "user_access_overrides_user_id_users_id_fk",
+          "tableFrom": "user_access_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_access_overrides_user_id_unique": {
+          "name": "user_access_overrides_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_details": {
+      "name": "user_details",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chronicle_id": {
+          "name": "chronicle_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line_1": {
+          "name": "address_line_1",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line_2": {
+          "name": "address_line_2",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip_code": {
+          "name": "zip_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cell_phone": {
+          "name": "cell_phone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssn": {
+          "name": "ssn",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssn_last4": {
+          "name": "ssn_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age_at_approval": {
+          "name": "age_at_approval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "place_of_birth": {
+          "name": "place_of_birth",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mothers_first_name_and_maiden_name": {
+          "name": "mothers_first_name_and_maiden_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fathers_first_and_last_name": {
+          "name": "fathers_first_and_last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_details_case_id": {
+          "name": "idx_user_details_case_id",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_details_case_id_cases_client_id_fk": {
+          "name": "user_details_case_id_cases_client_id_fk",
+          "tableFrom": "user_details",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_details_case_id_unique": {
+          "name": "user_details_case_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_id"
+          ]
+        },
+        "user_details_chronicle_id_unique": {
+          "name": "user_details_chronicle_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chronicle_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.archived_source_enum": {
+      "name": "archived_source_enum",
+      "schema": "public",
+      "values": [
+        "active_sheet",
+        "fees_closed_sheet"
+      ]
+    },
+    "public.claim_type_enum": {
+      "name": "claim_type_enum",
+      "schema": "public",
+      "values": [
+        "T2",
+        "T16",
+        "T2_T16"
+      ]
+    },
+    "public.decision_outcome_enum": {
+      "name": "decision_outcome_enum",
+      "schema": "public",
+      "values": [
+        "fully_favorable",
+        "partially_favorable",
+        "unfavorable",
+        "dismissed",
+        "remand",
+        "unknown"
+      ]
+    },
+    "public.fee_method_enum": {
+      "name": "fee_method_enum",
+      "schema": "public",
+      "values": [
+        "fee_agreement",
+        "fee_petition"
+      ]
+    },
+    "public.level_won_enum": {
+      "name": "level_won_enum",
+      "schema": "public",
+      "values": [
+        "INITIAL",
+        "RECON",
+        "HEARING",
+        "AC",
+        "FEDERAL_COURT",
+        "FEE_PETITION"
+      ]
+    },
+    "public.notification_severity_enum": {
+      "name": "notification_severity_enum",
+      "schema": "public",
+      "values": [
+        "info",
+        "warning",
+        "critical"
+      ]
+    },
+    "public.notification_type_enum": {
+      "name": "notification_type_enum",
+      "schema": "public",
+      "values": [
+        "case_aging",
+        "fee_payment",
+        "call_target_missed",
+        "case_assigned"
+      ]
+    },
+    "public.sync_status_enum": {
+      "name": "sync_status_enum",
+      "schema": "public",
+      "values": [
+        "not_synced",
+        "syncing",
+        "synced",
+        "error"
+      ]
+    },
+    "public.user_role_enum": {
+      "name": "user_role_enum",
+      "schema": "public",
+      "values": [
+        "admin",
+        "lead",
+        "member",
+        "system_admin"
+      ]
+    },
+    "public.win_sheet_status_enum": {
+      "name": "win_sheet_status_enum",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "started",
+        "in_progress",
+        "pending_payment",
+        "partially_paid",
+        "paid_in_full",
+        "closed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1782494416088,
       "tag": "0024_add_fees_closed_trigger_to_fee_records",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1782501445109,
+      "tag": "0025_add_inbound_call_tables",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(dashboard)/inbound-calls/page.tsx
+++ b/src/app/(dashboard)/inbound-calls/page.tsx
@@ -1,0 +1,16 @@
+import { db } from "@/lib/db";
+import { dropdownOptions } from "@/lib/db/schema";
+import { eq, asc } from "drizzle-orm";
+import { InboundCallsClient } from "@/components/inbound-calls/InboundCallsClient";
+
+export default async function InboundCallsPage() {
+  const members = await db
+    .select({ name: dropdownOptions.name })
+    .from(dropdownOptions)
+    .where(eq(dropdownOptions.category, "assigned_to"))
+    .orderBy(asc(dropdownOptions.sortOrder), asc(dropdownOptions.name));
+
+  const teamMembers = members.map((m) => m.name);
+
+  return <InboundCallsClient teamMembers={teamMembers} />;
+}

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -32,7 +32,6 @@ function DashboardShell({ children }: { children: ReactNode }) {
 
   const dark = resolvedTheme === "dark";
   const t = themeClasses(dark);
-  console.log("resolvedTheme:", resolvedTheme);
 
   return (
     <div

--- a/src/app/api/inbound-calls/[id]/route.ts
+++ b/src/app/api/inbound-calls/[id]/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { inboundCallRecords } from "@/lib/db/schema";
+import { eq, sql } from "drizzle-orm";
+import { auth } from "@/auth";
+import { z } from "zod";
+
+const resolveId = async (context: {
+  params: { id: string } | Promise<{ id: string }>;
+}) => {
+  const p = context.params instanceof Promise ? await context.params : context.params;
+  return parseInt(p.id);
+};
+
+const patchSchema = z.object({
+  callDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  number: z.string().max(50).nullable().optional(),
+  transcript: z.string().nullable().optional(),
+  caseLink: z.string().max(500).nullable().optional(),
+  specialistAssigned: z.string().max(200).nullable().optional(),
+  calledBackResolved: z.boolean().optional(),
+});
+
+// PATCH /api/inbound-calls/[id] — anyone authenticated
+export const PATCH = async (
+  req: NextRequest,
+  context: { params: { id: string } | Promise<{ id: string }> },
+) => {
+  try {
+    const session = await auth();
+    if (!session?.user) return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+
+    const id = await resolveId(context);
+    if (isNaN(id)) return NextResponse.json({ error: "Invalid ID" }, { status: 400 });
+
+    const body = await req.json();
+    const parsed = patchSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid input", issues: parsed.error.issues }, { status: 400 });
+    }
+
+    const updates: Record<string, unknown> = { ...parsed.data };
+    updates.updatedAt = sql`now()`;
+
+    const [row] = await db
+      .update(inboundCallRecords)
+      .set(updates)
+      .where(eq(inboundCallRecords.id, id))
+      .returning();
+
+    if (!row) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+    return NextResponse.json({
+      id: row.id,
+      callDate: row.callDate,
+      number: row.number ?? "",
+      transcript: row.transcript ?? "",
+      caseLink: row.caseLink ?? "",
+      specialistAssigned: row.specialistAssigned ?? "",
+      calledBackResolved: row.calledBackResolved,
+    });
+  } catch (err) {
+    console.error("PATCH /api/inbound-calls/[id] error:", err);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+};
+
+// DELETE /api/inbound-calls/[id] — anyone authenticated
+export const DELETE = async (
+  req: NextRequest,
+  context: { params: { id: string } | Promise<{ id: string }> },
+) => {
+  try {
+    const session = await auth();
+    if (!session?.user) return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+
+    const id = await resolveId(context);
+    if (isNaN(id)) return NextResponse.json({ error: "Invalid ID" }, { status: 400 });
+
+    await db.delete(inboundCallRecords).where(eq(inboundCallRecords.id, id));
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("DELETE /api/inbound-calls/[id] error:", err);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+};

--- a/src/app/api/inbound-calls/poc/route.ts
+++ b/src/app/api/inbound-calls/poc/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { inboundCallPoc } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+import { requireAdmin, guardStatus } from "@/lib/auth-helpers";
+import { auth } from "@/auth";
+import { z } from "zod";
+
+// GET /api/inbound-calls/poc?week=YYYY-MM-DD
+// Returns { assignments: Record<1|2|3|4|5, string[]> }
+export const GET = async (req: NextRequest) => {
+  try {
+    const session = await auth();
+    if (!session?.user) return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+
+    const week = new URL(req.url).searchParams.get("week");
+    if (!week || !/^\d{4}-\d{2}-\d{2}$/.test(week)) {
+      return NextResponse.json({ error: "week param required (YYYY-MM-DD)" }, { status: 400 });
+    }
+
+    const rows = await db
+      .select()
+      .from(inboundCallPoc)
+      .where(eq(inboundCallPoc.weekStart, week));
+
+    const assignments: Record<number, string[]> = { 1: [], 2: [], 3: [], 4: [], 5: [] };
+    for (const r of rows) {
+      if (r.dayOfWeek >= 1 && r.dayOfWeek <= 5) {
+        assignments[r.dayOfWeek].push(r.pocName);
+      }
+    }
+
+    return NextResponse.json({ assignments });
+  } catch (err) {
+    console.error("GET /api/inbound-calls/poc error:", err);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+};
+
+const putSchema = z.object({
+  weekStart: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  // dayOfWeek (1-5) -> array of poc names
+  assignments: z.record(z.string(), z.array(z.string().max(200))),
+});
+
+// PUT /api/inbound-calls/poc — admin only; replaces all assignments for the week
+export const PUT = async (req: NextRequest) => {
+  try {
+    const guard = await requireAdmin();
+    if (!guard.ok) return NextResponse.json({ error: guard.error }, { status: guardStatus(guard.error) });
+
+    const body = await req.json();
+    const parsed = putSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid input", issues: parsed.error.issues }, { status: 400 });
+    }
+
+    const { weekStart, assignments } = parsed.data;
+
+    await db.delete(inboundCallPoc).where(eq(inboundCallPoc.weekStart, weekStart));
+
+    const rows = Object.entries(assignments).flatMap(([dayStr, names]) => {
+      const day = parseInt(dayStr);
+      if (isNaN(day) || day < 1 || day > 5) return [];
+      return names.map((name) => ({
+        weekStart,
+        dayOfWeek: day,
+        pocName: name,
+      }));
+    });
+
+    if (rows.length > 0) {
+      await db.insert(inboundCallPoc).values(rows);
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("PUT /api/inbound-calls/poc error:", err);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+};

--- a/src/app/api/inbound-calls/route.ts
+++ b/src/app/api/inbound-calls/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { inboundCallRecords } from "@/lib/db/schema";
+import { eq, asc } from "drizzle-orm";
+import { auth } from "@/auth";
+import { z } from "zod";
+
+// GET /api/inbound-calls?week=YYYY-MM-DD
+export const GET = async (req: NextRequest) => {
+  try {
+    const session = await auth();
+    if (!session?.user) return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+
+    const week = new URL(req.url).searchParams.get("week");
+    if (!week || !/^\d{4}-\d{2}-\d{2}$/.test(week)) {
+      return NextResponse.json({ error: "week param required (YYYY-MM-DD)" }, { status: 400 });
+    }
+
+    const rows = await db
+      .select()
+      .from(inboundCallRecords)
+      .where(eq(inboundCallRecords.weekStart, week))
+      .orderBy(asc(inboundCallRecords.callDate), asc(inboundCallRecords.id));
+
+    const data = rows.map((r) => ({
+      id: r.id,
+      callDate: r.callDate,
+      number: r.number ?? "",
+      transcript: r.transcript ?? "",
+      caseLink: r.caseLink ?? "",
+      specialistAssigned: r.specialistAssigned ?? "",
+      calledBackResolved: r.calledBackResolved,
+    }));
+
+    return NextResponse.json({ data });
+  } catch (err) {
+    console.error("GET /api/inbound-calls error:", err);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+};
+
+const createSchema = z.object({
+  weekStart: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  callDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  number: z.string().max(50).optional(),
+  transcript: z.string().optional(),
+  caseLink: z.string().max(500).optional(),
+  specialistAssigned: z.string().max(200).optional(),
+  calledBackResolved: z.boolean().optional(),
+});
+
+// POST /api/inbound-calls — anyone authenticated
+export const POST = async (req: NextRequest) => {
+  try {
+    const session = await auth();
+    if (!session?.user) return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+
+    const body = await req.json();
+    const parsed = createSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid input", issues: parsed.error.issues }, { status: 400 });
+    }
+
+    const { weekStart, callDate, number, transcript, caseLink, specialistAssigned, calledBackResolved } = parsed.data;
+
+    const [row] = await db
+      .insert(inboundCallRecords)
+      .values({
+        weekStart,
+        callDate,
+        number: number ?? null,
+        transcript: transcript ?? null,
+        caseLink: caseLink ?? null,
+        specialistAssigned: specialistAssigned ?? null,
+        calledBackResolved: calledBackResolved ?? false,
+      })
+      .returning();
+
+    return NextResponse.json({
+      id: row.id,
+      callDate: row.callDate,
+      number: row.number ?? "",
+      transcript: row.transcript ?? "",
+      caseLink: row.caseLink ?? "",
+      specialistAssigned: row.specialistAssigned ?? "",
+      calledBackResolved: row.calledBackResolved,
+    }, { status: 201 });
+  } catch (err) {
+    console.error("POST /api/inbound-calls error:", err);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+};

--- a/src/components/inbound-calls/InboundCallsClient.tsx
+++ b/src/components/inbound-calls/InboundCallsClient.tsx
@@ -1,0 +1,581 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTheme } from "next-themes";
+import { useSession } from "next-auth/react";
+import {
+  PhoneIncoming,
+  Plus,
+  Save,
+  RefreshCw,
+  AlertCircle,
+  Trash2,
+  ChevronDown,
+  Check,
+} from "lucide-react";
+import { themeClasses } from "@/lib/theme-classes";
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function getMondayOf(dateStr: string): string {
+  const d = new Date(dateStr + "T00:00:00");
+  const day = d.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  d.setDate(d.getDate() + diff);
+  return d.toISOString().slice(0, 10);
+}
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function currentWeekStart(): string {
+  return getMondayOf(todayIso());
+}
+
+function weekLabel(weekStart: string): string {
+  const d = new Date(weekStart + "T00:00:00");
+  const month = d.toLocaleString("en-US", { month: "long" });
+  const weekNum = Math.ceil(d.getDate() / 7);
+  return `${month} Week ${weekNum}`;
+}
+
+function isCurrentWeek(weekStart: string): boolean {
+  return weekStart === currentWeekStart();
+}
+
+const DAYS = [
+  { num: 1, label: "Monday" },
+  { num: 2, label: "Tuesday" },
+  { num: 3, label: "Wednesday" },
+  { num: 4, label: "Thursday" },
+  { num: 5, label: "Friday" },
+];
+
+// ── types ─────────────────────────────────────────────────────────────────────
+
+interface CallRecord {
+  id: number;
+  callDate: string;
+  number: string;
+  transcript: string;
+  caseLink: string;
+  specialistAssigned: string;
+  calledBackResolved: boolean;
+}
+
+interface PocAssignments {
+  1: string[];
+  2: string[];
+  3: string[];
+  4: string[];
+  5: string[];
+}
+
+// ── component ─────────────────────────────────────────────────────────────────
+
+export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
+  const { resolvedTheme } = useTheme();
+  const dark = resolvedTheme === "dark";
+  const t = themeClasses(dark);
+  const { data: session } = useSession();
+  const role = session?.user?.role;
+  const isAdmin = role === "admin" || role === "system_admin";
+
+  // Week selection
+  const [selectedWeek, setSelectedWeek] = useState<string>(currentWeekStart());
+  const [availableWeeks, setAvailableWeeks] = useState<string[]>([]);
+  const [weekMenuOpen, setWeekMenuOpen] = useState(false);
+  const weekMenuRef = useRef<HTMLDivElement>(null);
+
+  // POC
+  const [pocAssignments, setPocAssignments] = useState<PocAssignments>({ 1: [], 2: [], 3: [], 4: [], 5: [] });
+  const [pocDraft, setPocDraft] = useState<PocAssignments>({ 1: [], 2: [], 3: [], 4: [], 5: [] });
+  const [pocEditMode, setPocEditMode] = useState(false);
+  const [pocSaving, setPocSaving] = useState(false);
+  const [pocError, setPocError] = useState<string | null>(null);
+
+  // Records
+  const [records, setRecords] = useState<CallRecord[]>([]);
+  const [recordsLoading, setRecordsLoading] = useState(false);
+  const [recordsError, setRecordsError] = useState<string | null>(null);
+  const [saving, setSaving] = useState<Record<number, boolean>>({});
+  const [addingRow, setAddingRow] = useState(false);
+
+  const recordsControllerRef = useRef<AbortController | null>(null);
+  const pocControllerRef = useRef<AbortController | null>(null);
+  const pocSaveControllerRef = useRef<AbortController | null>(null);
+  const fetchCancelledRef = useRef(false);
+
+  // ── fetch available weeks ───────────────────────────────────────────────────
+
+  useEffect(() => {
+    const cur = currentWeekStart();
+    // Generate last 8 weeks including current
+    const weeks: string[] = [];
+    for (let i = 0; i < 8; i++) {
+      const d = new Date(cur + "T00:00:00");
+      d.setDate(d.getDate() - i * 7);
+      weeks.push(d.toISOString().slice(0, 10));
+    }
+    setAvailableWeeks(weeks);
+  }, []);
+
+  // ── fetch POC ──────────────────────────────────────────────────────────────
+
+  const fetchPoc = useCallback(async (week: string) => {
+    pocControllerRef.current?.abort();
+    const controller = new AbortController();
+    pocControllerRef.current = controller;
+    setPocError(null);
+    try {
+      const res = await fetch(`/api/inbound-calls/poc?week=${week}`, { signal: controller.signal });
+      if (!res.ok) throw new Error(`Failed to load POC (${res.status})`);
+      const json = await res.json();
+      if (fetchCancelledRef.current) return;
+      setPocAssignments(json.assignments ?? { 1: [], 2: [], 3: [], 4: [], 5: [] });
+    } catch (e) {
+      if (fetchCancelledRef.current) return;
+      if ((e as Error).name !== "AbortError") setPocError((e as Error).message);
+    }
+  }, []);
+
+  // ── fetch records ──────────────────────────────────────────────────────────
+
+  const fetchRecords = useCallback(async (week: string) => {
+    recordsControllerRef.current?.abort();
+    const controller = new AbortController();
+    recordsControllerRef.current = controller;
+    setRecordsLoading(true);
+    setRecordsError(null);
+    try {
+      const res = await fetch(`/api/inbound-calls?week=${week}`, { signal: controller.signal });
+      if (!res.ok) throw new Error(`Failed to load call records (${res.status})`);
+      const json = await res.json();
+      if (fetchCancelledRef.current) return;
+      setRecords(json.data ?? []);
+    } catch (e) {
+      if (fetchCancelledRef.current) return;
+      if ((e as Error).name !== "AbortError") setRecordsError((e as Error).message);
+    } finally {
+      if (!fetchCancelledRef.current) setRecordsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchCancelledRef.current = false;
+    fetchPoc(selectedWeek);
+    fetchRecords(selectedWeek);
+    return () => {
+      fetchCancelledRef.current = true;
+      pocControllerRef.current?.abort();
+      recordsControllerRef.current?.abort();
+    };
+  }, [selectedWeek, fetchPoc, fetchRecords]);
+
+  // ── week menu close on outside click ───────────────────────────────────────
+
+  useEffect(() => {
+    if (!weekMenuOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (weekMenuRef.current && !weekMenuRef.current.contains(e.target as Node)) {
+        setWeekMenuOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [weekMenuOpen]);
+
+  // ── POC save ───────────────────────────────────────────────────────────────
+
+  const savePoc = async () => {
+    pocSaveControllerRef.current?.abort();
+    const controller = new AbortController();
+    pocSaveControllerRef.current = controller;
+    setPocSaving(true);
+    setPocError(null);
+    try {
+      const res = await fetch("/api/inbound-calls/poc", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ weekStart: selectedWeek, assignments: pocDraft }),
+        signal: controller.signal,
+      });
+      if (!res.ok) throw new Error(`Failed to save POC assignments (${res.status})`);
+      if (controller.signal.aborted) return;
+      setPocAssignments({ ...pocDraft });
+      setPocEditMode(false);
+    } catch (e) {
+      if ((e as Error).name === "AbortError") return;
+      setPocError((e as Error).message);
+    } finally {
+      if (!controller.signal.aborted) setPocSaving(false);
+    }
+  };
+
+  // ── record field update ────────────────────────────────────────────────────
+
+  const updateRecord = async (id: number, field: string, value: string | boolean | null) => {
+    setSaving((prev) => ({ ...prev, [id]: true }));
+    try {
+      const res = await fetch(`/api/inbound-calls/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ [field]: value }),
+      });
+      if (!res.ok) throw new Error(`Save failed (${res.status})`);
+    } catch {
+      // silently fail — row stays with local edit
+    } finally {
+      setSaving((prev) => ({ ...prev, [id]: false }));
+    }
+  };
+
+  const handleFieldChange = (id: number, field: keyof CallRecord, value: string | boolean) => {
+    setRecords((prev) =>
+      prev.map((r) => (r.id === id ? { ...r, [field]: value } : r)),
+    );
+  };
+
+  // ── add row ────────────────────────────────────────────────────────────────
+
+  const addRow = async () => {
+    setAddingRow(true);
+    try {
+      const res = await fetch("/api/inbound-calls", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          weekStart: selectedWeek,
+          callDate: todayIso(),
+        }),
+      });
+      if (!res.ok) throw new Error(`Failed to add row (${res.status})`);
+      const row = await res.json();
+      setRecords((prev) => [...prev, row]);
+    } catch {
+      // silently fail
+    } finally {
+      setAddingRow(false);
+    }
+  };
+
+  // ── delete row ─────────────────────────────────────────────────────────────
+
+  const deleteRow = async (id: number) => {
+    setRecords((prev) => prev.filter((r) => r.id !== id));
+    try {
+      await fetch(`/api/inbound-calls/${id}`, { method: "DELETE" });
+    } catch {
+      if (!fetchCancelledRef.current) fetchRecords(selectedWeek);
+    }
+  };
+
+  // ── styles ─────────────────────────────────────────────────────────────────
+
+  const card = `rounded-xl border ${t.card}`;
+  const inputCls = `w-full text-xs bg-transparent border-0 outline-none focus:ring-1 focus:ring-blue-500 rounded px-1.5 py-1 ${t.text} placeholder:${t.textMuted}`;
+  const thCls = `px-3 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider ${t.textMuted} whitespace-nowrap`;
+  const tdCls = `px-2 py-1.5 align-top`;
+
+  // ── render ─────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="space-y-4">
+      {/* ── header bar ── */}
+      <div className={`${card} px-4 py-3 flex items-center justify-between gap-3 flex-wrap`}>
+        <div className="flex items-center gap-3">
+          <div className={`w-9 h-9 rounded-lg flex items-center justify-center ${dark ? "bg-blue-900/40" : "bg-blue-50"}`}>
+            <PhoneIncoming aria-hidden="true" className={`h-4 w-4 ${dark ? "text-blue-400" : "text-blue-600"}`} />
+          </div>
+          <div>
+            <h2 className={`text-sm font-bold ${t.text}`}>Inbound Call History</h2>
+            <p className={`text-[11px] ${t.textMuted}`}>POC schedule and call log by week</p>
+          </div>
+        </div>
+
+        {/* week picker */}
+        <div className="relative" ref={weekMenuRef}>
+          <button
+            onClick={() => setWeekMenuOpen((v) => !v)}
+            className={`flex items-center gap-2 px-3 py-1.5 rounded-lg border text-xs font-medium transition-colors ${dark ? "border-neutral-700 text-neutral-200 hover:border-neutral-500" : "border-neutral-200 text-neutral-700 hover:border-neutral-400"}`}
+          >
+            {weekLabel(selectedWeek)}
+            {isCurrentWeek(selectedWeek) && (
+              <span className={`text-[10px] px-1.5 py-0.5 rounded-full ${dark ? "bg-blue-900/50 text-blue-300" : "bg-blue-100 text-blue-600"}`}>
+                This week
+              </span>
+            )}
+            <ChevronDown aria-hidden="true" className="h-3.5 w-3.5 opacity-60" />
+          </button>
+          {weekMenuOpen && (
+            <div className={`absolute right-0 mt-1 z-20 w-52 rounded-xl border shadow-lg overflow-hidden ${dark ? "bg-neutral-800 border-neutral-700" : "bg-white border-neutral-200"}`}>
+              {availableWeeks.map((w) => (
+                <button
+                  key={w}
+                  onClick={() => { setSelectedWeek(w); setWeekMenuOpen(false); }}
+                  className={`w-full text-left px-3 py-2 text-xs flex items-center justify-between transition-colors ${
+                    w === selectedWeek
+                      ? dark ? "bg-blue-900/40 text-blue-300" : "bg-blue-50 text-blue-700"
+                      : dark ? "hover:bg-neutral-700 text-neutral-200" : "hover:bg-neutral-50 text-neutral-700"
+                  }`}
+                >
+                  <span>{weekLabel(w)}</span>
+                  {isCurrentWeek(w) && <span className={`text-[10px] ${dark ? "text-blue-400" : "text-blue-500"}`}>Now</span>}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* ── POC grid ── */}
+      <div className={card}>
+        <div className={`px-4 py-3 border-b ${dark ? "border-neutral-700/60" : "border-neutral-100"} flex items-center justify-between gap-3`}>
+          <span className={`text-xs font-semibold ${t.text}`}>Point of Contact — {weekLabel(selectedWeek)}</span>
+          {isAdmin && !pocEditMode && (
+            <button
+              onClick={() => { setPocDraft({ ...pocAssignments }); setPocEditMode(true); }}
+              className={`text-[11px] px-2.5 py-1 rounded-lg border transition-colors ${dark ? "border-neutral-600 text-neutral-300 hover:border-neutral-400" : "border-neutral-200 text-neutral-600 hover:border-neutral-400"}`}
+            >
+              Edit schedule
+            </button>
+          )}
+          {isAdmin && pocEditMode && (
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => setPocEditMode(false)}
+                className={`text-[11px] px-2.5 py-1 rounded-lg border transition-colors ${dark ? "border-neutral-600 text-neutral-400 hover:border-neutral-400" : "border-neutral-200 text-neutral-500 hover:border-neutral-400"}`}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={savePoc}
+                disabled={pocSaving}
+                className="text-[11px] px-2.5 py-1 rounded-lg bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 transition-colors flex items-center gap-1.5"
+              >
+                {pocSaving && <RefreshCw aria-hidden="true" className="h-3 w-3 animate-spin" />}
+                <Save aria-hidden="true" className="h-3 w-3" />
+                Save
+              </button>
+            </div>
+          )}
+        </div>
+
+        {pocError && (
+          <div className={`mx-4 mt-3 rounded-lg px-3 py-2 flex items-center gap-2 text-xs ${dark ? "bg-red-900/20 border border-red-800 text-red-400" : "bg-red-50 border border-red-200 text-red-600"}`} role="alert">
+            <AlertCircle aria-hidden="true" className="h-3.5 w-3.5 shrink-0" />
+            {pocError}
+          </div>
+        )}
+
+        <div className="px-4 py-4 grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+          {DAYS.map(({ num, label }) => {
+            const assigned = pocAssignments[num as keyof PocAssignments] ?? [];
+            const draft = pocDraft[num as keyof PocAssignments] ?? [];
+
+            return (
+              <div
+                key={num}
+                className={`rounded-lg border p-3 min-h-[90px] ${dark ? "border-neutral-700 bg-neutral-800/40" : "border-neutral-200 bg-neutral-50/60"}`}
+              >
+                <p className={`text-[11px] font-semibold mb-2 ${t.textMuted}`}>{label}</p>
+                {pocEditMode && isAdmin ? (
+                  <div className="space-y-1.5">
+                    {teamMembers.map((name) => {
+                      const checked = draft.includes(name);
+                      return (
+                        <label key={name} className="flex items-center gap-1.5 cursor-pointer">
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            onChange={() => {
+                              setPocDraft((prev) => ({
+                                ...prev,
+                                [num]: checked
+                                  ? prev[num as keyof PocAssignments].filter((n) => n !== name)
+                                  : [...prev[num as keyof PocAssignments], name],
+                              }));
+                            }}
+                            className="h-3 w-3 rounded accent-blue-500"
+                          />
+                          <span className={`text-[11px] ${t.text} truncate`}>{name}</span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                ) : assigned.length > 0 ? (
+                  <div className="flex flex-wrap gap-1">
+                    {assigned.map((name) => (
+                      <span
+                        key={name}
+                        className={`text-[10px] px-2 py-0.5 rounded-full font-medium ${dark ? "bg-blue-900/40 text-blue-300" : "bg-blue-100 text-blue-700"}`}
+                      >
+                        {name}
+                      </span>
+                    ))}
+                  </div>
+                ) : (
+                  <span className={`text-[11px] italic ${t.textMuted}`}>No POC assigned</span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* ── call records table ── */}
+      <div className={card}>
+        <div className={`px-4 py-3 border-b ${dark ? "border-neutral-700/60" : "border-neutral-100"} flex items-center justify-between gap-3`}>
+          <span className={`text-xs font-semibold ${t.text}`}>
+            Call Log
+            {records.length > 0 && (
+              <span className={`ml-2 text-[11px] font-normal ${t.textMuted}`}>{records.length} record{records.length !== 1 ? "s" : ""}</span>
+            )}
+          </span>
+          <button
+            onClick={addRow}
+            disabled={addingRow}
+            className="flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
+          >
+            {addingRow
+              ? <RefreshCw aria-hidden="true" className="h-3 w-3 animate-spin" />
+              : <Plus aria-hidden="true" className="h-3 w-3" />
+            }
+            Add row
+          </button>
+        </div>
+
+        {recordsError && (
+          <div className={`mx-4 mt-3 rounded-lg px-3 py-2 flex items-center gap-2 text-xs ${dark ? "bg-red-900/20 border border-red-800 text-red-400" : "bg-red-50 border border-red-200 text-red-600"}`} role="alert">
+            <AlertCircle aria-hidden="true" className="h-3.5 w-3.5 shrink-0" />
+            {recordsError}
+          </div>
+        )}
+
+        <div className="overflow-x-auto">
+          {recordsLoading ? (
+            <div className="flex items-center justify-center py-14">
+              <RefreshCw aria-hidden="true" className={`h-5 w-5 animate-spin ${t.textMuted}`} />
+              <span className={`ml-3 text-sm ${t.textSub}`}>Loading...</span>
+            </div>
+          ) : records.length === 0 ? (
+            <div className={`text-center py-14 text-sm ${t.textMuted}`}>
+              No call records for {weekLabel(selectedWeek)}. Add one above.
+            </div>
+          ) : (
+            <table className="w-full min-w-[800px]">
+              <thead>
+                <tr className={`border-b ${dark ? "border-neutral-700/60" : "border-neutral-100"}`}>
+                  <th className={thCls} style={{ width: 110 }}>Date</th>
+                  <th className={thCls} style={{ width: 130 }}>Number</th>
+                  <th className={thCls}>Transcript</th>
+                  <th className={thCls} style={{ width: 160 }}>Case Link</th>
+                  <th className={thCls} style={{ width: 180 }}>Collection Specialist</th>
+                  <th className={`${thCls} text-center`} style={{ width: 80 }}>Resolved</th>
+                  <th className={thCls} style={{ width: 40 }}></th>
+                </tr>
+              </thead>
+              <tbody>
+                {records.map((row) => (
+                  <tr
+                    key={row.id}
+                    className={`border-b last:border-0 transition-colors ${dark ? "border-neutral-700/40 hover:bg-neutral-800/40" : "border-neutral-100 hover:bg-neutral-50/60"} ${saving[row.id] ? "opacity-70" : ""}`}
+                  >
+                    {/* Date */}
+                    <td className={tdCls}>
+                      <input
+                        type="date"
+                        value={row.callDate}
+                        onChange={(e) => handleFieldChange(row.id, "callDate", e.target.value)}
+                        onBlur={(e) => updateRecord(row.id, "callDate", e.target.value)}
+                        className={inputCls}
+                      />
+                    </td>
+                    {/* Number */}
+                    <td className={tdCls}>
+                      <input
+                        type="text"
+                        value={row.number}
+                        placeholder="Phone number"
+                        onChange={(e) => handleFieldChange(row.id, "number", e.target.value)}
+                        onBlur={(e) => updateRecord(row.id, "number", e.target.value || null)}
+                        className={inputCls}
+                      />
+                    </td>
+                    {/* Transcript */}
+                    <td className={tdCls}>
+                      <textarea
+                        value={row.transcript}
+                        placeholder="Call notes"
+                        rows={2}
+                        onChange={(e) => handleFieldChange(row.id, "transcript", e.target.value)}
+                        onBlur={(e) => updateRecord(row.id, "transcript", e.target.value || null)}
+                        className={`${inputCls} resize-none`}
+                      />
+                    </td>
+                    {/* Case Link */}
+                    <td className={tdCls}>
+                      <input
+                        type="text"
+                        value={row.caseLink}
+                        placeholder="URL or case ID"
+                        onChange={(e) => handleFieldChange(row.id, "caseLink", e.target.value)}
+                        onBlur={(e) => updateRecord(row.id, "caseLink", e.target.value || null)}
+                        className={inputCls}
+                      />
+                    </td>
+                    {/* Specialist */}
+                    <td className={tdCls}>
+                      <select
+                        value={row.specialistAssigned}
+                        onChange={(e) => {
+                          handleFieldChange(row.id, "specialistAssigned", e.target.value);
+                          updateRecord(row.id, "specialistAssigned", e.target.value || null);
+                        }}
+                        className={`${inputCls} cursor-pointer`}
+                      >
+                        <option value="">— Assign —</option>
+                        {teamMembers.map((name) => (
+                          <option key={name} value={name}>{name}</option>
+                        ))}
+                      </select>
+                    </td>
+                    {/* Called back / Resolved */}
+                    <td className={`${tdCls} text-center`}>
+                      <button
+                        onClick={() => {
+                          const next = !row.calledBackResolved;
+                          handleFieldChange(row.id, "calledBackResolved", next);
+                          updateRecord(row.id, "calledBackResolved", next);
+                        }}
+                        aria-label={row.calledBackResolved ? "Mark unresolved" : "Mark resolved"}
+                        className={`w-5 h-5 rounded border-2 flex items-center justify-center mx-auto transition-colors ${
+                          row.calledBackResolved
+                            ? "bg-emerald-500 border-emerald-500"
+                            : dark ? "border-neutral-500 hover:border-neutral-400" : "border-neutral-300 hover:border-neutral-400"
+                        }`}
+                      >
+                        {row.calledBackResolved && <Check aria-hidden="true" className="h-3 w-3 text-white" />}
+                      </button>
+                    </td>
+                    {/* Delete */}
+                    <td className={tdCls}>
+                      <button
+                        onClick={() => deleteRow(row.id)}
+                        aria-label="Delete row"
+                        className={`p-1 rounded transition-colors ${dark ? "text-neutral-500 hover:text-red-400" : "text-neutral-400 hover:text-red-500"}`}
+                      >
+                        <Trash2 aria-hidden="true" className="h-3.5 w-3.5" />
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/inbound-calls/InboundCallsClient.tsx
+++ b/src/components/inbound-calls/InboundCallsClient.tsx
@@ -17,20 +17,44 @@ import { themeClasses } from "@/lib/theme-classes";
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
-function getMondayOf(dateStr: string): string {
-  const d = new Date(dateStr + "T00:00:00");
-  const day = d.getDay();
-  const diff = day === 0 ? -6 : 1 - day;
-  d.setDate(d.getDate() + diff);
-  return d.toISOString().slice(0, 10);
+// All "today" and week-start logic is anchored to Eastern Time so the week
+// boundaries are consistent regardless of where the browser is running.
+const ET = "America/New_York";
+
+function todayEasternIso(): string {
+  return new Intl.DateTimeFormat("en-CA", { timeZone: ET }).format(new Date());
 }
 
-function todayIso(): string {
-  return new Date().toISOString().slice(0, 10);
+function isoToParts(dateStr: string): [number, number, number] {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  return [y, m, d];
+}
+
+function partsToIso(y: number, m: number, d: number): string {
+  return `${y}-${String(m).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
+}
+
+function getMondayOf(dateStr: string): string {
+  // Construct via numeric parts so the Date is always local midnight —
+  // new Date("YYYY-MM-DDT00:00:00") does the same, but toISOString() then
+  // converts back to UTC and shifts the date for timezones ahead of UTC.
+  const [y, m, d] = isoToParts(dateStr);
+  const date = new Date(y, m - 1, d);
+  const dow = date.getDay();
+  const diff = dow === 0 ? -6 : 1 - dow;
+  date.setDate(date.getDate() + diff);
+  return partsToIso(date.getFullYear(), date.getMonth() + 1, date.getDate());
 }
 
 function currentWeekStart(): string {
-  return getMondayOf(todayIso());
+  return getMondayOf(todayEasternIso());
+}
+
+function addWeeks(weekStart: string, delta: number): string {
+  const [y, m, d] = isoToParts(weekStart);
+  const date = new Date(y, m - 1, d);
+  date.setDate(date.getDate() + delta * 7);
+  return partsToIso(date.getFullYear(), date.getMonth() + 1, date.getDate());
 }
 
 function weekLabel(weekStart: string): string {
@@ -101,6 +125,7 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
   const [recordsError, setRecordsError] = useState<string | null>(null);
   const [saving, setSaving] = useState<Record<number, boolean>>({});
   const [addingRow, setAddingRow] = useState(false);
+  const [pendingDelete, setPendingDelete] = useState<number | null>(null);
 
   const recordsControllerRef = useRef<AbortController | null>(null);
   const pocControllerRef = useRef<AbortController | null>(null);
@@ -111,12 +136,9 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
 
   useEffect(() => {
     const cur = currentWeekStart();
-    // Generate last 8 weeks including current
     const weeks: string[] = [];
     for (let i = 0; i < 8; i++) {
-      const d = new Date(cur + "T00:00:00");
-      d.setDate(d.getDate() - i * 7);
-      weeks.push(d.toISOString().slice(0, 10));
+      weeks.push(addWeeks(cur, -i));
     }
     setAvailableWeeks(weeks);
   }, []);
@@ -164,6 +186,7 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
 
   useEffect(() => {
     fetchCancelledRef.current = false;
+    setPendingDelete(null);
     fetchPoc(selectedWeek);
     fetchRecords(selectedWeek);
     return () => {
@@ -247,7 +270,7 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           weekStart: selectedWeek,
-          callDate: todayIso(),
+          callDate: todayEasternIso(),
         }),
       });
       if (!res.ok) throw new Error(`Failed to add row (${res.status})`);
@@ -262,7 +285,8 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
 
   // ── delete row ─────────────────────────────────────────────────────────────
 
-  const deleteRow = async (id: number) => {
+  const confirmDelete = async (id: number) => {
+    setPendingDelete(null);
     setRecords((prev) => prev.filter((r) => r.id !== id));
     try {
       await fetch(`/api/inbound-calls/${id}`, { method: "DELETE" });
@@ -561,13 +585,30 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
                     </td>
                     {/* Delete */}
                     <td className={tdCls}>
-                      <button
-                        onClick={() => deleteRow(row.id)}
-                        aria-label="Delete row"
-                        className={`p-1 rounded transition-colors ${dark ? "text-neutral-500 hover:text-red-400" : "text-neutral-400 hover:text-red-500"}`}
-                      >
-                        <Trash2 aria-hidden="true" className="h-3.5 w-3.5" />
-                      </button>
+                      {pendingDelete === row.id ? (
+                        <div className="flex items-center gap-1">
+                          <button
+                            onClick={() => confirmDelete(row.id)}
+                            className="text-[10px] px-1.5 py-0.5 rounded bg-red-500 text-white hover:bg-red-600 transition-colors"
+                          >
+                            Delete
+                          </button>
+                          <button
+                            onClick={() => setPendingDelete(null)}
+                            className={`text-[10px] px-1.5 py-0.5 rounded border transition-colors ${dark ? "border-neutral-600 text-neutral-400 hover:border-neutral-400" : "border-neutral-200 text-neutral-500 hover:border-neutral-400"}`}
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      ) : (
+                        <button
+                          onClick={() => setPendingDelete(row.id)}
+                          aria-label="Delete row"
+                          className={`p-1 rounded transition-colors ${dark ? "text-neutral-500 hover:text-red-400" : "text-neutral-400 hover:text-red-500"}`}
+                        >
+                          <Trash2 aria-hidden="true" className="h-3.5 w-3.5" />
+                        </button>
+                      )}
                     </td>
                   </tr>
                 ))}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -2,8 +2,6 @@
 
 import { useState, useRef, useEffect, useSyncExternalStore } from "react";
 import { useTheme } from "next-themes";
-import { usePathname } from "next/navigation";
-import Link from "next/link";
 import { CalendarDays } from "lucide-react";
 import { ThemeToggle } from "@/components/layout/ThemeToggle";
 import { themeClasses } from "@/lib/theme-classes";
@@ -13,16 +11,6 @@ interface HeaderProps {
   dateRange: DateRange | null;
   onDateRangeChange: (range: DateRange | null) => void;
 }
-
-const TABS = [
-  { path: "/", label: "Overview" },
-  { path: "/scoreboard", label: "Scoreboard" },
-  { path: "/chronicle", label: "Chronicle Sync" },
-  { path: "/fee-petitions", label: "Fee Petitions" },
-  { path: "/overpaid-cases", label: "Overpaid Cases" },
-  { path: "/reports", label: "Reports" },
-  { path: "/notifications", label: "Notifications" },
-];
 
 const PRESETS = [
   { label: "Today", days: 0 },
@@ -44,33 +32,10 @@ export const Header = ({ dateRange, onDateRangeChange }: HeaderProps) => {
   );
   const dark = mounted ? resolvedTheme === "dark" : false;
   const t = themeClasses(dark);
-  const pathname = usePathname();
-
   const [open, setOpen] = useState(false);
   const [fromDate, setFromDate] = useState("");
   const [toDate, setToDate] = useState("");
   const dropRef = useRef<HTMLDivElement>(null);
-  const [unreadCount, setUnreadCount] = useState(0);
-
-  // Fetch unread notification count
-  useEffect(() => {
-    const controller = new AbortController();
-    const { signal } = controller;
-    const fetchCount = async () => {
-      try {
-        const res = await fetch("/api/notifications?unread=true&limit=1", { signal });
-        if (res.ok) {
-          const json = await res.json();
-          setUnreadCount(json.unreadCount || 0);
-        }
-      } catch (err) {
-        if ((err as Error).name === "AbortError") return;
-      }
-    };
-    fetchCount();
-    const interval = setInterval(fetchCount, 60000); // poll every 60s
-    return () => { clearInterval(interval); controller.abort(); };
-  }, []);
 
   useEffect(() => {
     const handler = (e: MouseEvent) => {
@@ -92,9 +57,6 @@ export const Header = ({ dateRange, onDateRangeChange }: HeaderProps) => {
       return () => clearTimeout(t);
     }
   }, [dateRange]);
-
-  const isActive = (path: string) =>
-    path === "/" ? pathname === "/" : pathname.startsWith(path);
 
   const applyPreset = (days: number) => {
     const now = new Date();
@@ -149,38 +111,8 @@ export const Header = ({ dateRange, onDateRangeChange }: HeaderProps) => {
 
   return (
     <header
-      className={`hidden md:flex h-14 ${t.bg} border-b ${t.border} items-center justify-between px-6 shrink-0`}
+      className={`hidden md:flex h-12 ${t.bg} border-b ${t.border} items-center justify-end px-6 shrink-0`}
     >
-      {/* Tab links */}
-      <div className="flex items-center gap-1">
-        {TABS.map((tab) => {
-          const active = isActive(tab.path);
-          return (
-            <Link
-              key={tab.path}
-              href={tab.path}
-              className={`h-8 px-3 rounded-md text-xs font-medium transition-colors ${
-                active
-                  ? dark
-                    ? "bg-neutral-800 text-neutral-100 font-semibold"
-                    : "bg-neutral-100 text-neutral-900 font-semibold"
-                  : dark
-                    ? "text-neutral-400 hover:text-neutral-200 hover:bg-neutral-800/50"
-                    : "text-neutral-500 hover:text-neutral-700 hover:bg-neutral-50"
-              } flex items-center gap-1.5`}
-            >
-              {tab.label}
-              {tab.path === "/notifications" && unreadCount > 0 && (
-                <span className="min-w-4 h-4 px-1 rounded-full bg-red-500 text-white text-[9px] font-bold flex items-center justify-center">
-                  {unreadCount > 99 ? "99+" : unreadCount}
-                </span>
-              )}
-            </Link>
-          );
-        })}
-      </div>
-
-      {/* Right actions */}
       <div className="flex items-center gap-2.5">
         <div className="relative" ref={dropRef}>
           <button

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -28,6 +28,7 @@ import {
   CheckCircle2,
   Archive,
   TableProperties,
+  PhoneIncoming,
 } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
 import { fmtClaim } from "@/lib/formatters";
@@ -61,12 +62,13 @@ const NAV_ITEMS: { section: string; items: NavItem[] }[] = [
     items: [
       { path: "/", icon: Home, label: "Overview" },
       { path: "/master-fees", icon: TableProperties, label: "Master Fees" },
+      { path: "/inbound-calls", icon: PhoneIncoming, label: "Inbound Calls" },
       { path: "/fees-closed", icon: CheckCircle2, label: "Fees Closed" },
-      { path: "/scoreboard", icon: Trophy, label: "Scoreboard" },
-      { path: "/chronicle", icon: Database, label: "Chronicle Sync" },
       { path: "/fee-petitions", icon: Gavel, label: "Fee Petitions" },
       { path: "/overpaid-cases", icon: TrendingDown, label: "Overpaid Cases" },
+      { path: "/scoreboard", icon: Trophy, label: "Scoreboard" },
       { path: "/reports", icon: FileText, label: "Reports" },
+      { path: "/chronicle", icon: Database, label: "Chronicle Sync" },
       { path: "/notifications", icon: Bell, label: "Notifications" },
     ],
   },

--- a/src/lib/access/pages.ts
+++ b/src/lib/access/pages.ts
@@ -20,6 +20,7 @@ export const PAGES = [
   { key: "admin", label: "Admin", path: "/admin" },
   { key: "settings", label: "Settings", path: "/settings" },
   { key: "archive", label: "Archive", path: "/archive" },
+  { key: "inbound_calls", label: "Inbound Calls", path: "/inbound-calls" },
 ] as const;
 
 export type PageKey = (typeof PAGES)[number]["key"];

--- a/src/lib/access/role-defaults.ts
+++ b/src/lib/access/role-defaults.ts
@@ -23,7 +23,7 @@ export const ROLE_PAGE_DEFAULTS: Record<AccessRole, PageKey[]> = {
   // Everything operational except user management + app settings.
   lead: PAGE_KEYS.filter((k) => k !== "admin" && k !== "settings" && k !== "archive"),
   // Front-line collections pages only.
-  member: ["overview", "master_fees", "fees_closed", "scoreboard", "reports", "notifications"],
+  member: ["overview", "master_fees", "fees_closed", "scoreboard", "reports", "notifications", "inbound_calls"],
 };
 
 export const rolePageDefaults = (role: string | null | undefined): PageKey[] =>

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -836,6 +836,53 @@ export const myCaseSyncTags = pgTable("mycase_sync_tags", {
 });
 
 // ============================================================================
+// INBOUND_CALL_POC — Weekly point-of-contact assignments per day (Mon–Fri)
+// ============================================================================
+
+export const inboundCallPoc = pgTable(
+  "inbound_call_poc",
+  {
+    id: serial("id").primaryKey(),
+    weekStart: date("week_start").notNull(), // Monday of the week (YYYY-MM-DD)
+    dayOfWeek: integer("day_of_week").notNull(), // 1=Mon 2=Tue 3=Wed 4=Thu 5=Fri
+    pocName: varchar("poc_name", { length: 200 }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    unique("uq_inbound_call_poc_week_day_name").on(
+      table.weekStart,
+      table.dayOfWeek,
+      table.pocName,
+    ),
+    index("idx_inbound_call_poc_week").on(table.weekStart),
+  ],
+);
+
+// ============================================================================
+// INBOUND_CALL_RECORDS — Call history log
+// ============================================================================
+
+export const inboundCallRecords = pgTable(
+  "inbound_call_records",
+  {
+    id: serial("id").primaryKey(),
+    weekStart: date("week_start").notNull(), // for week-based filtering
+    callDate: date("call_date").notNull(),
+    number: varchar("number", { length: 50 }),
+    transcript: text("transcript"),
+    caseLink: varchar("case_link", { length: 500 }),
+    specialistAssigned: varchar("specialist_assigned", { length: 200 }),
+    calledBackResolved: boolean("called_back_resolved").notNull().default(false),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("idx_inbound_call_records_week").on(table.weekStart),
+    index("idx_inbound_call_records_date").on(table.callDate),
+  ],
+);
+
+// ============================================================================
 // Case archive — records moved out of cases/fee_records when they are missing
 // from the sheet reconciliation (active or fees-closed).
 // No FK on originalClientId — the source row is deleted on archive.


### PR DESCRIPTION
## Summary

- **Inbound Calls page** (`/inbound-calls`): new page with weekly POC schedule and editable call log
  - POC grid (Mon–Fri): admin-only checkbox assignment per day; read-only badge display for all other roles
  - Call log table: editable inline (Date, Number, Transcript, Case Link, Collection Specialist, Resolved checkbox); auto-save on blur; anyone can add/delete rows
  - Week picker: last 8 weeks, defaults to current; "This week" badge on current week
  - Delete requires two-step inline confirmation to prevent accidental removal
  - All date logic anchored to `America/New_York` via `Intl.DateTimeFormat`
- **Sidebar reordered**: Overview → Master Fees → Inbound Calls → Fees Closed → Fee Petitions → Overpaid Cases → Scoreboard → Reports → Chronicle Sync → Notifications
- **Header tab nav removed**: tabs duplicated the sidebar; header now shows only the date range picker and theme toggle
- **Migration 0025**: adds `inbound_call_poc` and `inbound_call_records` tables
- **Page registry + role defaults**: `inbound_calls` page added; accessible to all roles (member, lead, admin, system_admin)