### PR TITLE
feat: duplicate case indicator and capabilities stale-token fix

### DIFF
--- a/src/components/modals/AddCaseModal.tsx
+++ b/src/components/modals/AddCaseModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState, useEffect, useRef } from "react";
 import { X, RefreshCw, Plus, CheckCircle2, ExternalLink, AlertCircle } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
 import {
@@ -72,6 +72,10 @@ export default function AddCaseModal({
   const [duplicateName, setDuplicateName] = useState<string | null>(null);
   const checkAbortRef = useRef<AbortController | null>(null);
 
+  useEffect(() => {
+    return () => { checkAbortRef.current?.abort(); };
+  }, []);
+
   const set = (key: keyof FormState, value: string) =>
     setForm((f) => ({ ...f, [key]: value }));
 
@@ -85,7 +89,7 @@ export default function AddCaseModal({
     try {
       const res = await fetch(`/api/cases/${trimmed}`, { signal: controller.signal });
       if (res.ok) {
-        const json = await res.json();
+        const json = await res.json() as { data?: { firstName?: string; lastName?: string } };
         const { firstName, lastName } = json.data ?? {};
         setDuplicateName(lastName && firstName ? `${lastName}, ${firstName}` : `Client ID ${trimmed}`);
         setClientIdStatus("duplicate");

--- a/src/components/modals/AddCaseModal.tsx
+++ b/src/components/modals/AddCaseModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
-import { X, RefreshCw, Plus, CheckCircle2, ExternalLink } from "lucide-react";
+import { useState, useRef } from "react";
+import { X, RefreshCw, Plus, CheckCircle2, ExternalLink, AlertCircle } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
 import {
   parseCaseLink,
@@ -68,6 +68,9 @@ export default function AddCaseModal({
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [done, setDone] = useState(false);
+  const [clientIdStatus, setClientIdStatus] = useState<"idle" | "checking" | "duplicate" | "clear">("idle");
+  const [duplicateName, setDuplicateName] = useState<string | null>(null);
+  const checkAbortRef = useRef<AbortController | null>(null);
 
   const set = (key: keyof FormState, value: string) =>
     setForm((f) => ({ ...f, [key]: value }));
@@ -121,10 +124,37 @@ export default function AddCaseModal({
   const assignees = dropdownOptions?.assigned_to ?? [];
   const statuses = dropdownOptions?.win_sheet_status ?? [];
 
+  const checkClientId = async (id: string) => {
+    const trimmed = id.trim();
+    if (!trimmed) { setClientIdStatus("idle"); setDuplicateName(null); return; }
+    checkAbortRef.current?.abort();
+    const controller = new AbortController();
+    checkAbortRef.current = controller;
+    setClientIdStatus("checking");
+    try {
+      const res = await fetch(`/api/cases/${trimmed}`, { signal: controller.signal });
+      if (res.ok) {
+        const json = await res.json();
+        const { firstName, lastName } = json.data ?? {};
+        setDuplicateName(lastName && firstName ? `${lastName}, ${firstName}` : `Client ID ${trimmed}`);
+        setClientIdStatus("duplicate");
+      } else if (res.status === 404) {
+        setClientIdStatus("clear");
+        setDuplicateName(null);
+      } else {
+        setClientIdStatus("idle");
+      }
+    } catch (e) {
+      if ((e as Error).name === "AbortError") return;
+      setClientIdStatus("idle");
+    }
+  };
+
   const canSubmit =
     form.clientId.trim() !== "" &&
     form.firstName.trim() !== "" &&
     form.lastName.trim() !== "" &&
+    clientIdStatus !== "duplicate" &&
     !busy;
 
   const submit = async () => {
@@ -278,10 +308,23 @@ export default function AddCaseModal({
                   <input
                     type="number"
                     value={form.clientId}
-                    onChange={(e) => set("clientId", e.target.value)}
+                    onChange={(e) => { set("clientId", e.target.value); setClientIdStatus("idle"); setDuplicateName(null); }}
+                    onBlur={(e) => checkClientId(e.target.value)}
                     placeholder="MyCase ID"
-                    className={inputCls}
+                    className={`${inputCls} ${clientIdStatus === "duplicate" ? "border-red-500 dark:border-red-600" : ""}`}
                   />
+                  {clientIdStatus === "checking" && (
+                    <p className={`mt-1 text-[11px] flex items-center gap-1 ${t.textMuted}`}>
+                      <RefreshCw className="h-3 w-3 animate-spin" aria-hidden="true" />
+                      Checking…
+                    </p>
+                  )}
+                  {clientIdStatus === "duplicate" && (
+                    <p className="mt-1 text-[11px] text-red-600 dark:text-red-400 flex items-center gap-1" role="alert">
+                      <AlertCircle className="h-3 w-3 shrink-0" aria-hidden="true" />
+                      Already exists: {duplicateName}
+                    </p>
+                  )}
                 </div>
                 <div>
                   <label className={lblCls}>First Name *</label>

--- a/src/components/modals/AddCaseModal.tsx
+++ b/src/components/modals/AddCaseModal.tsx
@@ -75,6 +75,32 @@ export default function AddCaseModal({
   const set = (key: keyof FormState, value: string) =>
     setForm((f) => ({ ...f, [key]: value }));
 
+  const checkClientId = async (id: string) => {
+    const trimmed = id.trim();
+    if (!trimmed) { setClientIdStatus("idle"); setDuplicateName(null); return; }
+    checkAbortRef.current?.abort();
+    const controller = new AbortController();
+    checkAbortRef.current = controller;
+    setClientIdStatus("checking");
+    try {
+      const res = await fetch(`/api/cases/${trimmed}`, { signal: controller.signal });
+      if (res.ok) {
+        const json = await res.json();
+        const { firstName, lastName } = json.data ?? {};
+        setDuplicateName(lastName && firstName ? `${lastName}, ${firstName}` : `Client ID ${trimmed}`);
+        setClientIdStatus("duplicate");
+      } else if (res.status === 404) {
+        setClientIdStatus("clear");
+        setDuplicateName(null);
+      } else {
+        setClientIdStatus("idle");
+      }
+    } catch (e) {
+      if ((e as Error).name === "AbortError") return;
+      setClientIdStatus("idle");
+    }
+  };
+
   // Paste the worksheet "CASE LINK" text — e.g.
   // "2026.05.22 Watson, Katrina v. ALJ WENDY HOLLINGSWORTH" — and fill the
   // name/date/ALJ fields from it. Existing values are kept when the line has
@@ -101,6 +127,11 @@ export default function AddCaseModal({
       externalId: value,
       clientId: id ? String(id) : f.clientId,
     }));
+    if (id) {
+      setClientIdStatus("idle");
+      setDuplicateName(null);
+      checkClientId(String(id));
+    }
   };
 
   // Paste a Chronicle URL (or a bare client id); we store the raw value for
@@ -123,32 +154,6 @@ export default function AddCaseModal({
   const levels = dropdownOptions?.case_level ?? [];
   const assignees = dropdownOptions?.assigned_to ?? [];
   const statuses = dropdownOptions?.win_sheet_status ?? [];
-
-  const checkClientId = async (id: string) => {
-    const trimmed = id.trim();
-    if (!trimmed) { setClientIdStatus("idle"); setDuplicateName(null); return; }
-    checkAbortRef.current?.abort();
-    const controller = new AbortController();
-    checkAbortRef.current = controller;
-    setClientIdStatus("checking");
-    try {
-      const res = await fetch(`/api/cases/${trimmed}`, { signal: controller.signal });
-      if (res.ok) {
-        const json = await res.json();
-        const { firstName, lastName } = json.data ?? {};
-        setDuplicateName(lastName && firstName ? `${lastName}, ${firstName}` : `Client ID ${trimmed}`);
-        setClientIdStatus("duplicate");
-      } else if (res.status === 404) {
-        setClientIdStatus("clear");
-        setDuplicateName(null);
-      } else {
-        setClientIdStatus("idle");
-      }
-    } catch (e) {
-      if ((e as Error).name === "AbortError") return;
-      setClientIdStatus("idle");
-    }
-  };
 
   const canSubmit =
     form.clientId.trim() !== "" &&

--- a/src/components/scoreboard/Scoreboard.tsx
+++ b/src/components/scoreboard/Scoreboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useReducer, useEffect } from "react";
 import { useTheme } from "next-themes";
 import { RefreshCw, ChevronLeft, ChevronRight } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
@@ -51,6 +51,22 @@ const TEAMS = [
   { key: "T16",        label: "T16 Team",         headerBg: "bg-red-700"  },
 ];
 
+// ---------- state ----------
+
+type FetchState = { weeks: WeekSlot[]; loading: boolean; error: string | null };
+type FetchAction =
+  | { type: "start" }
+  | { type: "success"; weeks: WeekSlot[] }
+  | { type: "error"; message: string };
+
+function fetchReducer(state: FetchState, action: FetchAction): FetchState {
+  switch (action.type) {
+    case "start":   return { ...state, loading: true, error: null };
+    case "success": return { weeks: action.weeks, loading: false, error: null };
+    case "error":   return { ...state, loading: false, error: action.message };
+  }
+}
+
 // ---------- component ----------
 
 export const Scoreboard = () => {
@@ -59,14 +75,15 @@ export const Scoreboard = () => {
   const t = themeClasses(dark);
 
   const [weekOffset, setWeekOffset] = useState(0);
-  const [weeks, setWeeks] = useState<WeekSlot[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [{ weeks, loading, error }, dispatch] = useReducer(fetchReducer, {
+    weeks: [],
+    loading: true,
+    error: null,
+  });
 
   useEffect(() => {
     let cancelled = false;
-    setLoading(true);
-    setError(null);
+    dispatch({ type: "start" });
     const mondays = Array.from({ length: 5 }, (_, i) => getMonday(weekOffset - i));
     const controllers = mondays.map(() => new AbortController());
 
@@ -90,13 +107,11 @@ export const Scoreboard = () => {
     )
       .then((results) => {
         if (cancelled) return;
-        setWeeks(results);
-        setLoading(false);
+        dispatch({ type: "success", weeks: results });
       })
       .catch((err: Error) => {
         if (err.name === "AbortError" || cancelled) return;
-        setError(err.message);
-        setLoading(false);
+        dispatch({ type: "error", message: err.message });
       });
 
     return () => {
@@ -128,7 +143,7 @@ export const Scoreboard = () => {
         </div>
         <div className="flex items-center gap-1 shrink-0">
           <button
-            onClick={() => setWeekOffset((v) => v - 1)}
+            onClick={() => setWeekOffset(weekOffset - 1)}
             className={`flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium border transition-colors ${dark ? "border-neutral-700 text-neutral-300 hover:bg-neutral-800" : "border-neutral-200 text-neutral-600 hover:bg-neutral-50"}`}
             aria-label="Previous 5 weeks"
           >
@@ -144,7 +159,7 @@ export const Scoreboard = () => {
             </button>
           )}
           <button
-            onClick={() => setWeekOffset((v) => v + 1)}
+            onClick={() => setWeekOffset(weekOffset + 1)}
             disabled={weekOffset >= 0}
             className={`flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium border transition-colors ${weekOffset >= 0 ? (dark ? "border-neutral-800 text-neutral-600 cursor-not-allowed" : "border-neutral-100 text-neutral-300 cursor-not-allowed") : (dark ? "border-neutral-700 text-neutral-300 hover:bg-neutral-800" : "border-neutral-200 text-neutral-600 hover:bg-neutral-50")}`}
             aria-label="Next 5 weeks"

--- a/src/hooks/useCapabilities.ts
+++ b/src/hooks/useCapabilities.ts
@@ -18,8 +18,12 @@ import {
  */
 export function useCapabilities() {
   const { data: session } = useSession();
-  const capabilities = (session?.user?.capabilities ??
-    roleCapabilityDefaults(session?.user?.role)) as CapabilityKey[];
+  const rawCaps = session?.user?.capabilities;
+  const capabilities = (
+    Array.isArray(rawCaps) && rawCaps.length > 0
+      ? rawCaps
+      : roleCapabilityDefaults(session?.user?.role)
+  ) as CapabilityKey[];
 
   return {
     capabilities,


### PR DESCRIPTION
## Summary

- On-blur and MyCase URL autofill duplicate Client ID check in Add Case modal — shows red inline warning with existing case name, blocks submit
- Fixed `useCapabilities` stale-token bug where old JWTs (minted before the capabilities system) produced `session.user.capabilities = []`, bypassing the role-defaults fallback and hiding capability-gated UI (e.g. the Add Case button on Master Fees)