### PR TITLE
feat: reports overhaul, recent activity tab, inbound call counts

### DIFF
--- a/src/app/(dashboard)/notifications/page.tsx
+++ b/src/app/(dashboard)/notifications/page.tsx
@@ -16,9 +16,11 @@ import {
   ChevronRight,
   Eye,
   ClipboardList,
+  Activity,
 } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
 import { AuditLogTab } from "@/components/notifications/AuditLogTab";
+import { RecentActivityTab } from "@/components/notifications/RecentActivityTab";
 
 // ============================================================================
 // Types
@@ -38,7 +40,7 @@ interface Notification {
 }
 
 type FilterType = "all" | Notification["type"];
-type PageTab = "notifications" | "audit_logs";
+type PageTab = "notifications" | "audit_logs" | "recent_activity";
 
 const TYPE_META: Record<
   Notification["type"],
@@ -88,8 +90,9 @@ const FILTER_TABS: { key: FilterType; label: string }[] = [
 ];
 
 const PAGE_TABS: { key: PageTab; label: string; icon: React.ElementType }[] = [
-  { key: "notifications", label: "Notifications", icon: Bell },
-  { key: "audit_logs",    label: "Audit Logs",    icon: ClipboardList },
+  { key: "notifications",   label: "Notifications",   icon: Bell },
+  { key: "audit_logs",      label: "Audit Logs",      icon: ClipboardList },
+  { key: "recent_activity", label: "Recent Activity", icon: Activity },
 ];
 
 // ============================================================================
@@ -268,6 +271,9 @@ export default function NotificationsPage() {
 
       {/* Audit Logs tab */}
       {pageTab === "audit_logs" && <AuditLogTab dark={dark} t={t} />}
+
+      {/* Recent Activity tab */}
+      {pageTab === "recent_activity" && <RecentActivityTab dark={dark} t={t} />}
 
       {/* Notifications tab */}
       {pageTab === "notifications" && <>

--- a/src/app/api/activity-log/route.ts
+++ b/src/app/api/activity-log/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { db } from "@/lib/db";
+import { sql } from "drizzle-orm";
+
+export async function GET(req: NextRequest) {
+  try {
+    const session = await auth();
+    if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    const { searchParams } = req.nextUrl;
+    const week = searchParams.get("week") ?? new Date().toISOString().split("T")[0];
+
+    const monday = new Date(week + "T00:00:00");
+    const sunday = new Date(monday);
+    sunday.setDate(monday.getDate() + 6);
+    const to = sunday.toISOString().split("T")[0];
+
+    const rows = await db.execute(sql`
+      SELECT
+        al.id,
+        al.case_id            AS "caseId",
+        al.message,
+        al.created_by         AS "createdBy",
+        al.created_at         AS "createdAt",
+        c.last_name           AS "lastName",
+        c.first_name          AS "firstName"
+      FROM activity_log al
+      LEFT JOIN cases c ON c.client_id = al.case_id
+      WHERE al.created_at >= ${week}::date
+        AND al.created_at < (${to}::date + interval '1 day')
+      ORDER BY al.created_at DESC
+      LIMIT 300
+    `);
+
+    return NextResponse.json({
+      data: (
+        rows as unknown as {
+          id: string;
+          caseId: number;
+          message: string;
+          createdBy: string | null;
+          createdAt: string;
+          lastName: string | null;
+          firstName: string | null;
+        }[]
+      ).map((r) => ({
+        id: r.id,
+        caseId: r.caseId,
+        message: r.message,
+        createdBy: r.createdBy ?? "Unknown",
+        createdAt: r.createdAt,
+        caseName:
+          r.lastName && r.firstName ? `${r.lastName}, ${r.firstName}` : null,
+      })),
+    });
+  } catch (err) {
+    console.error("GET /api/activity-log error:", err);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -101,7 +101,19 @@ export const GET = async (req: NextRequest) => {
       ORDER BY d.dt::date
     `);
 
-    // 7. Recent activity entries (for the feed)
+    // 7. Inbound call records assigned to a specialist in date range
+    const inboundIbCounts = await db.execute(sql`
+      SELECT
+        specialist_assigned AS agent_name,
+        COUNT(*)::int AS ib_count
+      FROM inbound_call_records
+      WHERE specialist_assigned IS NOT NULL
+        AND specialist_assigned != ''
+        AND call_date >= ${from}::date AND call_date <= ${to}::date
+      GROUP BY specialist_assigned
+    `);
+
+    // 8. Recent activity entries (for the feed)
     const recentActivity = await db.execute(sql`
       SELECT
         al.id,
@@ -214,6 +226,14 @@ export const GET = async (req: NextRequest) => {
       a.pifCount = r.pif_count;
       a.activeCount = r.active_count;
       a.pendingCount = r.pending_count;
+    }
+    for (const r of inboundIbCounts as unknown as {
+      agent_name: string;
+      ib_count: number;
+    }[]) {
+      const a = ensure(r.agent_name);
+      a.clientCallsIb += r.ib_count;
+      a.totalCalls += r.ib_count;
     }
 
     const agents = Array.from(agentMap.values())

--- a/src/app/api/scoreboard/route.ts
+++ b/src/app/api/scoreboard/route.ts
@@ -160,7 +160,13 @@ export const GET = async (req: NextRequest) => {
         COALESCE((SELECT SUM(dm.client_calls_ib + dm.client_calls_ob) FROM daily_metrics dm
          WHERE dm.agent_name = tm.name
          AND dm.metric_date >= ${startDate}::date
-         AND dm.metric_date < ${endExclusive}::date), 0) AS week_client_calls,
+         AND dm.metric_date < ${endExclusive}::date), 0)
+        + COALESCE((SELECT COUNT(*) FROM inbound_call_records icr
+         WHERE icr.specialist_assigned = tm.name
+         AND icr.specialist_assigned IS NOT NULL
+         AND icr.specialist_assigned != ''
+         AND icr.call_date >= ${startDate}::date
+         AND icr.call_date < ${endExclusive}::date), 0) AS week_client_calls,
 
         COALESCE((SELECT SUM(dm.win_sheets_created) FROM daily_metrics dm
          WHERE dm.agent_name = tm.name

--- a/src/components/notifications/RecentActivityTab.tsx
+++ b/src/components/notifications/RecentActivityTab.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { useState, useEffect, useRef, Fragment } from "react";
+import { ChevronLeft, ChevronRight, RefreshCw, Clock, AlertCircle } from "lucide-react";
+import { themeClasses } from "@/lib/theme-classes";
+
+interface ActivityEntry {
+  id: string;
+  caseId: number;
+  message: string;
+  createdBy: string;
+  createdAt: string;
+  caseName: string | null;
+}
+
+interface RecentActivityTabProps {
+  dark: boolean;
+  t: ReturnType<typeof themeClasses>;
+}
+
+const getMonday = (offset = 0): string => {
+  const d = new Date();
+  const day = d.getDay();
+  d.setDate(d.getDate() - day + (day === 0 ? -6 : 1) + offset * 7);
+  return d.toISOString().split("T")[0];
+};
+
+const formatWeekLabel = (monday: string): string => {
+  const start = new Date(monday + "T00:00:00");
+  const end = new Date(monday + "T00:00:00");
+  end.setDate(end.getDate() + 4);
+  const opts: Intl.DateTimeFormatOptions = { month: "short", day: "numeric" };
+  return `${start.toLocaleDateString("en-US", opts)} – ${end.toLocaleDateString("en-US", { ...opts, year: "numeric" })}`;
+};
+
+const fmtDateOnly = (iso: string): string =>
+  new Date(iso).toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+
+const toDateKey = (iso: string): string =>
+  new Date(iso).toLocaleDateString("en-CA");
+
+const thBase = "px-3 py-2 text-[11px] font-semibold uppercase tracking-wide";
+const tdBase = "px-3 py-2 text-xs";
+
+export function RecentActivityTab({ dark, t }: RecentActivityTabProps) {
+  const [weekOffset, setWeekOffset] = useState(0);
+  const [entries, setEntries] = useState<ActivityEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const monday = getMonday(weekOffset);
+
+  useEffect(() => {
+    let cancelled = false;
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setLoading(true);
+    setError(null);
+
+    fetch(`/api/activity-log?week=${monday}`, { signal: controller.signal })
+      .then((res) => {
+        if (!res.ok) throw new Error(`Failed to load activity log (${res.status})`);
+        return res.json();
+      })
+      .then((json) => {
+        if (cancelled) return;
+        setEntries(json.data ?? []);
+      })
+      .catch((err) => {
+        if (cancelled || (err as Error).name === "AbortError") return;
+        setError((err as Error).message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+      abortRef.current?.abort();
+    };
+  }, [monday]);
+
+  const byDate = entries.reduce<Record<string, ActivityEntry[]>>((acc, e) => {
+    const key = toDateKey(e.createdAt);
+    (acc[key] ??= []).push(e);
+    return acc;
+  }, {});
+  const dates = Object.keys(byDate).sort((a, b) => b.localeCompare(a));
+
+  const rowDivide = dark ? "border-neutral-800/40" : "border-neutral-100";
+  const rowHover  = dark ? "hover:bg-neutral-800/30" : "hover:bg-neutral-50";
+  const dateBg    = dark ? "bg-neutral-800/60" : "bg-neutral-50";
+
+  return (
+    <div className={`rounded-xl border ${t.card}`}>
+      {/* Header */}
+      <div className={`p-4 flex flex-col sm:flex-row sm:items-center justify-between gap-3 border-b ${t.borderLight}`}>
+        <div className="flex items-center gap-3">
+          <div className={`w-10 h-10 rounded-lg flex items-center justify-center ${dark ? "bg-amber-900/40" : "bg-amber-50"}`}>
+            <Clock className={`h-5 w-5 ${dark ? "text-amber-400" : "text-amber-600"}`} aria-hidden="true" />
+          </div>
+          <div>
+            <h3 className={`text-sm font-bold ${t.text}`}>Recent Activity</h3>
+            <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
+              Case activity log — {formatWeekLabel(monday)}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={() => setWeekOffset((v) => v - 1)}
+            className={`h-8 w-8 rounded-md flex items-center justify-center transition-colors ${t.hover} ${t.textSub}`}
+            aria-label="Previous week"
+          >
+            <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+          </button>
+          <span className={`text-[11px] font-medium ${t.textSub} whitespace-nowrap px-2`}>
+            {formatWeekLabel(monday)}
+          </span>
+          <button
+            onClick={() => setWeekOffset((v) => v + 1)}
+            disabled={weekOffset >= 0}
+            className={`h-8 w-8 rounded-md flex items-center justify-center transition-colors ${t.hover} ${t.textSub} disabled:opacity-40`}
+            aria-label="Next week"
+          >
+            <ChevronRight className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div
+          className={`m-4 rounded-lg border p-3 flex items-center gap-2 text-xs ${dark ? "bg-red-900/20 border-red-800 text-red-400" : "bg-red-50 border-red-200 text-red-700"}`}
+          role="alert"
+        >
+          <AlertCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
+          {error}
+        </div>
+      )}
+
+      {/* Loading */}
+      {loading && (
+        <div className="flex items-center justify-center py-16">
+          <RefreshCw className={`h-5 w-5 animate-spin ${t.textMuted}`} aria-hidden="true" />
+          <span className={`ml-2 text-sm ${t.textSub}`}>Loading activity...</span>
+        </div>
+      )}
+
+      {/* Empty */}
+      {!loading && !error && dates.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-16">
+          <Clock className={`h-8 w-8 ${t.textMuted} mb-3`} aria-hidden="true" />
+          <p className={`text-sm font-medium ${t.text}`}>No activity logged for this week</p>
+          <p className={`text-xs ${t.textMuted} mt-1`}>
+            Case updates appear here as agents work their cases.
+          </p>
+        </div>
+      )}
+
+      {/* Table */}
+      {!loading && !error && dates.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-150">
+            <thead>
+              <tr className={`border-b ${t.borderLight}`}>
+                <th className={`${thBase} ${t.textSub} text-left`}>Time</th>
+                <th className={`${thBase} ${t.textSub} text-left`}>Agent</th>
+                <th className={`${thBase} ${t.textSub} text-left`}>Case</th>
+                <th className={`${thBase} ${t.textSub} text-left`}>Activity</th>
+              </tr>
+            </thead>
+            <tbody>
+              {dates.map((date) => (
+                <Fragment key={date}>
+                  <tr className={dateBg}>
+                    <td colSpan={4} className={`${tdBase} font-semibold ${t.textSub}`}>
+                      {fmtDateOnly(date + "T12:00:00")}
+                    </td>
+                  </tr>
+                  {byDate[date].map((entry) => (
+                    <tr
+                      key={entry.id}
+                      className={`border-b ${rowDivide} ${rowHover} transition-colors`}
+                    >
+                      <td className={`${tdBase} ${t.textMuted} shrink-0 whitespace-nowrap`}>
+                        {new Date(entry.createdAt).toLocaleTimeString("en-US", {
+                          hour: "numeric",
+                          minute: "2-digit",
+                        })}
+                      </td>
+                      <td className={`${tdBase} ${t.text} font-medium whitespace-nowrap`}>
+                        {entry.createdBy}
+                      </td>
+                      <td className={`${tdBase} ${entry.caseName ? t.textSub : t.textMuted} whitespace-nowrap`}>
+                        {entry.caseName ?? "—"}
+                      </td>
+                      <td className={`${tdBase} ${t.textSub} max-w-xs`}>
+                        {entry.message}
+                      </td>
+                    </tr>
+                  ))}
+                </Fragment>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/reports/Reports.tsx
+++ b/src/components/reports/Reports.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import { useTheme } from "next-themes";
 import {
   BarChart3,
@@ -9,10 +9,9 @@ import {
   Calendar,
   Users,
   ChevronDown,
-  ChevronRight,
   ArrowUpDown,
+  Phone,
 } from "lucide-react";
-import { ActivityEntry } from "@/components/reports/RecentActivityFeed";
 import { ScoreboardTracker } from "@/components/reports/ScoreboardTracker";
 import { themeClasses } from "@/lib/theme-classes";
 import { fmtFull, fmtDate } from "@/lib/formatters";
@@ -52,7 +51,6 @@ interface ReportData {
   to: string;
   agents: AgentRow[];
   totals: Totals;
-  recentActivity: ActivityEntry[];
 }
 
 // ---------- helpers ----------
@@ -126,8 +124,8 @@ export const Reports = () => {
   const [error, setError] = useState<string | null>(null);
   const [sortKey, setSortKey] = useState<SortKey>("totalCalls");
   const [sortAsc, setSortAsc] = useState(false);
-  const [expandedAgent, setExpandedAgent] = useState<string | null>(null);
   const [showPresets, setShowPresets] = useState(false);
+  const [activeTab, setActiveTab] = useState<"breakdown" | "tracking">("breakdown");
 
   const fetchAbortRef = useRef<AbortController | null>(null);
 
@@ -234,8 +232,36 @@ export const Reports = () => {
     />
   );
 
+  const TABS: { key: "breakdown" | "tracking"; label: string; icon: React.ElementType }[] = [
+    { key: "breakdown", label: "Activity Report", icon: BarChart3 },
+    { key: "tracking",  label: "Agent Tracking",  icon: Phone },
+  ];
+
   return (
     <div className="space-y-4">
+      {/* Tab switcher */}
+      <div className={`flex gap-1 p-1 rounded-lg border w-fit ${dark ? "bg-neutral-900 border-neutral-800" : "bg-neutral-100/60 border-neutral-200"}`}>
+        {TABS.map(({ key, label, icon: Icon }) => (
+          <button
+            key={key}
+            onClick={() => setActiveTab(key)}
+            className={`h-8 px-3 rounded-md text-xs font-medium flex items-center gap-1.5 transition-colors ${
+              activeTab === key
+                ? dark
+                  ? "bg-neutral-800 text-neutral-100"
+                  : "bg-white text-neutral-900 shadow-sm"
+                : dark
+                  ? "text-neutral-400 hover:text-neutral-200"
+                  : "text-neutral-500 hover:text-neutral-700"
+            }`}
+          >
+            <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === "breakdown" && <>
       {/* Header with date range picker */}
       <div className={`${sectionCard} p-4 md:p-5`}>
         <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
@@ -245,6 +271,7 @@ export const Reports = () => {
             >
               <BarChart3
                 className={`h-5 w-5 ${dark ? "text-indigo-400" : "text-indigo-600"}`}
+                aria-hidden="true"
               />
             </div>
             <div>
@@ -358,7 +385,7 @@ export const Reports = () => {
               <h4
                 className={`text-xs font-bold ${t.text} flex items-center gap-2`}
               >
-                <Users className="h-3.5 w-3.5" /> Agent Breakdown
+                <Users className="h-3.5 w-3.5" aria-hidden="true" /> Agent Breakdown
                 <span className={`text-[10px] font-normal ${t.textMuted}`}>
                   ({sortedAgents.length} agents)
                 </span>
@@ -369,18 +396,17 @@ export const Reports = () => {
             </div>
 
             <div className="overflow-x-auto">
-              <table className="w-full min-w-250">
+              <table className="w-full min-w-300">
                 <thead>
                   <tr className={`border-b ${t.borderLight}`}>
-                    <th className={`${thBase} ${t.textSub} text-left w-8`} />
                     <th
-                      className={`${thBase} ${t.textSub} text-left`}
+                      className={`${thBase} ${t.textSub} text-left cursor-pointer select-none`}
                       onClick={() => handleSort("name")}
                     >
                       Agent <SortIcon col="name" />
                     </th>
                     <th
-                      className={`${thBase} ${t.textSub} text-right`}
+                      className={`${thBase} ${t.textSub} text-right cursor-pointer select-none`}
                       onClick={() => handleSort("totalCalls")}
                     >
                       Calls <SortIcon col="totalCalls" />
@@ -388,32 +414,36 @@ export const Reports = () => {
                     <th className={`${thBase} ${t.textSub} text-right`}>SSA</th>
                     <th className={`${thBase} ${t.textSub} text-right`}>IB</th>
                     <th className={`${thBase} ${t.textSub} text-right`}>OB</th>
+                    <th className={`${thBase} ${t.textSub} text-right`}>Days</th>
+                    <th className={`${thBase} ${t.textSub} text-right`}>Avg/Day</th>
                     <th
-                      className={`${thBase} ${t.textSub} text-right`}
+                      className={`${thBase} ${t.textSub} text-right cursor-pointer select-none`}
                       onClick={() => handleSort("activityCount")}
                     >
                       Activity <SortIcon col="activityCount" />
                     </th>
                     <th
-                      className={`${thBase} ${t.textSub} text-right`}
+                      className={`${thBase} ${t.textSub} text-right cursor-pointer select-none`}
                       onClick={() => handleSort("casesTouched")}
                     >
                       Cases <SortIcon col="casesTouched" />
                     </th>
                     <th
-                      className={`${thBase} ${t.textSub} text-right`}
+                      className={`${thBase} ${t.textSub} text-right cursor-pointer select-none`}
                       onClick={() => handleSort("statusChanges")}
                     >
                       Changes <SortIcon col="statusChanges" />
                     </th>
+                    <th className={`${thBase} ${t.textSub} text-right`}>PIF</th>
+                    <th className={`${thBase} ${t.textSub} text-right`}>Act/Pend</th>
                     <th
-                      className={`${thBase} ${t.textSub} text-right`}
+                      className={`${thBase} ${t.textSub} text-right cursor-pointer select-none`}
                       onClick={() => handleSort("collected")}
                     >
                       Collected <SortIcon col="collected" />
                     </th>
                     <th
-                      className={`${thBase} ${t.textSub} text-right`}
+                      className={`${thBase} ${t.textSub} text-right cursor-pointer select-none`}
                       onClick={() => handleSort("totalAssigned")}
                     >
                       Assigned <SortIcon col="totalAssigned" />
@@ -424,242 +454,61 @@ export const Reports = () => {
                   {sortedAgents.length === 0 ? (
                     <tr>
                       <td
-                        colSpan={11}
+                        colSpan={14}
                         className={`${tdBase} text-center py-8 ${t.textMuted}`}
                       >
                         No agent data for this date range.
                       </td>
                     </tr>
                   ) : (
-                    sortedAgents.map((agent) => {
-                      const isExpanded = expandedAgent === agent.name;
-                      return (
-                        <tr key={agent.name} className="group">
-                          <td colSpan={11} className="p-0">
-                            {/* Main row */}
-                            <div
-                              className={`flex items-center border-b ${rowBorder} ${rowHover} transition-colors cursor-pointer`}
-                              onClick={() =>
-                                setExpandedAgent(isExpanded ? null : agent.name)
-                              }
-                            >
-                              <div
-                                className={`${tdBase} w-8 flex items-center justify-center`}
-                              >
-                                {isExpanded ? (
-                                  <ChevronDown className="h-3 w-3" />
-                                ) : (
-                                  <ChevronRight className="h-3 w-3" />
-                                )}
-                              </div>
-                              <div
-                                className={`${tdBase} flex-1 ${t.text} font-semibold`}
-                              >
-                                {agent.name}
-                              </div>
-                              <div
-                                className={`${tdBase} text-right font-semibold ${t.text}`}
-                              >
-                                {agent.totalCalls}
-                              </div>
-                              <div
-                                className={`${tdBase} text-right ${t.textSub}`}
-                              >
-                                {agent.ssaCalls}
-                              </div>
-                              <div
-                                className={`${tdBase} text-right ${t.textSub}`}
-                              >
-                                {agent.clientCallsIb}
-                              </div>
-                              <div
-                                className={`${tdBase} text-right ${t.textSub}`}
-                              >
-                                {agent.clientCallsOb}
-                              </div>
-                              <div
-                                className={`${tdBase} text-right ${t.textSub}`}
-                              >
-                                {agent.activityCount}
-                              </div>
-                              <div
-                                className={`${tdBase} text-right ${t.textSub}`}
-                              >
-                                {agent.casesTouched}
-                              </div>
-                              <div
-                                className={`${tdBase} text-right ${t.textSub}`}
-                              >
-                                {agent.statusChanges}
-                              </div>
-                              <div
-                                className={`${tdBase} text-right ${agent.collected > 0 ? "text-emerald-500 font-semibold" : t.textMuted}`}
-                              >
-                                {agent.collected > 0
-                                  ? fmtFull(agent.collected)
-                                  : "—"}
-                              </div>
-                              <div
-                                className={`${tdBase} text-right ${t.textSub}`}
-                              >
-                                {agent.totalAssigned}
-                              </div>
-                            </div>
-
-                            {/* Expanded detail */}
-                            {isExpanded && (
-                              <div
-                                className={`px-4 py-3 border-b ${rowBorder} ${dark ? "bg-neutral-800/20" : "bg-neutral-50/50"}`}
-                              >
-                                <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 text-[11px]">
-                                  <div>
-                                    <p
-                                      className={`text-[10px] font-semibold uppercase ${t.textMuted}`}
-                                    >
-                                      Days Active
-                                    </p>
-                                    <p className={`font-semibold ${t.text}`}>
-                                      {agent.daysActive}
-                                    </p>
-                                  </div>
-                                  <div>
-                                    <p
-                                      className={`text-[10px] font-semibold uppercase ${t.textMuted}`}
-                                    >
-                                      Avg Calls/Day
-                                    </p>
-                                    <p className={`font-semibold ${t.text}`}>
-                                      {agent.daysActive > 0
-                                        ? Math.round(
-                                            agent.totalCalls / agent.daysActive,
-                                          )
-                                        : 0}
-                                    </p>
-                                  </div>
-                                  <div>
-                                    <p
-                                      className={`text-[10px] font-semibold uppercase ${t.textMuted}`}
-                                    >
-                                      PIF Cases
-                                    </p>
-                                    <p className="font-semibold text-emerald-500">
-                                      {agent.pifCount}
-                                    </p>
-                                  </div>
-                                  <div>
-                                    <p
-                                      className={`text-[10px] font-semibold uppercase ${t.textMuted}`}
-                                    >
-                                      Active / Pending
-                                    </p>
-                                    <p className={`font-semibold ${t.text}`}>
-                                      {agent.activeCount} / {agent.pendingCount}
-                                    </p>
-                                  </div>
-                                </div>
-
-                                {/* Agent's activity entries */}
-                                {data.recentActivity.filter(
-                                  (a) => a.createdBy === agent.name,
-                                ).length > 0 && (
-                                  <div className="mt-3">
-                                    <p
-                                      className={`text-[10px] font-semibold uppercase ${t.textMuted} mb-1.5`}
-                                    >
-                                      Recent Activity
-                                    </p>
-                                    <div className="space-y-1.5 max-h-40 overflow-y-auto">
-                                      {data.recentActivity
-                                        .filter(
-                                          (a) => a.createdBy === agent.name,
-                                        )
-                                        .slice(0, 10)
-                                        .map((a) => (
-                                          <div
-                                            key={a.id}
-                                            className={`flex items-start gap-2 text-[11px] ${t.textSub}`}
-                                          >
-                                            <span
-                                              className={`text-[9px] ${t.textMuted} shrink-0 w-16`}
-                                            >
-                                              {new Date(
-                                                a.createdAt,
-                                              ).toLocaleDateString("en-US", {
-                                                month: "short",
-                                                day: "numeric",
-                                              })}
-                                            </span>
-                                            <span className="flex-1 leading-snug">
-                                              {a.caseName && (
-                                                <span
-                                                  className={`font-medium ${t.text}`}
-                                                >
-                                                  {a.caseName}:{" "}
-                                                </span>
-                                              )}
-                                              {a.message}
-                                            </span>
-                                          </div>
-                                        ))}
-                                    </div>
-                                  </div>
-                                )}
-                              </div>
-                            )}
-                          </td>
-                        </tr>
-                      );
-                    })
+                    sortedAgents.map((agent) => (
+                      <tr
+                        key={agent.name}
+                        className={`border-b ${rowBorder} ${rowHover} transition-colors`}
+                      >
+                        <td className={`${tdBase} ${t.text} font-semibold`}>{agent.name}</td>
+                        <td className={`${tdBase} text-right font-semibold ${t.text}`}>{agent.totalCalls}</td>
+                        <td className={`${tdBase} text-right ${t.textSub}`}>{agent.ssaCalls}</td>
+                        <td className={`${tdBase} text-right ${t.textSub}`}>{agent.clientCallsIb}</td>
+                        <td className={`${tdBase} text-right ${t.textSub}`}>{agent.clientCallsOb}</td>
+                        <td className={`${tdBase} text-right ${t.textSub}`}>{agent.daysActive}</td>
+                        <td className={`${tdBase} text-right ${t.textSub}`}>
+                          {agent.daysActive > 0 ? Math.round(agent.totalCalls / agent.daysActive) : 0}
+                        </td>
+                        <td className={`${tdBase} text-right ${t.textSub}`}>{agent.activityCount}</td>
+                        <td className={`${tdBase} text-right ${t.textSub}`}>{agent.casesTouched}</td>
+                        <td className={`${tdBase} text-right ${t.textSub}`}>{agent.statusChanges}</td>
+                        <td className={`${tdBase} text-right font-semibold text-emerald-500`}>
+                          {agent.pifCount > 0 ? agent.pifCount : <span className={t.textMuted}>—</span>}
+                        </td>
+                        <td className={`${tdBase} text-right ${t.textSub}`}>
+                          {agent.activeCount} / {agent.pendingCount}
+                        </td>
+                        <td className={`${tdBase} text-right ${agent.collected > 0 ? "text-emerald-500 font-semibold" : t.textMuted}`}>
+                          {agent.collected > 0 ? fmtFull(agent.collected) : "—"}
+                        </td>
+                        <td className={`${tdBase} text-right ${t.textSub}`}>{agent.totalAssigned}</td>
+                      </tr>
+                    ))
                   )}
 
                   {/* Totals row */}
                   {sortedAgents.length > 0 && (
-                    <tr
-                      className={`border-t-2 ${dark ? "border-neutral-700" : "border-neutral-300"}`}
-                    >
-                      <td className={`${tdBase}`} />
+                    <tr className={`border-t-2 ${dark ? "border-neutral-700" : "border-neutral-300"}`}>
                       <td className={`${tdBase} font-bold ${t.text}`}>Total</td>
-                      <td
-                        className={`${tdBase} text-right font-bold ${t.text}`}
-                      >
-                        {data.totals.totalCalls}
-                      </td>
-                      <td
-                        className={`${tdBase} text-right font-semibold ${t.textSub}`}
-                      >
-                        {data.totals.ssaCalls}
-                      </td>
-                      <td
-                        className={`${tdBase} text-right font-semibold ${t.textSub}`}
-                      >
-                        {data.totals.clientCallsIb}
-                      </td>
-                      <td
-                        className={`${tdBase} text-right font-semibold ${t.textSub}`}
-                      >
-                        {data.totals.clientCallsOb}
-                      </td>
-                      <td
-                        className={`${tdBase} text-right font-semibold ${t.textSub}`}
-                      >
-                        {data.totals.activityCount}
-                      </td>
-                      <td
-                        className={`${tdBase} text-right font-semibold ${t.textSub}`}
-                      >
-                        {data.totals.casesTouched}
-                      </td>
-                      <td
-                        className={`${tdBase} text-right font-semibold ${t.textSub}`}
-                      >
-                        {data.totals.statusChanges}
-                      </td>
-                      <td
-                        className={`${tdBase} text-right font-bold text-emerald-500`}
-                      >
-                        {data.totals.collected > 0
-                          ? fmtFull(data.totals.collected)
-                          : "—"}
+                      <td className={`${tdBase} text-right font-bold ${t.text}`}>{data.totals.totalCalls}</td>
+                      <td className={`${tdBase} text-right font-semibold ${t.textSub}`}>{data.totals.ssaCalls}</td>
+                      <td className={`${tdBase} text-right font-semibold ${t.textSub}`}>{data.totals.clientCallsIb}</td>
+                      <td className={`${tdBase} text-right font-semibold ${t.textSub}`}>{data.totals.clientCallsOb}</td>
+                      <td className={`${tdBase}`} />
+                      <td className={`${tdBase}`} />
+                      <td className={`${tdBase} text-right font-semibold ${t.textSub}`}>{data.totals.activityCount}</td>
+                      <td className={`${tdBase} text-right font-semibold ${t.textSub}`}>{data.totals.casesTouched}</td>
+                      <td className={`${tdBase} text-right font-semibold ${t.textSub}`}>{data.totals.statusChanges}</td>
+                      <td className={`${tdBase}`} />
+                      <td className={`${tdBase}`} />
+                      <td className={`${tdBase} text-right font-bold text-emerald-500`}>
+                        {data.totals.collected > 0 ? fmtFull(data.totals.collected) : "—"}
                       </td>
                       <td className={`${tdBase}`} />
                     </tr>
@@ -671,7 +520,9 @@ export const Reports = () => {
         </>
       )}
 
-      <ScoreboardTracker dark={dark} t={t} />
+      </>}
+
+      {activeTab === "tracking" && <ScoreboardTracker dark={dark} t={t} />}
     </div>
   );
 };


### PR DESCRIPTION
## Summary

- **Agent Breakdown table fixed** — replaced flex div rows with proper `<td>` cells; columns now align correctly with headers
- **Expansion cards promoted to inline columns** — Days Active, Avg/Day, PIF, and Active/Pending are now visible directly in the table row without expanding
- **Reports split into tabs** — Activity Report and Agent Tracking are now two tabs in a single section instead of two stacked blocks
- **Recent Activity moved to Notifications** — removed per-agent activity from the collapsible rows (root cause of the table offset); added as a dedicated "Recent Activity" tab in Notifications with week navigation
- **New `/api/activity-log` endpoint** — powers the Recent Activity tab; grouped by date, week-navigable
- **Inbound calls count toward agent IB totals** — `inbound_call_records` where `specialist_assigned` is set now contribute to `clientCallsIb` and `totalCalls` in both the Activity Report and Agent Tracking queries