### PR TITLE
feat: move summary cards to reports page

### DIFF
--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -12,7 +12,6 @@ import { RecentActivityFeed, ActivityEntry } from "@/components/reports/RecentAc
 
 const toISO = (d: Date) => d.toISOString().slice(0, 10);
 
-
 export default function OverviewPage() {
   const {
     cases,

--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -8,20 +8,10 @@ import { RevenuePanel } from "@/components/cases/RevenuePanel";
 import { useDashboard } from "@/hooks/useDashboard";
 import { themeClasses } from "@/lib/theme-classes";
 import { RefreshCw, AlertCircle } from "lucide-react";
-import {
-  ScoreboardSummaryCards,
-  ScoreboardSummary,
-} from "@/components/scoreboard/ScoreboardSummaryCards";
 import { RecentActivityFeed, ActivityEntry } from "@/components/reports/RecentActivityFeed";
 
 const toISO = (d: Date) => d.toISOString().slice(0, 10);
 
-const currentMonday = () => {
-  const d = new Date();
-  const day = d.getDay();
-  const diff = d.getDate() - day + (day === 0 ? -6 : 1);
-  return new Date(d.getFullYear(), d.getMonth(), diff);
-};
 
 export default function OverviewPage() {
   const {
@@ -36,39 +26,7 @@ export default function OverviewPage() {
   const dark = resolvedTheme === "dark";
   const t = themeClasses(dark);
 
-  const [scoreboardSummary, setScoreboardSummary] = useState<ScoreboardSummary | null>(null);
-  const [scoreboardLabel, setScoreboardLabel] = useState("This Week");
   const [recentActivities, setRecentActivities] = useState<ActivityEntry[]>([]);
-
-  useEffect(() => {
-    let cancelled = false;
-    const controller = new AbortController();
-    const week = toISO(currentMonday());
-    fetch(`/api/scoreboard?week=${week}`, { signal: controller.signal })
-      .then((res) => {
-        if (!res.ok) throw new Error(`Failed to load scoreboard (${res.status})`);
-        return res.json();
-      })
-      .then((json) => {
-        if (cancelled) return;
-        setScoreboardSummary(json.summary);
-        if (json.start && json.end) {
-          const fmt = (s: string) =>
-            new Date(s + "T12:00:00").toLocaleDateString("en-US", {
-              month: "short",
-              day: "numeric",
-            });
-          setScoreboardLabel(`${fmt(json.start)} – ${fmt(json.end)}`);
-        }
-      })
-      .catch((err: Error) => {
-        if (err.name === "AbortError") return;
-      });
-    return () => {
-      cancelled = true;
-      controller.abort();
-    };
-  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -130,19 +88,6 @@ export default function OverviewPage() {
         <CollectionsPanel data={monthlyData} />
         <RevenuePanel stats={summary} cases={cases} />
       </div>
-      {scoreboardSummary && (
-        <div
-          className={`rounded-xl border p-4 space-y-4 ${dark ? "bg-neutral-900 border-neutral-800" : "bg-white border-neutral-200"}`}
-        >
-          <ScoreboardSummaryCards
-            summary={scoreboardSummary}
-            teams={[]}
-            label={scoreboardLabel}
-            dark={dark}
-            t={t}
-          />
-        </div>
-      )}
       {recentActivities.length > 0 && (
         <RecentActivityFeed
           activities={recentActivities}

--- a/src/components/reports/Reports.tsx
+++ b/src/components/reports/Reports.tsx
@@ -147,7 +147,10 @@ export const Reports = () => {
         return res.json() as Promise<{ summary: ScoreboardSummary }>;
       })
       .then((json) => { if (!cancelled) setSummary(json.summary ?? null); })
-      .catch((err: Error) => { if (err.name === "AbortError" || cancelled) return; });
+      .catch((err: Error) => {
+        if (err.name === "AbortError" || cancelled) return;
+        console.error("Reports summary fetch error:", err);
+      });
     return () => { cancelled = true; summaryAbortRef.current?.abort(); };
   }, []);
 
@@ -404,7 +407,6 @@ export const Reports = () => {
           label=""
           dark={dark}
           t={t}
-          showMiniCards={true}
         />
       )}
 

--- a/src/components/reports/Reports.tsx
+++ b/src/components/reports/Reports.tsx
@@ -13,6 +13,10 @@ import {
   Phone,
 } from "lucide-react";
 import { ScoreboardTracker } from "@/components/reports/ScoreboardTracker";
+import {
+  ScoreboardSummaryCards,
+  type ScoreboardSummary,
+} from "@/components/scoreboard/ScoreboardSummaryCards";
 import { themeClasses } from "@/lib/theme-classes";
 import { fmtFull, fmtDate } from "@/lib/formatters";
 
@@ -128,6 +132,24 @@ export const Reports = () => {
   const [activeTab, setActiveTab] = useState<"breakdown" | "tracking">("breakdown");
 
   const fetchAbortRef = useRef<AbortController | null>(null);
+  const summaryAbortRef = useRef<AbortController | null>(null);
+  const [summary, setSummary] = useState<ScoreboardSummary | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    summaryAbortRef.current?.abort();
+    const controller = new AbortController();
+    summaryAbortRef.current = controller;
+    const monday = toISO(startOfWeek(new Date()));
+    fetch(`/api/scoreboard?week=${monday}`, { signal: controller.signal })
+      .then((res) => {
+        if (!res.ok) throw new Error(`Failed to load summary (${res.status})`);
+        return res.json() as Promise<{ summary: ScoreboardSummary }>;
+      })
+      .then((json) => { if (!cancelled) setSummary(json.summary ?? null); })
+      .catch((err: Error) => { if (err.name === "AbortError" || cancelled) return; });
+    return () => { cancelled = true; summaryAbortRef.current?.abort(); };
+  }, []);
 
   const fetchReport = useCallback(async () => {
     fetchAbortRef.current?.abort();
@@ -373,6 +395,17 @@ export const Reports = () => {
             Generating report...
           </span>
         </div>
+      )}
+
+      {summary && (
+        <ScoreboardSummaryCards
+          summary={summary}
+          teams={[]}
+          label=""
+          dark={dark}
+          t={t}
+          showMiniCards={true}
+        />
       )}
 
       {data && !loading && (


### PR DESCRIPTION
## Summary

- Moves the portfolio snapshot cards (Cases Assigned, Win Sheets, T2/T16/CONC >60D, Collected, Full Fee, SSA/Client Calls) from the Overview page to the top of the Activity Report tab in Reports
- Reports page fetches current-week scoreboard snapshot independently of the date range filter
- Removes the cards and their associated fetch/state from the Overview page