### PR TITLE
chore: sync develop → main

### DIFF
--- a/src/app/(dashboard)/fee-petitions/actions.ts
+++ b/src/app/(dashboard)/fee-petitions/actions.ts
@@ -3,6 +3,9 @@
 import { db } from "@/lib/db";
 import { feePetitions } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
+import { parseBool } from "@/lib/import/csv-parser";
+import { resolveCaseId } from "@/lib/import/resolve-case";
+import type { ImportResult } from "@/components/modals/CsvImportModal";
 
 const FIELD_KEYS = [
   "noa",
@@ -125,4 +128,76 @@ export async function bulkRestoreChecklists(input: {
     console.error("bulkRestoreChecklists error:", error);
     return { ok: false, error: "Server error" };
   }
+}
+
+const BOOL_KEYS = [
+  "noa",
+  "time_delineation",
+  "fee_petition_doc",
+  "ltr_to_clmt",
+  "ltr_to_clmt_with_signature",
+  "ltr_to_alj",
+  "fax_conf_fee_pet",
+] as const;
+
+export async function bulkImportFeePetitions(
+  rawRows: Record<string, string>[],
+): Promise<ImportResult> {
+  let imported = 0;
+  const rowErrors: ImportResult["rowErrors"] = [];
+
+  for (let i = 0; i < rawRows.length; i++) {
+    const raw = rawRows[i];
+    const rowNum = i + 1;
+
+    const resolved = await resolveCaseId(raw["client_id"] ?? "");
+    if ("error" in resolved) {
+      rowErrors.push({ row: rowNum, error: resolved.error });
+      continue;
+    }
+
+    const values: Partial<typeof feePetitions.$inferInsert> = {
+      caseId: resolved.caseId,
+    };
+
+    let parseOk = true;
+    for (const key of BOOL_KEYS) {
+      const cell = raw[key];
+      if (cell === undefined) continue;
+      const b = parseBool(cell);
+      if (b === null) {
+        rowErrors.push({ row: rowNum, error: `Invalid boolean value for "${key}": "${cell}"` });
+        parseOk = false;
+        break;
+      }
+      const schemaKey = key.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase()) as keyof typeof feePetitions.$inferInsert;
+      (values as Record<string, unknown>)[schemaKey] = b;
+    }
+
+    if (!parseOk) continue;
+
+    if (raw["update_note"] !== undefined) {
+      const note = raw["update_note"].trim();
+      if (note.length > 5000) {
+        rowErrors.push({ row: rowNum, error: "update_note exceeds 5000 characters" });
+        continue;
+      }
+      values.updateNote = note;
+    }
+
+    try {
+      await db
+        .insert(feePetitions)
+        .values(values as typeof feePetitions.$inferInsert)
+        .onConflictDoUpdate({
+          target: feePetitions.caseId,
+          set: { ...values, updatedAt: new Date() },
+        });
+      imported++;
+    } catch {
+      rowErrors.push({ row: rowNum, error: "Database error — row skipped" });
+    }
+  }
+
+  return { imported, failed: rowErrors.length, rowErrors };
 }

--- a/src/app/(dashboard)/inbound-calls/actions.ts
+++ b/src/app/(dashboard)/inbound-calls/actions.ts
@@ -1,0 +1,66 @@
+"use server";
+
+import { db } from "@/lib/db";
+import { inboundCallRecords } from "@/lib/db/schema";
+import { parseBool, parseDate } from "@/lib/import/csv-parser";
+import type { ImportResult } from "@/components/modals/CsvImportModal";
+
+function getMondayOf(dateStr: string): string {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  const date = new Date(y, m - 1, d);
+  const dow = date.getDay();
+  const diff = dow === 0 ? -6 : 1 - dow;
+  date.setDate(date.getDate() + diff);
+  const mm = String(date.getMonth() + 1).padStart(2, "0");
+  const dd = String(date.getDate()).padStart(2, "0");
+  return `${date.getFullYear()}-${mm}-${dd}`;
+}
+
+export async function bulkImportInboundCalls(
+  rawRows: Record<string, string>[],
+): Promise<ImportResult> {
+  let imported = 0;
+  const rowErrors: ImportResult["rowErrors"] = [];
+
+  for (let i = 0; i < rawRows.length; i++) {
+    const raw = rawRows[i];
+    const rowNum = i + 1;
+
+    const callDate = parseDate(raw["call_date"] ?? "");
+    if (!callDate) {
+      rowErrors.push({ row: rowNum, error: "Invalid or missing call_date" });
+      continue;
+    }
+
+    const weekStart = getMondayOf(callDate);
+
+    let calledBackResolved = false;
+    if (raw["called_back_resolved"] !== undefined && raw["called_back_resolved"].trim()) {
+      const b = parseBool(raw["called_back_resolved"]);
+      if (b === null) {
+        rowErrors.push({ row: rowNum, error: "Invalid called_back_resolved value" });
+        continue;
+      }
+      calledBackResolved = b;
+    }
+
+    const values: typeof inboundCallRecords.$inferInsert = {
+      weekStart,
+      callDate,
+      number: raw["number"]?.trim() || null,
+      transcript: raw["transcript"]?.trim() || null,
+      caseLink: raw["case_link"]?.trim() || null,
+      specialistAssigned: raw["specialist_assigned"]?.trim() || null,
+      calledBackResolved,
+    };
+
+    try {
+      await db.insert(inboundCallRecords).values(values);
+      imported++;
+    } catch {
+      rowErrors.push({ row: rowNum, error: "Database error — row skipped" });
+    }
+  }
+
+  return { imported, failed: rowErrors.length, rowErrors };
+}

--- a/src/app/(dashboard)/overpaid-cases/actions.ts
+++ b/src/app/(dashboard)/overpaid-cases/actions.ts
@@ -3,6 +3,9 @@
 import { db } from "@/lib/db";
 import { feeRecords, overpaidCases } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
+import { parseBool, parseDate, parseDecimalString } from "@/lib/import/csv-parser";
+import { resolveCaseId } from "@/lib/import/resolve-case";
+import type { ImportResult } from "@/components/modals/CsvImportModal";
 
 const FIELD_KEYS = ["overpaidAmount", "opLtrDate", "opLtrReceived", "checksCleared", "updateNote", "region"] as const;
 
@@ -141,4 +144,86 @@ export async function updateFeesConfirmation(input: {
     console.error("updateFeesConfirmation error:", error);
     return { ok: false, error: "Server error" };
   }
+}
+
+export async function bulkImportOverpaidCases(
+  rawRows: Record<string, string>[],
+): Promise<ImportResult> {
+  let imported = 0;
+  const rowErrors: ImportResult["rowErrors"] = [];
+
+  for (let i = 0; i < rawRows.length; i++) {
+    const raw = rawRows[i];
+    const rowNum = i + 1;
+
+    const resolved = await resolveCaseId(raw["client_id"] ?? "");
+    if ("error" in resolved) {
+      rowErrors.push({ row: rowNum, error: resolved.error });
+      continue;
+    }
+
+    const values: Partial<typeof overpaidCases.$inferInsert> & { caseId: number } = {
+      caseId: resolved.caseId,
+    };
+    let parseOk = true;
+
+    if (raw["op_ltr_date"] !== undefined && raw["op_ltr_date"].trim()) {
+      const d = parseDate(raw["op_ltr_date"]);
+      if (!d) { rowErrors.push({ row: rowNum, error: "Invalid op_ltr_date" }); parseOk = false; }
+      else values.opLtrDate = d;
+    }
+
+    if (parseOk && raw["op_ltr_received"] !== undefined && raw["op_ltr_received"].trim()) {
+      const d = parseDate(raw["op_ltr_received"]);
+      if (!d) { rowErrors.push({ row: rowNum, error: "Invalid op_ltr_received" }); parseOk = false; }
+      else values.opLtrReceived = d;
+    }
+
+    if (parseOk && raw["overpaid_amount"] !== undefined && raw["overpaid_amount"].trim()) {
+      const amount = parseDecimalString(raw["overpaid_amount"]);
+      if (!amount) { rowErrors.push({ row: rowNum, error: "Invalid overpaid_amount" }); parseOk = false; }
+      else values.overpaidAmount = amount;
+    }
+
+    if (parseOk && raw["checks_cleared"] !== undefined && raw["checks_cleared"].trim()) {
+      const b = parseBool(raw["checks_cleared"]);
+      if (b === null) { rowErrors.push({ row: rowNum, error: "Invalid checks_cleared value" }); parseOk = false; }
+      else {
+        values.checksCleared = b;
+        if (b) values.checksClearedAt = new Date();
+      }
+    }
+
+    if (parseOk && raw["region"] !== undefined) {
+      values.region = raw["region"].trim() || null;
+    }
+
+    if (parseOk && raw["update_note"] !== undefined) {
+      const note = raw["update_note"].trim();
+      if (note.length > 5000) { rowErrors.push({ row: rowNum, error: "update_note exceeds 5000 characters" }); parseOk = false; }
+      else values.updateNote = note;
+    }
+
+    if (!parseOk) continue;
+
+    try {
+      await db
+        .insert(overpaidCases)
+        .values(values)
+        .onConflictDoUpdate({
+          target: overpaidCases.caseId,
+          set: { ...values, updatedAt: new Date() },
+        });
+      // Mark the fee_record as overpaid so the page query picks it up
+      await db
+        .update(feeRecords)
+        .set({ markedOverpaid: true })
+        .where(eq(feeRecords.caseId, resolved.caseId));
+      imported++;
+    } catch {
+      rowErrors.push({ row: rowNum, error: "Database error — row skipped" });
+    }
+  }
+
+  return { imported, failed: rowErrors.length, rowErrors };
 }

--- a/src/app/(dashboard)/scoreboard/actions.ts
+++ b/src/app/(dashboard)/scoreboard/actions.ts
@@ -1,0 +1,93 @@
+"use server";
+
+import { db } from "@/lib/db";
+import { dailyMetrics } from "@/lib/db/schema";
+import { and, eq } from "drizzle-orm";
+import { parseDate, parseNonNegativeInt } from "@/lib/import/csv-parser";
+import type { ImportResult } from "@/components/modals/CsvImportModal";
+
+export async function bulkImportDailyMetrics(
+  rawRows: Record<string, string>[],
+): Promise<ImportResult> {
+  let imported = 0;
+  const rowErrors: ImportResult["rowErrors"] = [];
+
+  for (let i = 0; i < rawRows.length; i++) {
+    const raw = rawRows[i];
+    const rowNum = i + 1;
+
+    const agentName = raw["agent_name"]?.trim();
+    if (!agentName) {
+      rowErrors.push({ row: rowNum, error: "agent_name is required" });
+      continue;
+    }
+
+    const metricDate = parseDate(raw["metric_date"] ?? "");
+    if (!metricDate) {
+      rowErrors.push({ row: rowNum, error: "Invalid or missing metric_date" });
+      continue;
+    }
+
+    let parseOk = true;
+    const values = {
+      agentName,
+      metricDate,
+      ssaCalls: 0,
+      clientCallsIb: 0,
+      clientCallsOb: 0,
+      winSheetsCreated: 0,
+      notes: null as string | null,
+    };
+
+    for (const [csvKey, field] of [
+      ["ssa_calls", "ssaCalls"],
+      ["client_calls_ib", "clientCallsIb"],
+      ["client_calls_ob", "clientCallsOb"],
+      ["win_sheets_created", "winSheetsCreated"],
+    ] as const) {
+      if (raw[csvKey] !== undefined && raw[csvKey].trim()) {
+        const n = parseNonNegativeInt(raw[csvKey]);
+        if (n === null) {
+          rowErrors.push({ row: rowNum, error: `Invalid value for "${csvKey}" — must be a non-negative integer` });
+          parseOk = false;
+          break;
+        }
+        (values as Record<string, unknown>)[field] = n;
+      }
+    }
+
+    if (!parseOk) continue;
+
+    if (raw["notes"] !== undefined) {
+      values.notes = raw["notes"].trim() || null;
+    }
+
+    try {
+      // No unique constraint on (agentName, metricDate) — check then upsert
+      const existing = await db
+        .select({ id: dailyMetrics.id })
+        .from(dailyMetrics)
+        .where(
+          and(
+            eq(dailyMetrics.agentName, agentName),
+            eq(dailyMetrics.metricDate, metricDate),
+          ),
+        )
+        .limit(1);
+
+      if (existing.length) {
+        await db
+          .update(dailyMetrics)
+          .set({ ...values, updatedAt: new Date() })
+          .where(eq(dailyMetrics.id, existing[0].id));
+      } else {
+        await db.insert(dailyMetrics).values(values);
+      }
+      imported++;
+    } catch {
+      rowErrors.push({ row: rowNum, error: "Database error — row skipped" });
+    }
+  }
+
+  return { imported, failed: rowErrors.length, rowErrors };
+}

--- a/src/components/fee-petitions/FeePetitions.tsx
+++ b/src/components/fee-petitions/FeePetitions.tsx
@@ -16,14 +16,17 @@ import {
   ChevronLeft,
   ChevronRight,
   Download,
+  Upload,
   X,
   Undo2,
   ArchiveX,
 } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
 import { fmt, fmtDate } from "@/lib/formatters";
-import { upsertFeePetition, bulkMarkComplete, bulkRestoreChecklists } from "@/app/(dashboard)/fee-petitions/actions";
+import { upsertFeePetition, bulkMarkComplete, bulkRestoreChecklists, bulkImportFeePetitions } from "@/app/(dashboard)/fee-petitions/actions";
 import { useCapabilities } from "@/hooks/useCapabilities";
+import CsvImportModal, { type ColumnDef, type ImportResult } from "@/components/modals/CsvImportModal";
+import { parseBool } from "@/lib/import/csv-parser";
 
 // ---------- types ----------
 interface FeePetitionRow {
@@ -166,6 +169,7 @@ export const FeePetitions = () => {
   const [undoing, setUndoing] = useState(false);
   const [bulkCloseConfirming, setBulkCloseConfirming] = useState(false);
   const [bulkClosing, setBulkClosing] = useState(false);
+  const [csvImportOpen, setCsvImportOpen] = useState(false);
   const selectAllRef = useRef<HTMLInputElement>(null);
 
   const { can } = useCapabilities();
@@ -709,8 +713,55 @@ export const FeePetitions = () => {
   const presetBase = `shrink-0 px-2.5 py-1 rounded-full text-[11px] font-medium border transition-colors`;
   const colSpan = CHECKBOX_COLUMNS.length + 7;
 
+  const FP_CSV_COLUMNS: ColumnDef[] = [
+    { key: "client_id", label: "Client ID / Name", required: true, hint: "Integer client ID or \"First Last\" / \"Last, First\"" },
+    { key: "noa", label: "NOA", hint: "true/false/yes/no/1/0" },
+    { key: "time_delineation", label: "Time Delineation", hint: "true/false/yes/no/1/0" },
+    { key: "fee_petition_doc", label: "Fee Petition Doc", hint: "true/false/yes/no/1/0" },
+    { key: "ltr_to_clmt", label: "Ltr to Clmt", hint: "true/false/yes/no/1/0" },
+    { key: "ltr_to_clmt_with_signature", label: "Ltr to Clmt (Sig)", hint: "true/false/yes/no/1/0" },
+    { key: "ltr_to_alj", label: "Ltr to ALJ", hint: "true/false/yes/no/1/0" },
+    { key: "fax_conf_fee_pet", label: "Fax Conf Fee Pet", hint: "true/false/yes/no/1/0" },
+    { key: "update_note", label: "Update Note", hint: "Optional text, max 5000 chars" },
+  ];
+
+  const FP_TEMPLATE_CSV =
+    "client_id,noa,time_delineation,fee_petition_doc,ltr_to_clmt,ltr_to_clmt_with_signature,ltr_to_alj,fax_conf_fee_pet,update_note\n" +
+    "123456,true,true,false,false,false,false,false,Example note\n";
+
+  const validateFpRow = (raw: Record<string, string>): string[] => {
+    const errors: string[] = [];
+    if (!raw["client_id"]?.trim()) errors.push("client_id is required");
+    const boolKeys = ["noa", "time_delineation", "fee_petition_doc", "ltr_to_clmt", "ltr_to_clmt_with_signature", "ltr_to_alj", "fax_conf_fee_pet"];
+    for (const key of boolKeys) {
+      if (raw[key] !== undefined && raw[key].trim() && parseBool(raw[key]) === null) {
+        errors.push(`Invalid boolean for "${key}"`);
+      }
+    }
+    if (raw["update_note"] && raw["update_note"].length > 5000) errors.push("update_note too long");
+    return errors;
+  };
+
+  const handleFpImport = async (validRows: Record<string, string>[]): Promise<ImportResult> => {
+    return bulkImportFeePetitions(validRows);
+  };
+
   return (
     <div className="space-y-4">
+      {csvImportOpen && (
+        <CsvImportModal
+          dark={dark}
+          title="Import Fee Petitions"
+          description="Upload a CSV to bulk-upsert checklist data for fee petition cases."
+          columns={FP_CSV_COLUMNS}
+          templateFilename="fee-petitions-template.csv"
+          templateCsv={FP_TEMPLATE_CSV}
+          validateRow={validateFpRow}
+          onImport={handleFpImport}
+          onClose={() => setCsvImportOpen(false)}
+          onSuccess={fetchPetitions}
+        />
+      )}
       <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
         {liveMessage}
       </div>
@@ -954,6 +1005,14 @@ export const FeePetitions = () => {
               <span className="hidden sm:inline">
                 {selectedIds.size > 0 ? `Export ${selectedIds.size} selected` : "Export"}
               </span>
+            </button>
+            <button
+              onClick={() => setCsvImportOpen(true)}
+              className={`h-8 px-2.5 rounded-md border text-xs font-medium flex items-center gap-1.5 ${t.outlineBtn}`}
+              aria-label="Import from CSV"
+            >
+              <Upload aria-hidden="true" className="h-3.5 w-3.5" />
+              <span className="hidden sm:inline">Import</span>
             </button>
           </div>
         </div>

--- a/src/components/fee-petitions/FeePetitions.tsx
+++ b/src/components/fee-petitions/FeePetitions.tsx
@@ -25,7 +25,7 @@ import { themeClasses } from "@/lib/theme-classes";
 import { fmt, fmtDate } from "@/lib/formatters";
 import { upsertFeePetition, bulkMarkComplete, bulkRestoreChecklists, bulkImportFeePetitions } from "@/app/(dashboard)/fee-petitions/actions";
 import { useCapabilities } from "@/hooks/useCapabilities";
-import CsvImportModal, { type ColumnDef, type ImportResult } from "@/components/modals/CsvImportModal";
+import CsvImportModal, { type ColumnDef } from "@/components/modals/CsvImportModal";
 import { parseBool } from "@/lib/import/csv-parser";
 
 // ---------- types ----------
@@ -107,6 +107,37 @@ const patchPetition = async (
 ) => {
   const result = await upsertFeePetition({ caseId, fields: body });
   if (!result.ok) throw new Error(result.error);
+};
+
+// ---------- csv import config ----------
+const FP_CSV_COLUMNS: ColumnDef[] = [
+  { key: "client_id", label: "Client ID / Name", required: true, hint: "Integer client ID or \"First Last\" / \"Last, First\"" },
+  { key: "noa", label: "NOA", hint: "true/false/yes/no/1/0" },
+  { key: "time_delineation", label: "Time Delineation", hint: "true/false/yes/no/1/0" },
+  { key: "fee_petition_doc", label: "Fee Petition Doc", hint: "true/false/yes/no/1/0" },
+  { key: "ltr_to_clmt", label: "Ltr to Clmt", hint: "true/false/yes/no/1/0" },
+  { key: "ltr_to_clmt_with_signature", label: "Ltr to Clmt (Sig)", hint: "true/false/yes/no/1/0" },
+  { key: "ltr_to_alj", label: "Ltr to ALJ", hint: "true/false/yes/no/1/0" },
+  { key: "fax_conf_fee_pet", label: "Fax Conf Fee Pet", hint: "true/false/yes/no/1/0" },
+  { key: "update_note", label: "Update Note", hint: "Optional text, max 5000 chars" },
+];
+
+const FP_TEMPLATE_CSV =
+  "client_id,noa,time_delineation,fee_petition_doc,ltr_to_clmt,ltr_to_clmt_with_signature,ltr_to_alj,fax_conf_fee_pet,update_note\n" +
+  "123456,true,true,false,false,false,false,false,Example note\n";
+
+const FP_BOOL_KEYS = ["noa", "time_delineation", "fee_petition_doc", "ltr_to_clmt", "ltr_to_clmt_with_signature", "ltr_to_alj", "fax_conf_fee_pet"];
+
+const validateFpRow = (raw: Record<string, string>): string[] => {
+  const errors: string[] = [];
+  if (!raw["client_id"]?.trim()) errors.push("client_id is required");
+  for (const key of FP_BOOL_KEYS) {
+    if (raw[key] !== undefined && raw[key].trim() && parseBool(raw[key]) === null) {
+      errors.push(`Invalid boolean for "${key}"`);
+    }
+  }
+  if (raw["update_note"] && raw["update_note"].length > 5000) errors.push("update_note too long");
+  return errors;
 };
 
 // ---------- component ----------
@@ -713,39 +744,6 @@ export const FeePetitions = () => {
   const presetBase = `shrink-0 px-2.5 py-1 rounded-full text-[11px] font-medium border transition-colors`;
   const colSpan = CHECKBOX_COLUMNS.length + 7;
 
-  const FP_CSV_COLUMNS: ColumnDef[] = [
-    { key: "client_id", label: "Client ID / Name", required: true, hint: "Integer client ID or \"First Last\" / \"Last, First\"" },
-    { key: "noa", label: "NOA", hint: "true/false/yes/no/1/0" },
-    { key: "time_delineation", label: "Time Delineation", hint: "true/false/yes/no/1/0" },
-    { key: "fee_petition_doc", label: "Fee Petition Doc", hint: "true/false/yes/no/1/0" },
-    { key: "ltr_to_clmt", label: "Ltr to Clmt", hint: "true/false/yes/no/1/0" },
-    { key: "ltr_to_clmt_with_signature", label: "Ltr to Clmt (Sig)", hint: "true/false/yes/no/1/0" },
-    { key: "ltr_to_alj", label: "Ltr to ALJ", hint: "true/false/yes/no/1/0" },
-    { key: "fax_conf_fee_pet", label: "Fax Conf Fee Pet", hint: "true/false/yes/no/1/0" },
-    { key: "update_note", label: "Update Note", hint: "Optional text, max 5000 chars" },
-  ];
-
-  const FP_TEMPLATE_CSV =
-    "client_id,noa,time_delineation,fee_petition_doc,ltr_to_clmt,ltr_to_clmt_with_signature,ltr_to_alj,fax_conf_fee_pet,update_note\n" +
-    "123456,true,true,false,false,false,false,false,Example note\n";
-
-  const validateFpRow = (raw: Record<string, string>): string[] => {
-    const errors: string[] = [];
-    if (!raw["client_id"]?.trim()) errors.push("client_id is required");
-    const boolKeys = ["noa", "time_delineation", "fee_petition_doc", "ltr_to_clmt", "ltr_to_clmt_with_signature", "ltr_to_alj", "fax_conf_fee_pet"];
-    for (const key of boolKeys) {
-      if (raw[key] !== undefined && raw[key].trim() && parseBool(raw[key]) === null) {
-        errors.push(`Invalid boolean for "${key}"`);
-      }
-    }
-    if (raw["update_note"] && raw["update_note"].length > 5000) errors.push("update_note too long");
-    return errors;
-  };
-
-  const handleFpImport = async (validRows: Record<string, string>[]): Promise<ImportResult> => {
-    return bulkImportFeePetitions(validRows);
-  };
-
   return (
     <div className="space-y-4">
       {csvImportOpen && (
@@ -757,7 +755,7 @@ export const FeePetitions = () => {
           templateFilename="fee-petitions-template.csv"
           templateCsv={FP_TEMPLATE_CSV}
           validateRow={validateFpRow}
-          onImport={handleFpImport}
+          onImport={bulkImportFeePetitions}
           onClose={() => setCsvImportOpen(false)}
           onSuccess={fetchPetitions}
         />

--- a/src/components/inbound-calls/InboundCallsClient.tsx
+++ b/src/components/inbound-calls/InboundCallsClient.tsx
@@ -15,7 +15,7 @@ import {
   Upload,
 } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
-import CsvImportModal, { type ColumnDef, type ImportResult } from "@/components/modals/CsvImportModal";
+import CsvImportModal, { type ColumnDef } from "@/components/modals/CsvImportModal";
 import { bulkImportInboundCalls } from "@/app/(dashboard)/inbound-calls/actions";
 import { parseBool, parseDate } from "@/lib/import/csv-parser";
 
@@ -99,6 +99,30 @@ interface PocAssignments {
   4: string[];
   5: string[];
 }
+
+// ── csv import config ─────────────────────────────────────────────────────────
+
+const IC_CSV_COLUMNS: ColumnDef[] = [
+  { key: "call_date", label: "Call Date", required: true, hint: "YYYY-MM-DD or MM/DD/YYYY (week_start is derived automatically)" },
+  { key: "number", label: "Number", hint: "Phone number (optional)" },
+  { key: "transcript", label: "Transcript", hint: "Call notes (optional)" },
+  { key: "case_link", label: "Case Link", hint: "URL or case ID (optional)" },
+  { key: "specialist_assigned", label: "Specialist Assigned", hint: "Name (optional)" },
+  { key: "called_back_resolved", label: "Called Back / Resolved", hint: "true/false/yes/no/1/0" },
+];
+
+const IC_TEMPLATE_CSV =
+  "call_date,number,transcript,case_link,specialist_assigned,called_back_resolved\n" +
+  "2024-01-15,555-1234,Caller asked about status,https://...,Jane Smith,false\n";
+
+const validateIcRow = (raw: Record<string, string>): string[] => {
+  const errors: string[] = [];
+  if (!raw["call_date"]?.trim() || !parseDate(raw["call_date"])) errors.push("Invalid or missing call_date");
+  if (raw["called_back_resolved"]?.trim() && parseBool(raw["called_back_resolved"]) === null) {
+    errors.push("Invalid called_back_resolved value");
+  }
+  return errors;
+};
 
 // ── component ─────────────────────────────────────────────────────────────────
 
@@ -309,32 +333,6 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
 
   // ── render ─────────────────────────────────────────────────────────────────
 
-  const IC_CSV_COLUMNS: ColumnDef[] = [
-    { key: "call_date", label: "Call Date", required: true, hint: "YYYY-MM-DD or MM/DD/YYYY (week_start is derived automatically)" },
-    { key: "number", label: "Number", hint: "Phone number (optional)" },
-    { key: "transcript", label: "Transcript", hint: "Call notes (optional)" },
-    { key: "case_link", label: "Case Link", hint: "URL or case ID (optional)" },
-    { key: "specialist_assigned", label: "Specialist Assigned", hint: "Name (optional)" },
-    { key: "called_back_resolved", label: "Called Back / Resolved", hint: "true/false/yes/no/1/0" },
-  ];
-
-  const IC_TEMPLATE_CSV =
-    "call_date,number,transcript,case_link,specialist_assigned,called_back_resolved\n" +
-    "2024-01-15,555-1234,Caller asked about status,https://...,Jane Smith,false\n";
-
-  const validateIcRow = (raw: Record<string, string>): string[] => {
-    const errors: string[] = [];
-    if (!raw["call_date"]?.trim() || !parseDate(raw["call_date"])) errors.push("Invalid or missing call_date");
-    if (raw["called_back_resolved"]?.trim() && parseBool(raw["called_back_resolved"]) === null) {
-      errors.push("Invalid called_back_resolved value");
-    }
-    return errors;
-  };
-
-  const handleIcImport = async (validRows: Record<string, string>[]): Promise<ImportResult> => {
-    return bulkImportInboundCalls(validRows);
-  };
-
   return (
     <div className="space-y-4">
       {csvImportOpen && (
@@ -346,7 +344,7 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
           templateFilename="inbound-calls-template.csv"
           templateCsv={IC_TEMPLATE_CSV}
           validateRow={validateIcRow}
-          onImport={handleIcImport}
+          onImport={bulkImportInboundCalls}
           onClose={() => setCsvImportOpen(false)}
           onSuccess={() => void fetchRecords(selectedWeek)}
           defaultHeaderRow={2}

--- a/src/components/inbound-calls/InboundCallsClient.tsx
+++ b/src/components/inbound-calls/InboundCallsClient.tsx
@@ -12,8 +12,12 @@ import {
   Trash2,
   ChevronDown,
   Check,
+  Upload,
 } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
+import CsvImportModal, { type ColumnDef, type ImportResult } from "@/components/modals/CsvImportModal";
+import { bulkImportInboundCalls } from "@/app/(dashboard)/inbound-calls/actions";
+import { parseBool, parseDate } from "@/lib/import/csv-parser";
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -126,6 +130,7 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
   const [saving, setSaving] = useState<Record<number, boolean>>({});
   const [addingRow, setAddingRow] = useState(false);
   const [pendingDelete, setPendingDelete] = useState<number | null>(null);
+  const [csvImportOpen, setCsvImportOpen] = useState(false);
 
   const recordsControllerRef = useRef<AbortController | null>(null);
   const pocControllerRef = useRef<AbortController | null>(null);
@@ -304,8 +309,49 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
 
   // ── render ─────────────────────────────────────────────────────────────────
 
+  const IC_CSV_COLUMNS: ColumnDef[] = [
+    { key: "call_date", label: "Call Date", required: true, hint: "YYYY-MM-DD or MM/DD/YYYY (week_start is derived automatically)" },
+    { key: "number", label: "Number", hint: "Phone number (optional)" },
+    { key: "transcript", label: "Transcript", hint: "Call notes (optional)" },
+    { key: "case_link", label: "Case Link", hint: "URL or case ID (optional)" },
+    { key: "specialist_assigned", label: "Specialist Assigned", hint: "Name (optional)" },
+    { key: "called_back_resolved", label: "Called Back / Resolved", hint: "true/false/yes/no/1/0" },
+  ];
+
+  const IC_TEMPLATE_CSV =
+    "call_date,number,transcript,case_link,specialist_assigned,called_back_resolved\n" +
+    "2024-01-15,555-1234,Caller asked about status,https://...,Jane Smith,false\n";
+
+  const validateIcRow = (raw: Record<string, string>): string[] => {
+    const errors: string[] = [];
+    if (!raw["call_date"]?.trim() || !parseDate(raw["call_date"])) errors.push("Invalid or missing call_date");
+    if (raw["called_back_resolved"]?.trim() && parseBool(raw["called_back_resolved"]) === null) {
+      errors.push("Invalid called_back_resolved value");
+    }
+    return errors;
+  };
+
+  const handleIcImport = async (validRows: Record<string, string>[]): Promise<ImportResult> => {
+    return bulkImportInboundCalls(validRows);
+  };
+
   return (
     <div className="space-y-4">
+      {csvImportOpen && (
+        <CsvImportModal
+          dark={dark}
+          title="Import Inbound Calls"
+          description="Upload a CSV to bulk-insert call records. Each row creates a new record (no deduplication)."
+          columns={IC_CSV_COLUMNS}
+          templateFilename="inbound-calls-template.csv"
+          templateCsv={IC_TEMPLATE_CSV}
+          validateRow={validateIcRow}
+          onImport={handleIcImport}
+          onClose={() => setCsvImportOpen(false)}
+          onSuccess={() => void fetchRecords(selectedWeek)}
+          defaultHeaderRow={2}
+        />
+      )}
       {/* ── header bar ── */}
       <div className={`${card} px-4 py-3 flex items-center justify-between gap-3 flex-wrap`}>
         <div className="flex items-center gap-3">
@@ -457,17 +503,27 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
               <span className={`ml-2 text-[11px] font-normal ${t.textMuted}`}>{records.length} record{records.length !== 1 ? "s" : ""}</span>
             )}
           </span>
-          <button
-            onClick={addRow}
-            disabled={addingRow}
-            className="flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
-          >
-            {addingRow
-              ? <RefreshCw aria-hidden="true" className="h-3 w-3 animate-spin" />
-              : <Plus aria-hidden="true" className="h-3 w-3" />
-            }
-            Add row
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setCsvImportOpen(true)}
+              className={`flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg border transition-colors ${dark ? "border-neutral-600 text-neutral-300 hover:border-neutral-400" : "border-neutral-200 text-neutral-600 hover:border-neutral-400"}`}
+              aria-label="Import call records from CSV"
+            >
+              <Upload aria-hidden="true" className="h-3 w-3" />
+              Import CSV
+            </button>
+            <button
+              onClick={addRow}
+              disabled={addingRow}
+              className="flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            >
+              {addingRow
+                ? <RefreshCw aria-hidden="true" className="h-3 w-3 animate-spin" />
+                : <Plus aria-hidden="true" className="h-3 w-3" />
+              }
+              Add row
+            </button>
+          </div>
         </div>
 
         {recordsError && (

--- a/src/components/modals/CsvImportModal.tsx
+++ b/src/components/modals/CsvImportModal.tsx
@@ -1,0 +1,676 @@
+"use client";
+
+import { useRef, useState } from "react";
+import {
+  X,
+  Upload,
+  FileText,
+  CheckCircle2,
+  AlertTriangle,
+  RefreshCw,
+  ArrowRight,
+  ArrowLeft,
+} from "lucide-react";
+import { themeClasses } from "@/lib/theme-classes";
+import { parseCsvText, applyMapping, autoMapColumns } from "@/lib/import/csv-parser";
+
+export interface ColumnDef {
+  key: string;
+  /** Label exactly as it appears in the dashboard table header. */
+  label: string;
+  required?: boolean;
+  hint?: string;
+}
+
+export interface ImportResult {
+  imported: number;
+  failed: number;
+  rowErrors: Array<{ row: number; error: string }>;
+}
+
+interface ParsedRow {
+  rowNumber: number;
+  raw: Record<string, string>;
+  errors: string[];
+}
+
+interface CsvImportModalProps {
+  dark: boolean;
+  title: string;
+  description: string;
+  /** Each entry corresponds to a dashboard field (same labels as table headers). */
+  columns: ColumnDef[];
+  templateFilename: string;
+  templateCsv: string;
+  /** Client-side row validator; receives a row keyed by dashboard field keys. */
+  validateRow: (mapped: Record<string, string>, rowNumber: number) => string[];
+  /** Called with valid mapped rows; wraps the server action. */
+  onImport: (validRows: Record<string, string>[]) => Promise<ImportResult>;
+  onClose: () => void;
+  onSuccess: () => void;
+  /**
+   * Which row (1-indexed) contains the column headers.
+   * Rows above it are treated as metadata and ignored.
+   * Defaults to 1.
+   */
+  defaultHeaderRow?: number;
+}
+
+type Step = "upload" | "map" | "preview" | "importing" | "done";
+
+export default function CsvImportModal({
+  dark,
+  title,
+  description,
+  columns,
+  templateFilename,
+  templateCsv,
+  validateRow,
+  onImport,
+  onClose,
+  onSuccess,
+  defaultHeaderRow = 1,
+}: CsvImportModalProps) {
+  const t = themeClasses(dark);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [step, setStep] = useState<Step>("upload");
+  const [dragOver, setDragOver] = useState(false);
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [headerRow, setHeaderRow] = useState(defaultHeaderRow);
+  // Keep the raw file text so we can re-parse when headerRow changes
+  const [fileText, setFileText] = useState<string | null>(null);
+
+  // Raw CSV data
+  const [csvHeaders, setCsvHeaders] = useState<string[]>([]);
+  const [csvRows, setCsvRows] = useState<Record<string, string>[]>([]);
+
+  // Mapping: dashboardFieldKey → csvHeader (or "" to skip)
+  const [mapping, setMapping] = useState<Record<string, string>>({});
+
+  // Validated rows after mapping applied
+  const [parsedRows, setParsedRows] = useState<ParsedRow[]>([]);
+
+  const [importResult, setImportResult] = useState<ImportResult | null>(null);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const validRows = parsedRows.filter((r) => r.errors.length === 0);
+  const errorRows = parsedRows.filter((r) => r.errors.length > 0);
+
+  // ── file handling ──────────────────────────────────────────────────────────
+
+  const parseAndAdvance = (text: string, row: number) => {
+    const { headers, rows } = parseCsvText(text, row - 1); // prop is 1-indexed
+    if (!headers.length) { setParseError("No header row found at that position."); return; }
+    if (!rows.length) { setParseError("File has no data rows after the header."); return; }
+    setParseError(null);
+    setCsvHeaders(headers);
+    setCsvRows(rows);
+    const suggested = autoMapColumns(
+      columns.map((c) => c.key),
+      columns.map((c) => c.label),
+      headers,
+    );
+    setMapping(suggested);
+    setStep("map");
+  };
+
+  const readFile = (file: File) => {
+    if (!/\.csv$/i.test(file.name)) {
+      setParseError("Only .csv files are supported.");
+      return;
+    }
+    setParseError(null);
+    setFileName(file.name);
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const text = e.target?.result;
+      if (typeof text !== "string") { setParseError("Could not read file."); return; }
+      setFileText(text);
+      parseAndAdvance(text, headerRow);
+    };
+    reader.readAsText(file);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setDragOver(false);
+    const file = e.dataTransfer.files?.[0];
+    if (file) readFile(file);
+  };
+
+  // ── apply mapping → validate ───────────────────────────────────────────────
+
+  const FOOTER_LABELS = new Set([
+    "total", "total amount", "grand total", "subtotal", "sum", "totals",
+  ]);
+
+  const applyAndPreview = () => {
+    const mapped = applyMapping(csvRows, mapping);
+    const parsed: ParsedRow[] = [];
+    mapped.forEach((row, i) => {
+      // Silently skip blank padding rows
+      if (Object.values(row).every((v) => !v)) return;
+      // Silently skip aggregate footer rows (e.g. "TOTAL AMOUNT" summary row)
+      if (Object.values(row).some((v) => FOOTER_LABELS.has(v.trim().toLowerCase()))) return;
+      parsed.push({
+        rowNumber: i + 1,
+        raw: row,
+        errors: validateRow(row, i + 1),
+      });
+    });
+    setParsedRows(parsed);
+    setServerError(null);
+    setStep("preview");
+  };
+
+  // ── import ─────────────────────────────────────────────────────────────────
+
+  const handleImport = async () => {
+    if (!validRows.length) return;
+    setStep("importing");
+    setServerError(null);
+    try {
+      const result = await onImport(validRows.map((r) => r.raw));
+      setImportResult(result);
+      setStep("done");
+      if (result.imported > 0) onSuccess();
+    } catch (err) {
+      setServerError((err as Error).message ?? "Import failed");
+      setStep("preview");
+    }
+  };
+
+  // ── helpers ────────────────────────────────────────────────────────────────
+
+  const downloadTemplate = () => {
+    const blob = new Blob([templateCsv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = templateFilename;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const requiredUnmapped = columns.filter(
+    (c) => c.required && !mapping[c.key],
+  );
+
+  const STEPS: { id: Step; label: string }[] = [
+    { id: "upload", label: "Upload" },
+    { id: "map", label: "Map columns" },
+    { id: "preview", label: "Preview" },
+  ];
+  const activeStepIndex = STEPS.findIndex((s) => s.id === step);
+
+  const lblCls = `text-[10px] font-semibold uppercase tracking-wider ${t.textMuted}`;
+  const errBg = dark
+    ? "bg-red-900/20 border-red-800 text-red-300"
+    : "bg-red-50 border-red-200 text-red-700";
+  const warnBg = dark
+    ? "bg-amber-900/20 border-amber-800 text-amber-300"
+    : "bg-amber-50 border-amber-200 text-amber-700";
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      onClick={onClose}
+    >
+      <div className="absolute inset-0 bg-black/50" />
+      <div
+        className={`relative w-full max-w-3xl max-h-[92vh] overflow-hidden flex flex-col rounded-xl border ${t.card} mx-4`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className={`flex items-center justify-between px-5 py-3 border-b ${t.borderLight}`}>
+          <div>
+            <h3 className={`text-sm font-bold ${t.text}`}>{title}</h3>
+            <p className={`text-[11px] ${t.textMuted} mt-0.5`}>{description}</p>
+          </div>
+          <button
+            onClick={onClose}
+            className={`h-7 w-7 rounded-md flex items-center justify-center ${t.hover} ${t.textSub}`}
+            aria-label="Close"
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+
+        {/* Step indicator */}
+        {(step === "upload" || step === "map" || step === "preview") && (
+          <div className={`grid grid-cols-3 gap-1 p-1.5 ${dark ? "bg-neutral-900/50" : "bg-neutral-50"} border-b ${t.borderLight}`}>
+            {STEPS.map((s, idx) => {
+              const isActive = s.id === step;
+              const isDone = idx < activeStepIndex;
+              return (
+                <div
+                  key={s.id}
+                  className={`text-center py-1.5 rounded-md text-[11px] font-medium transition-colors ${
+                    isActive
+                      ? dark ? "bg-neutral-100 text-neutral-900" : "bg-neutral-900 text-white"
+                      : isDone
+                        ? dark ? "text-neutral-300" : "text-neutral-500"
+                        : dark ? "text-neutral-600" : "text-neutral-300"
+                  }`}
+                >
+                  {idx + 1}. {s.label}
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto p-5 space-y-4">
+
+          {/* ── STEP 1: UPLOAD ── */}
+          {step === "upload" && (
+            <>
+              {parseError && (
+                <div role="alert" className={`rounded-md border p-3 text-xs ${errBg}`}>
+                  {parseError}
+                </div>
+              )}
+
+              <div
+                onClick={() => fileInputRef.current?.click()}
+                onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
+                onDragLeave={() => setDragOver(false)}
+                onDrop={handleDrop}
+                className={`rounded-lg border-2 border-dashed p-10 text-center cursor-pointer transition-colors ${
+                  dragOver
+                    ? dark ? "border-blue-500 bg-blue-900/10" : "border-blue-400 bg-blue-50"
+                    : dark ? "border-neutral-700 hover:border-neutral-500" : "border-neutral-300 hover:border-neutral-400"
+                }`}
+              >
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".csv"
+                  className="hidden"
+                  onChange={(e) => { const f = e.target.files?.[0]; if (f) readFile(f); }}
+                />
+                <FileText className={`h-8 w-8 mx-auto mb-3 ${t.textMuted}`} aria-hidden="true" />
+                <p className={`text-sm font-semibold ${t.text}`}>
+                  {fileName ?? "Drag & drop a CSV file, or click to browse"}
+                </p>
+                <p className={`text-[11px] mt-1 ${t.textMuted}`}>Only .csv files. Any column names — you'll map them in the next step.</p>
+              </div>
+
+              {/* Header row selector */}
+              <div className={`flex items-center gap-3 px-1`}>
+                <label className={`text-[11px] font-medium ${t.textSub} shrink-0`}>
+                  Column headers are on row:
+                </label>
+                <div className="flex items-center gap-1">
+                  {[1, 2, 3, 4].map((n) => (
+                    <button
+                      key={n}
+                      type="button"
+                      onClick={() => {
+                        setHeaderRow(n);
+                        if (fileText) parseAndAdvance(fileText, n);
+                      }}
+                      className={`h-7 w-7 rounded-md border text-[11px] font-semibold transition-colors ${
+                        headerRow === n
+                          ? dark ? "bg-neutral-100 text-neutral-900 border-neutral-100" : "bg-neutral-900 text-white border-neutral-900"
+                          : `${t.outlineBtn}`
+                      }`}
+                    >
+                      {n}
+                    </button>
+                  ))}
+                </div>
+                <p className={`text-[11px] ${t.textMuted}`}>
+                  {headerRow > 1 ? `Rows 1–${headerRow - 1} will be skipped as metadata.` : "Row 1 is the header row."}
+                </p>
+              </div>
+
+              <div className={`rounded-lg border ${t.borderLight} overflow-hidden`}>
+                <div className={`px-3 py-2 border-b ${t.borderLight} flex items-center justify-between`}>
+                  <span className={lblCls}>Dashboard fields available for import</span>
+                  <button
+                    onClick={downloadTemplate}
+                    className={`text-[11px] font-medium underline ${t.textSub} hover:opacity-80`}
+                  >
+                    Download template
+                  </button>
+                </div>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-[11px]">
+                    <thead>
+                      <tr className={`border-b ${t.borderLight} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"}`}>
+                        <th className={`${lblCls} text-left px-3 py-2`}>Field</th>
+                        <th className={`${lblCls} text-left px-3 py-2`}>Notes</th>
+                        <th className={`${lblCls} text-center px-3 py-2 w-20`}>Required</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {columns.map((col) => (
+                        <tr key={col.key} className={`border-b last:border-b-0 ${t.borderLight}`}>
+                          <td className={`${t.text} px-3 py-1.5 font-medium`}>{col.label}</td>
+                          <td className={`${t.textSub} px-3 py-1.5`}>{col.hint ?? "—"}</td>
+                          <td className="px-3 py-1.5 text-center">
+                            {col.required ? (
+                              <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${dark ? "bg-red-900/40 text-red-400" : "bg-red-50 text-red-600"}`}>
+                                YES
+                              </span>
+                            ) : (
+                              <span className={`text-[10px] ${t.textMuted}`}>opt</span>
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </>
+          )}
+
+          {/* ── STEP 2: MAP COLUMNS ── */}
+          {step === "map" && (
+            <>
+              <div className={`rounded-md border p-3 text-[11px] ${dark ? "bg-neutral-800/60 border-neutral-700 text-neutral-300" : "bg-neutral-50 border-neutral-200 text-neutral-600"}`}>
+                <p>
+                  Your file has <span className="font-semibold">{csvHeaders.length} columns</span> and{" "}
+                  <span className="font-semibold">{csvRows.length} rows</span>.
+                  For each dashboard field below, pick the matching column from your CSV.
+                  Leave optional fields on <span className="font-semibold">— Skip —</span> to ignore them.
+                </p>
+              </div>
+
+              {requiredUnmapped.length > 0 && (
+                <div role="alert" className={`rounded-md border p-3 text-[11px] flex items-start gap-2 ${warnBg}`}>
+                  <AlertTriangle className="h-3.5 w-3.5 shrink-0 mt-0.5" aria-hidden="true" />
+                  <span>
+                    Required field{requiredUnmapped.length !== 1 ? "s" : ""} not yet mapped:{" "}
+                    <span className="font-semibold">{requiredUnmapped.map((c) => c.label).join(", ")}</span>
+                  </span>
+                </div>
+              )}
+
+              <div className={`rounded-lg border ${t.borderLight} overflow-hidden`}>
+                <table className="w-full text-[12px]">
+                  <thead>
+                    <tr className={`border-b ${t.borderLight} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"}`}>
+                      <th className={`${lblCls} text-left px-3 py-2`}>Dashboard field</th>
+                      <th className={`${lblCls} text-left px-3 py-2 hidden sm:table-cell`}>Notes</th>
+                      <th className={`${lblCls} text-left px-3 py-2`}>Your CSV column</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {columns.map((col) => {
+                      const isMapped = !!mapping[col.key];
+                      const isReqUnmapped = col.required && !isMapped;
+                      return (
+                        <tr key={col.key} className={`border-b last:border-b-0 ${t.borderLight}`}>
+                          <td className={`px-3 py-2 font-medium ${isReqUnmapped ? (dark ? "text-red-400" : "text-red-600") : t.text}`}>
+                            {col.label}
+                            {col.required && (
+                              <span className="ml-1 text-red-500" aria-label="required">*</span>
+                            )}
+                          </td>
+                          <td className={`px-3 py-2 ${t.textMuted} text-[11px] hidden sm:table-cell`}>
+                            {col.hint ?? "—"}
+                          </td>
+                          <td className="px-3 py-2">
+                            <select
+                              value={mapping[col.key] ?? ""}
+                              onChange={(e) =>
+                                setMapping((prev) => ({ ...prev, [col.key]: e.target.value }))
+                              }
+                              className={`w-full h-7 px-2 rounded-md border text-[11px] outline-none cursor-pointer ${
+                                isReqUnmapped
+                                  ? dark ? "border-red-700 bg-neutral-900 text-red-300" : "border-red-300 bg-white text-red-700"
+                                  : t.inputBg
+                              }`}
+                            >
+                              <option value="">— Skip —</option>
+                              {csvHeaders.map((h, i) => (
+                                <option key={`${h}-${i}`} value={h}>{h}</option>
+                              ))}
+                            </select>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+
+              {/* CSV header preview */}
+              <div className={`text-[11px] ${t.textMuted}`}>
+                Columns detected in your file:{" "}
+                {csvHeaders.map((h, i) => (
+                  <span key={`${h}-${i}`}>
+                    <span className={`font-mono ${t.textSub}`}>{h}</span>
+                    {i < csvHeaders.length - 1 ? ", " : ""}
+                  </span>
+                ))}
+              </div>
+            </>
+          )}
+
+          {/* ── STEP 3: PREVIEW ── */}
+          {step === "preview" && (
+            <>
+              {serverError && (
+                <div role="alert" className={`rounded-md border p-3 text-xs ${errBg}`}>{serverError}</div>
+              )}
+
+              <div className="grid grid-cols-3 gap-3">
+                {[
+                  { label: "Total rows", value: parsedRows.length, color: t.text },
+                  { label: "Valid", value: validRows.length, color: dark ? "text-emerald-400" : "text-emerald-600" },
+                  { label: "Errors", value: errorRows.length, color: errorRows.length ? (dark ? "text-red-400" : "text-red-600") : t.textMuted },
+                ].map((s) => (
+                  <div key={s.label} className={`rounded-lg border ${t.borderLight} p-3`}>
+                    <p className={lblCls}>{s.label}</p>
+                    <p className={`text-lg font-bold tabular-nums mt-0.5 ${s.color}`}>{s.value}</p>
+                  </div>
+                ))}
+              </div>
+
+              {errorRows.length > 0 && (
+                <div className={`rounded-md border p-3 text-[11px] ${warnBg}`}>
+                  <div className="flex items-center gap-1.5 font-semibold mb-1">
+                    <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
+                    {errorRows.length} row{errorRows.length !== 1 ? "s" : ""} will be skipped
+                  </div>
+                  <ul className="space-y-0.5 max-h-28 overflow-y-auto">
+                    {errorRows.slice(0, 15).map((r) => (
+                      <li key={r.rowNumber}>Row {r.rowNumber}: {r.errors.join("; ")}</li>
+                    ))}
+                    {errorRows.length > 15 && (
+                      <li className="opacity-60">…and {errorRows.length - 15} more</li>
+                    )}
+                  </ul>
+                </div>
+              )}
+
+              <div className={`rounded-lg border ${t.borderLight} overflow-hidden`}>
+                <div className="overflow-x-auto max-h-72 overflow-y-auto">
+                  <table className="w-full text-[11px]">
+                    <thead className="sticky top-0">
+                      <tr className={`border-b ${t.borderLight} ${dark ? "bg-neutral-900" : "bg-neutral-50"}`}>
+                        <th className={`${lblCls} text-left px-3 py-2 w-10`}>#</th>
+                        <th className={`${lblCls} text-left px-3 py-2 w-16`}>Status</th>
+                        {/* Show first 4 mapped fields as preview columns */}
+                        {columns
+                          .filter((c) => mapping[c.key])
+                          .slice(0, 4)
+                          .map((col) => (
+                            <th key={col.key} className={`${lblCls} text-left px-3 py-2`}>
+                              {col.label}
+                            </th>
+                          ))}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {parsedRows.slice(0, 200).map((row) => {
+                        const hasError = row.errors.length > 0;
+                        return (
+                          <tr
+                            key={row.rowNumber}
+                            title={hasError ? row.errors.join("; ") : undefined}
+                            className={`border-b last:border-b-0 ${t.borderLight} ${
+                              hasError
+                                ? dark ? "bg-red-900/10" : "bg-red-50/60"
+                                : ""
+                            }`}
+                          >
+                            <td className={`px-3 py-1.5 ${t.textMuted} tabular-nums`}>{row.rowNumber}</td>
+                            <td className="px-3 py-1.5">
+                              {hasError ? (
+                                <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${dark ? "bg-red-900/40 text-red-400" : "bg-red-100 text-red-700"}`}>
+                                  ERR
+                                </span>
+                              ) : (
+                                <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${dark ? "bg-emerald-900/40 text-emerald-400" : "bg-emerald-100 text-emerald-700"}`}>
+                                  OK
+                                </span>
+                              )}
+                            </td>
+                            {columns
+                              .filter((c) => mapping[c.key])
+                              .slice(0, 4)
+                              .map((col) => (
+                                <td key={col.key} className={`px-3 py-1.5 ${t.textSub} max-w-40 truncate`}>
+                                  {row.raw[col.key] || "—"}
+                                </td>
+                              ))}
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+                {parsedRows.length > 200 && (
+                  <div className={`px-3 py-2 text-[11px] ${t.textMuted} border-t ${t.borderLight} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"}`}>
+                    Showing first 200 of {parsedRows.length} rows. All valid rows will be imported.
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+
+          {/* ── IMPORTING ── */}
+          {step === "importing" && (
+            <div className="flex flex-col items-center justify-center py-16 gap-3">
+              <RefreshCw className={`h-6 w-6 animate-spin ${t.textMuted}`} aria-hidden="true" />
+              <p className={`text-sm ${t.textSub}`}>
+                Importing {validRows.length} row{validRows.length !== 1 ? "s" : ""}…
+              </p>
+            </div>
+          )}
+
+          {/* ── DONE ── */}
+          {step === "done" && importResult && (
+            <div className="py-8">
+              <div className={`max-w-md mx-auto rounded-lg border p-5 ${
+                importResult.imported > 0
+                  ? dark ? "bg-emerald-900/20 border-emerald-800 text-emerald-300" : "bg-emerald-50 border-emerald-200 text-emerald-800"
+                  : dark ? "bg-amber-900/20 border-amber-800 text-amber-300" : "bg-amber-50 border-amber-200 text-amber-800"
+              }`}>
+                <div className="flex items-start gap-3">
+                  <CheckCircle2 className="h-5 w-5 mt-0.5 shrink-0" aria-hidden="true" />
+                  <div className="text-[13px]">
+                    <p className="font-bold">
+                      {importResult.imported} row{importResult.imported !== 1 ? "s" : ""} imported.
+                    </p>
+                    {importResult.failed > 0 && (
+                      <p className="opacity-90 mt-1">
+                        {importResult.failed} row{importResult.failed !== 1 ? "s" : ""} failed.
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </div>
+
+              {importResult.rowErrors.length > 0 && (
+                <div className={`mt-3 max-w-md mx-auto rounded-md border p-3 text-[11px] ${warnBg}`}>
+                  <p className="font-semibold mb-1">Row errors:</p>
+                  <ul className="space-y-0.5 max-h-32 overflow-y-auto">
+                    {importResult.rowErrors.map((e, i) => (
+                      <li key={i}>Row {e.row}: {e.error}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className={`flex items-center justify-between px-5 py-3 border-t ${t.borderLight}`}>
+          {/* Left: back / cancel */}
+          <div>
+            {step === "map" && (
+              <button
+                onClick={() => setStep("upload")}
+                className={`h-8 px-3 text-xs font-medium flex items-center gap-1 ${t.textSub} hover:underline`}
+              >
+                <ArrowLeft className="h-3 w-3" aria-hidden="true" />
+                Back
+              </button>
+            )}
+            {step === "preview" && (
+              <button
+                onClick={() => setStep("map")}
+                className={`h-8 px-3 text-xs font-medium flex items-center gap-1 ${t.textSub} hover:underline`}
+              >
+                <ArrowLeft className="h-3 w-3" aria-hidden="true" />
+                Back
+              </button>
+            )}
+            {step === "upload" && (
+              <button
+                onClick={onClose}
+                className={`h-8 px-4 rounded-md text-xs font-medium border ${t.outlineBtn}`}
+              >
+                Cancel
+              </button>
+            )}
+          </div>
+
+          {/* Right: next / import / done */}
+          <div>
+            {step === "map" && (
+              <button
+                onClick={applyAndPreview}
+                disabled={requiredUnmapped.length > 0}
+                className={`h-8 px-4 rounded-md text-xs font-semibold flex items-center gap-1.5 ${t.ctaBtn} disabled:opacity-50`}
+              >
+                Preview
+                <ArrowRight className="h-3 w-3" aria-hidden="true" />
+              </button>
+            )}
+
+            {step === "preview" && (
+              <button
+                onClick={handleImport}
+                disabled={validRows.length === 0}
+                className={`h-8 px-4 rounded-md text-xs font-semibold flex items-center gap-1.5 ${t.ctaBtn} disabled:opacity-50`}
+              >
+                <Upload className="h-3 w-3" aria-hidden="true" />
+                Import {validRows.length} row{validRows.length !== 1 ? "s" : ""}
+              </button>
+            )}
+
+            {step === "done" && (
+              <button
+                onClick={onClose}
+                className={`h-8 px-4 rounded-md text-xs font-semibold ${t.ctaBtn}`}
+              >
+                Done
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/modals/CsvImportModal.tsx
+++ b/src/components/modals/CsvImportModal.tsx
@@ -58,6 +58,16 @@ interface CsvImportModalProps {
 
 type Step = "upload" | "map" | "preview" | "importing" | "done";
 
+const FOOTER_LABELS = new Set([
+  "total", "total amount", "grand total", "subtotal", "sum", "totals",
+]);
+
+const STEPS: { id: Step; label: string }[] = [
+  { id: "upload", label: "Upload" },
+  { id: "map", label: "Map columns" },
+  { id: "preview", label: "Preview" },
+];
+
 export default function CsvImportModal({
   dark,
   title,
@@ -142,10 +152,6 @@ export default function CsvImportModal({
 
   // ── apply mapping → validate ───────────────────────────────────────────────
 
-  const FOOTER_LABELS = new Set([
-    "total", "total amount", "grand total", "subtotal", "sum", "totals",
-  ]);
-
   const applyAndPreview = () => {
     const mapped = applyMapping(csvRows, mapping);
     const parsed: ParsedRow[] = [];
@@ -198,11 +204,6 @@ export default function CsvImportModal({
     (c) => c.required && !mapping[c.key],
   );
 
-  const STEPS: { id: Step; label: string }[] = [
-    { id: "upload", label: "Upload" },
-    { id: "map", label: "Map columns" },
-    { id: "preview", label: "Preview" },
-  ];
   const activeStepIndex = STEPS.findIndex((s) => s.id === step);
 
   const lblCls = `text-[10px] font-semibold uppercase tracking-wider ${t.textMuted}`;

--- a/src/components/overpaid-cases/OverpaidCases.tsx
+++ b/src/components/overpaid-cases/OverpaidCases.tsx
@@ -23,7 +23,7 @@ import {
 import { themeClasses } from "@/lib/theme-classes";
 import { fmt, fmtFull } from "@/lib/formatters";
 import { upsertOverpaidCase, updateFeesConfirmation, bulkMarkCleared, bulkRestoreCleared, bulkImportOverpaidCases } from "@/app/(dashboard)/overpaid-cases/actions";
-import CsvImportModal, { type ColumnDef, type ImportResult } from "@/components/modals/CsvImportModal";
+import CsvImportModal, { type ColumnDef } from "@/components/modals/CsvImportModal";
 import { parseBool, parseDate, parseDecimalString } from "@/lib/import/csv-parser";
 
 // ---------- types ----------
@@ -82,6 +82,32 @@ const patchCase = async (
 ) => {
   const result = await upsertOverpaidCase({ caseId, fields: body as Parameters<typeof upsertOverpaidCase>[0]["fields"] });
   if (!result.ok) throw new Error(result.error);
+};
+
+// ---------- csv import config ----------
+const OC_CSV_COLUMNS: ColumnDef[] = [
+  { key: "client_id", label: "Client ID / Name", required: true, hint: "Integer client ID or \"First Last\" / \"Last, First\"" },
+  { key: "op_ltr_date", label: "OP Ltr Date", hint: "YYYY-MM-DD or MM/DD/YYYY" },
+  { key: "op_ltr_received", label: "OP Ltr Received", hint: "YYYY-MM-DD or MM/DD/YYYY" },
+  { key: "overpaid_amount", label: "Overpaid Amount", hint: "Decimal, e.g. 1234.56" },
+  { key: "checks_cleared", label: "Checks Cleared", hint: "true/false/yes/no/1/0" },
+  { key: "region", label: "Region", hint: "Optional text" },
+  { key: "update_note", label: "Update Note", hint: "Optional text, max 5000 chars" },
+];
+
+const OC_TEMPLATE_CSV =
+  "client_id,op_ltr_date,op_ltr_received,overpaid_amount,checks_cleared,region,update_note\n" +
+  "123456,2024-01-15,2024-01-20,1500.00,false,Region A,Example note\n";
+
+const validateOcRow = (raw: Record<string, string>): string[] => {
+  const errors: string[] = [];
+  if (!raw["client_id"]?.trim()) errors.push("client_id is required");
+  if (raw["op_ltr_date"]?.trim() && !parseDate(raw["op_ltr_date"])) errors.push("Invalid op_ltr_date");
+  if (raw["op_ltr_received"]?.trim() && !parseDate(raw["op_ltr_received"])) errors.push("Invalid op_ltr_received");
+  if (raw["overpaid_amount"]?.trim() && !parseDecimalString(raw["overpaid_amount"])) errors.push("Invalid overpaid_amount");
+  if (raw["checks_cleared"]?.trim() && parseBool(raw["checks_cleared"]) === null) errors.push("Invalid checks_cleared value");
+  if (raw["update_note"] && raw["update_note"].length > 5000) errors.push("update_note too long");
+  return errors;
 };
 
 // ---------- component ----------
@@ -745,35 +771,6 @@ export const OverpaidCases = () => {
     : "bg-indigo-100 border-indigo-400 text-indigo-800";
   const presetBase = `shrink-0 px-2.5 py-1 rounded-full text-[11px] font-medium border transition-colors`;
 
-  const OC_CSV_COLUMNS: ColumnDef[] = [
-    { key: "client_id", label: "Client ID / Name", required: true, hint: "Integer client ID or \"First Last\" / \"Last, First\"" },
-    { key: "op_ltr_date", label: "OP Ltr Date", hint: "YYYY-MM-DD or MM/DD/YYYY" },
-    { key: "op_ltr_received", label: "OP Ltr Received", hint: "YYYY-MM-DD or MM/DD/YYYY" },
-    { key: "overpaid_amount", label: "Overpaid Amount", hint: "Decimal, e.g. 1234.56" },
-    { key: "checks_cleared", label: "Checks Cleared", hint: "true/false/yes/no/1/0" },
-    { key: "region", label: "Region", hint: "Optional text" },
-    { key: "update_note", label: "Update Note", hint: "Optional text, max 5000 chars" },
-  ];
-
-  const OC_TEMPLATE_CSV =
-    "client_id,op_ltr_date,op_ltr_received,overpaid_amount,checks_cleared,region,update_note\n" +
-    "123456,2024-01-15,2024-01-20,1500.00,false,Region A,Example note\n";
-
-  const validateOcRow = (raw: Record<string, string>): string[] => {
-    const errors: string[] = [];
-    if (!raw["client_id"]?.trim()) errors.push("client_id is required");
-    if (raw["op_ltr_date"]?.trim() && !parseDate(raw["op_ltr_date"])) errors.push("Invalid op_ltr_date");
-    if (raw["op_ltr_received"]?.trim() && !parseDate(raw["op_ltr_received"])) errors.push("Invalid op_ltr_received");
-    if (raw["overpaid_amount"]?.trim() && !parseDecimalString(raw["overpaid_amount"])) errors.push("Invalid overpaid_amount");
-    if (raw["checks_cleared"]?.trim() && parseBool(raw["checks_cleared"]) === null) errors.push("Invalid checks_cleared value");
-    if (raw["update_note"] && raw["update_note"].length > 5000) errors.push("update_note too long");
-    return errors;
-  };
-
-  const handleOcImport = async (validRows: Record<string, string>[]): Promise<ImportResult> => {
-    return bulkImportOverpaidCases(validRows);
-  };
-
   return (
     <div className="space-y-4">
       {csvImportOpen && (
@@ -785,7 +782,7 @@ export const OverpaidCases = () => {
           templateFilename="overpaid-cases-template.csv"
           templateCsv={OC_TEMPLATE_CSV}
           validateRow={validateOcRow}
-          onImport={handleOcImport}
+          onImport={bulkImportOverpaidCases}
           onClose={() => setCsvImportOpen(false)}
           onSuccess={fetchCases}
         />

--- a/src/components/overpaid-cases/OverpaidCases.tsx
+++ b/src/components/overpaid-cases/OverpaidCases.tsx
@@ -16,12 +16,15 @@ import {
   ChevronLeft,
   ChevronRight,
   Download,
+  Upload,
   X,
   Undo2,
 } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
 import { fmt, fmtFull } from "@/lib/formatters";
-import { upsertOverpaidCase, updateFeesConfirmation, bulkMarkCleared, bulkRestoreCleared } from "@/app/(dashboard)/overpaid-cases/actions";
+import { upsertOverpaidCase, updateFeesConfirmation, bulkMarkCleared, bulkRestoreCleared, bulkImportOverpaidCases } from "@/app/(dashboard)/overpaid-cases/actions";
+import CsvImportModal, { type ColumnDef, type ImportResult } from "@/components/modals/CsvImportModal";
+import { parseBool, parseDate, parseDecimalString } from "@/lib/import/csv-parser";
 
 // ---------- types ----------
 interface OverpaidCaseRow {
@@ -657,6 +660,7 @@ export const OverpaidCases = () => {
   };
 
   const [exporting, setExporting] = useState(false);
+  const [csvImportOpen, setCsvImportOpen] = useState(false);
 
   const downloadCsv = async () => {
     setExporting(true);
@@ -741,8 +745,51 @@ export const OverpaidCases = () => {
     : "bg-indigo-100 border-indigo-400 text-indigo-800";
   const presetBase = `shrink-0 px-2.5 py-1 rounded-full text-[11px] font-medium border transition-colors`;
 
+  const OC_CSV_COLUMNS: ColumnDef[] = [
+    { key: "client_id", label: "Client ID / Name", required: true, hint: "Integer client ID or \"First Last\" / \"Last, First\"" },
+    { key: "op_ltr_date", label: "OP Ltr Date", hint: "YYYY-MM-DD or MM/DD/YYYY" },
+    { key: "op_ltr_received", label: "OP Ltr Received", hint: "YYYY-MM-DD or MM/DD/YYYY" },
+    { key: "overpaid_amount", label: "Overpaid Amount", hint: "Decimal, e.g. 1234.56" },
+    { key: "checks_cleared", label: "Checks Cleared", hint: "true/false/yes/no/1/0" },
+    { key: "region", label: "Region", hint: "Optional text" },
+    { key: "update_note", label: "Update Note", hint: "Optional text, max 5000 chars" },
+  ];
+
+  const OC_TEMPLATE_CSV =
+    "client_id,op_ltr_date,op_ltr_received,overpaid_amount,checks_cleared,region,update_note\n" +
+    "123456,2024-01-15,2024-01-20,1500.00,false,Region A,Example note\n";
+
+  const validateOcRow = (raw: Record<string, string>): string[] => {
+    const errors: string[] = [];
+    if (!raw["client_id"]?.trim()) errors.push("client_id is required");
+    if (raw["op_ltr_date"]?.trim() && !parseDate(raw["op_ltr_date"])) errors.push("Invalid op_ltr_date");
+    if (raw["op_ltr_received"]?.trim() && !parseDate(raw["op_ltr_received"])) errors.push("Invalid op_ltr_received");
+    if (raw["overpaid_amount"]?.trim() && !parseDecimalString(raw["overpaid_amount"])) errors.push("Invalid overpaid_amount");
+    if (raw["checks_cleared"]?.trim() && parseBool(raw["checks_cleared"]) === null) errors.push("Invalid checks_cleared value");
+    if (raw["update_note"] && raw["update_note"].length > 5000) errors.push("update_note too long");
+    return errors;
+  };
+
+  const handleOcImport = async (validRows: Record<string, string>[]): Promise<ImportResult> => {
+    return bulkImportOverpaidCases(validRows);
+  };
+
   return (
     <div className="space-y-4">
+      {csvImportOpen && (
+        <CsvImportModal
+          dark={dark}
+          title="Import Overpaid Cases"
+          description="Upload a CSV to bulk-upsert overpaid case tracking data."
+          columns={OC_CSV_COLUMNS}
+          templateFilename="overpaid-cases-template.csv"
+          templateCsv={OC_TEMPLATE_CSV}
+          validateRow={validateOcRow}
+          onImport={handleOcImport}
+          onClose={() => setCsvImportOpen(false)}
+          onSuccess={fetchCases}
+        />
+      )}
       <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
         {liveMessage}
       </div>
@@ -984,6 +1031,14 @@ export const OverpaidCases = () => {
               <span className="hidden sm:inline">
                 {selectedIds.size > 0 ? `Export ${selectedIds.size} selected` : "Export"}
               </span>
+            </button>
+            <button
+              onClick={() => setCsvImportOpen(true)}
+              className={`h-8 px-2.5 rounded-md border text-xs font-medium flex items-center gap-1.5 ${t.outlineBtn}`}
+              aria-label="Import from CSV"
+            >
+              <Upload aria-hidden="true" className="h-3.5 w-3.5" />
+              <span className="hidden sm:inline">Import</span>
             </button>
           </div>
         </div>

--- a/src/components/scoreboard/Scoreboard.tsx
+++ b/src/components/scoreboard/Scoreboard.tsx
@@ -4,7 +4,7 @@ import { useState, useReducer, useEffect } from "react";
 import { useTheme } from "next-themes";
 import { RefreshCw, ChevronLeft, ChevronRight, Upload } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
-import CsvImportModal, { type ColumnDef, type ImportResult } from "@/components/modals/CsvImportModal";
+import CsvImportModal, { type ColumnDef } from "@/components/modals/CsvImportModal";
 import { bulkImportDailyMetrics } from "@/app/(dashboard)/scoreboard/actions";
 import { parseDate, parseNonNegativeInt } from "@/lib/import/csv-parser";
 
@@ -70,6 +70,35 @@ function fetchReducer(state: FetchState, action: FetchAction): FetchState {
   }
 }
 
+// ---------- csv import config ----------
+const DM_CSV_COLUMNS: ColumnDef[] = [
+  { key: "agent_name", label: "Agent Name", required: true, hint: "Must match a team member name" },
+  { key: "metric_date", label: "Metric Date", required: true, hint: "YYYY-MM-DD or MM/DD/YYYY" },
+  { key: "ssa_calls", label: "SSA Calls", hint: "Non-negative integer" },
+  { key: "client_calls_ib", label: "Client Calls IB", hint: "Non-negative integer" },
+  { key: "client_calls_ob", label: "Client Calls OB", hint: "Non-negative integer" },
+  { key: "win_sheets_created", label: "Win Sheets Created", hint: "Non-negative integer" },
+  { key: "notes", label: "Notes", hint: "Optional text" },
+];
+
+const DM_TEMPLATE_CSV =
+  "agent_name,metric_date,ssa_calls,client_calls_ib,client_calls_ob,win_sheets_created,notes\n" +
+  "Jane Smith,2024-01-15,5,3,2,1,\n";
+
+const DM_INT_KEYS = ["ssa_calls", "client_calls_ib", "client_calls_ob", "win_sheets_created"];
+
+const validateDmRow = (raw: Record<string, string>): string[] => {
+  const errors: string[] = [];
+  if (!raw["agent_name"]?.trim()) errors.push("agent_name is required");
+  if (!raw["metric_date"]?.trim() || !parseDate(raw["metric_date"])) errors.push("Invalid or missing metric_date");
+  for (const key of DM_INT_KEYS) {
+    if (raw[key] !== undefined && raw[key].trim() && parseNonNegativeInt(raw[key]) === null) {
+      errors.push(`Invalid value for "${key}" — must be a non-negative integer`);
+    }
+  }
+  return errors;
+};
+
 // ---------- component ----------
 
 export const Scoreboard = () => {
@@ -133,36 +162,6 @@ export const Scoreboard = () => {
     1
   );
 
-  const DM_CSV_COLUMNS: ColumnDef[] = [
-    { key: "agent_name", label: "Agent Name", required: true, hint: "Must match a team member name" },
-    { key: "metric_date", label: "Metric Date", required: true, hint: "YYYY-MM-DD or MM/DD/YYYY" },
-    { key: "ssa_calls", label: "SSA Calls", hint: "Non-negative integer" },
-    { key: "client_calls_ib", label: "Client Calls IB", hint: "Non-negative integer" },
-    { key: "client_calls_ob", label: "Client Calls OB", hint: "Non-negative integer" },
-    { key: "win_sheets_created", label: "Win Sheets Created", hint: "Non-negative integer" },
-    { key: "notes", label: "Notes", hint: "Optional text" },
-  ];
-
-  const DM_TEMPLATE_CSV =
-    "agent_name,metric_date,ssa_calls,client_calls_ib,client_calls_ob,win_sheets_created,notes\n" +
-    "Jane Smith,2024-01-15,5,3,2,1,\n";
-
-  const validateDmRow = (raw: Record<string, string>): string[] => {
-    const errors: string[] = [];
-    if (!raw["agent_name"]?.trim()) errors.push("agent_name is required");
-    if (!raw["metric_date"]?.trim() || !parseDate(raw["metric_date"])) errors.push("Invalid or missing metric_date");
-    for (const key of ["ssa_calls", "client_calls_ib", "client_calls_ob", "win_sheets_created"]) {
-      if (raw[key] !== undefined && raw[key].trim() && parseNonNegativeInt(raw[key]) === null) {
-        errors.push(`Invalid value for "${key}" — must be a non-negative integer`);
-      }
-    }
-    return errors;
-  };
-
-  const handleDmImport = async (validRows: Record<string, string>[]): Promise<ImportResult> => {
-    return bulkImportDailyMetrics(validRows);
-  };
-
   return (
     <>
     {csvImportOpen && (
@@ -174,7 +173,7 @@ export const Scoreboard = () => {
         templateFilename="daily-metrics-template.csv"
         templateCsv={DM_TEMPLATE_CSV}
         validateRow={validateDmRow}
-        onImport={handleDmImport}
+        onImport={bulkImportDailyMetrics}
         onClose={() => setCsvImportOpen(false)}
         onSuccess={() => dispatch({ type: "start" })}
       />

--- a/src/components/scoreboard/Scoreboard.tsx
+++ b/src/components/scoreboard/Scoreboard.tsx
@@ -2,8 +2,11 @@
 
 import { useState, useReducer, useEffect } from "react";
 import { useTheme } from "next-themes";
-import { RefreshCw, ChevronLeft, ChevronRight } from "lucide-react";
+import { RefreshCw, ChevronLeft, ChevronRight, Upload } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
+import CsvImportModal, { type ColumnDef, type ImportResult } from "@/components/modals/CsvImportModal";
+import { bulkImportDailyMetrics } from "@/app/(dashboard)/scoreboard/actions";
+import { parseDate, parseNonNegativeInt } from "@/lib/import/csv-parser";
 
 // ---------- types ----------
 
@@ -75,6 +78,7 @@ export const Scoreboard = () => {
   const t = themeClasses(dark);
 
   const [weekOffset, setWeekOffset] = useState(0);
+  const [csvImportOpen, setCsvImportOpen] = useState(false);
   const [{ weeks, loading, error }, dispatch] = useReducer(fetchReducer, {
     weeks: [],
     loading: true,
@@ -129,7 +133,52 @@ export const Scoreboard = () => {
     1
   );
 
+  const DM_CSV_COLUMNS: ColumnDef[] = [
+    { key: "agent_name", label: "Agent Name", required: true, hint: "Must match a team member name" },
+    { key: "metric_date", label: "Metric Date", required: true, hint: "YYYY-MM-DD or MM/DD/YYYY" },
+    { key: "ssa_calls", label: "SSA Calls", hint: "Non-negative integer" },
+    { key: "client_calls_ib", label: "Client Calls IB", hint: "Non-negative integer" },
+    { key: "client_calls_ob", label: "Client Calls OB", hint: "Non-negative integer" },
+    { key: "win_sheets_created", label: "Win Sheets Created", hint: "Non-negative integer" },
+    { key: "notes", label: "Notes", hint: "Optional text" },
+  ];
+
+  const DM_TEMPLATE_CSV =
+    "agent_name,metric_date,ssa_calls,client_calls_ib,client_calls_ob,win_sheets_created,notes\n" +
+    "Jane Smith,2024-01-15,5,3,2,1,\n";
+
+  const validateDmRow = (raw: Record<string, string>): string[] => {
+    const errors: string[] = [];
+    if (!raw["agent_name"]?.trim()) errors.push("agent_name is required");
+    if (!raw["metric_date"]?.trim() || !parseDate(raw["metric_date"])) errors.push("Invalid or missing metric_date");
+    for (const key of ["ssa_calls", "client_calls_ib", "client_calls_ob", "win_sheets_created"]) {
+      if (raw[key] !== undefined && raw[key].trim() && parseNonNegativeInt(raw[key]) === null) {
+        errors.push(`Invalid value for "${key}" — must be a non-negative integer`);
+      }
+    }
+    return errors;
+  };
+
+  const handleDmImport = async (validRows: Record<string, string>[]): Promise<ImportResult> => {
+    return bulkImportDailyMetrics(validRows);
+  };
+
   return (
+    <>
+    {csvImportOpen && (
+      <CsvImportModal
+        dark={dark}
+        title="Import Daily Metrics"
+        description="Upload a CSV to bulk-import or update daily metric entries for the scoreboard."
+        columns={DM_CSV_COLUMNS}
+        templateFilename="daily-metrics-template.csv"
+        templateCsv={DM_TEMPLATE_CSV}
+        validateRow={validateDmRow}
+        onImport={handleDmImport}
+        onClose={() => setCsvImportOpen(false)}
+        onSuccess={() => dispatch({ type: "start" })}
+      />
+    )}
     <div className={`rounded-xl border ${t.card} overflow-hidden`}>
       {/* Header */}
       <div className={`px-5 py-4 border-b ${t.borderLight} flex items-center justify-between gap-4`}>
@@ -142,6 +191,14 @@ export const Scoreboard = () => {
           </p>
         </div>
         <div className="flex items-center gap-1 shrink-0">
+          <button
+            onClick={() => setCsvImportOpen(true)}
+            className={`flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium border transition-colors ${dark ? "border-neutral-700 text-neutral-300 hover:bg-neutral-800" : "border-neutral-200 text-neutral-600 hover:bg-neutral-50"}`}
+            aria-label="Import daily metrics from CSV"
+          >
+            <Upload aria-hidden="true" className="h-3.5 w-3.5" />
+            Import
+          </button>
           <button
             onClick={() => setWeekOffset(weekOffset - 1)}
             className={`flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium border transition-colors ${dark ? "border-neutral-700 text-neutral-300 hover:bg-neutral-800" : "border-neutral-200 text-neutral-600 hover:bg-neutral-50"}`}
@@ -263,5 +320,6 @@ export const Scoreboard = () => {
         </div>
       )}
     </div>
+    </>
   );
 };

--- a/src/lib/import/csv-parser.ts
+++ b/src/lib/import/csv-parser.ts
@@ -1,0 +1,184 @@
+/**
+ * Parses a CSV string and returns the original header strings plus rows keyed
+ * by those original headers (preserving exact capitalisation and spacing).
+ *
+ * @param headerRowIndex - 0-based index of the row that contains column headers.
+ *   Rows before this index are treated as metadata and skipped.
+ *   Defaults to 0 (first row).
+ */
+export function parseCsvText(
+  text: string,
+  headerRowIndex: number = 0,
+): {
+  headers: string[];
+  rows: Record<string, string>[];
+} {
+  const normalized = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  // Strip UTF-8 BOM if present
+  const clean = normalized.startsWith("﻿") ? normalized.slice(1) : normalized;
+  const lines = clean.split("\n").filter((_, i) => {
+    // Keep the header row and everything after; drop lines before it
+    return i >= headerRowIndex;
+  });
+  if (lines.length < 2) return { headers: [], rows: [] };
+
+  const headers = splitCsvLine(lines[0]).map((h) => h.trim());
+
+  const rows: Record<string, string>[] = [];
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.trim()) continue;
+    const cells = splitCsvLine(line);
+    const row: Record<string, string> = {};
+    headers.forEach((h, j) => {
+      row[h] = (cells[j] ?? "").trim();
+    });
+    rows.push(row);
+  }
+  return { headers, rows };
+}
+
+/**
+ * Applies a field mapping to raw CSV rows.
+ * `mapping` maps expected field keys to original CSV header strings.
+ * Fields mapped to "" or absent are resolved to "".
+ */
+export function applyMapping(
+  rows: Record<string, string>[],
+  mapping: Record<string, string>,
+): Record<string, string>[] {
+  return rows.map((raw) => {
+    const out: Record<string, string> = {};
+    for (const [expectedKey, csvHeader] of Object.entries(mapping)) {
+      out[expectedKey] = (csvHeader && raw[csvHeader] != null) ? raw[csvHeader] : "";
+    }
+    return out;
+  });
+}
+
+/**
+ * Auto-suggests a mapping from expected field keys to CSV headers.
+ * Tries to match by normalising both sides (lowercase, collapse punctuation).
+ */
+export function autoMapColumns(
+  fieldKeys: string[],
+  fieldLabels: string[],
+  csvHeaders: string[],
+): Record<string, string> {
+  const norm = (s: string) =>
+    s.toLowerCase().replace(/[_\s\-/()]+/g, " ").trim();
+
+  const mapping: Record<string, string> = {};
+  for (let i = 0; i < fieldKeys.length; i++) {
+    const keyNorm = norm(fieldKeys[i]);
+    const labelNorm = norm(fieldLabels[i]);
+
+    const match = csvHeaders.find((h) => {
+      const hn = norm(h);
+      return hn === keyNorm || hn === labelNorm;
+    });
+    mapping[fieldKeys[i]] = match ?? "";
+  }
+  return mapping;
+}
+
+function splitCsvLine(line: string): string[] {
+  const result: string[] = [];
+  let current = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"';
+        i++;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (ch === "," && !inQuotes) {
+      result.push(current);
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+  result.push(current);
+  return result;
+}
+
+/**
+ * Parses a boolean-like string.
+ * Accepts: true/false, yes/no, 1/0, y/n, x (checked), and empty string (false).
+ * Returns null for unrecognised values.
+ */
+export function parseBool(value: string): boolean | null {
+  const v = value.trim().toLowerCase();
+  if (["true", "yes", "1", "y", "x"].includes(v)) return true;
+  if (["false", "no", "0", "n", ""].includes(v)) return false;
+  return null;
+}
+
+/**
+ * Parses a date string to ISO "YYYY-MM-DD".
+ * Accepts YYYY-MM-DD and MM/DD/YYYY. Returns null for empty or invalid input.
+ */
+export function parseDate(value: string): string | null {
+  const v = value.trim();
+  if (!v) return null;
+
+  if (/^\d{4}-\d{2}-\d{2}$/.test(v)) {
+    const d = new Date(v + "T12:00:00");
+    if (!isNaN(d.getTime())) return v;
+  }
+
+  const mdy = v.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+  if (mdy) {
+    const iso = `${mdy[3]}-${mdy[1].padStart(2, "0")}-${mdy[2].padStart(2, "0")}`;
+    const d = new Date(iso + "T12:00:00");
+    if (!isNaN(d.getTime())) return iso;
+  }
+
+  // MM/DD/YY — two-digit year treated as 20YY
+  const mdyShort = v.match(/^(\d{1,2})\/(\d{1,2})\/(\d{2})$/);
+  if (mdyShort) {
+    const iso = `20${mdyShort[3]}-${mdyShort[1].padStart(2, "0")}-${mdyShort[2].padStart(2, "0")}`;
+    const d = new Date(iso + "T12:00:00");
+    if (!isNaN(d.getTime())) return iso;
+  }
+
+  // Fallback: extract a date pattern embedded in a longer string (e.g. "Recv'd 3/26/2026")
+  const embedded4 = v.match(/(\d{1,2})\/(\d{1,2})\/(\d{4})/);
+  if (embedded4) {
+    const iso = `${embedded4[3]}-${embedded4[1].padStart(2, "0")}-${embedded4[2].padStart(2, "0")}`;
+    const d = new Date(iso + "T12:00:00");
+    if (!isNaN(d.getTime())) return iso;
+  }
+
+  const embedded2 = v.match(/(\d{1,2})\/(\d{1,2})\/(\d{2})(?!\d)/);
+  if (embedded2) {
+    const iso = `20${embedded2[3]}-${embedded2[1].padStart(2, "0")}-${embedded2[2].padStart(2, "0")}`;
+    const d = new Date(iso + "T12:00:00");
+    if (!isNaN(d.getTime())) return iso;
+  }
+
+  return null;
+}
+
+/** Parses a non-negative integer string. Returns null for empty or invalid. */
+export function parseNonNegativeInt(value: string): number | null {
+  const v = value.trim();
+  if (!v) return null;
+  if (!/^\d+$/.test(v)) return null;
+  const n = parseInt(v, 10);
+  return isNaN(n) ? null : n;
+}
+
+/** Parses a decimal string (strips commas). Returns null for empty or invalid. */
+export function parseDecimalString(value: string): string | null {
+  const v = value.trim().replace(/[$,]/g, "");
+  if (!v) return null;
+  const n = parseFloat(v);
+  if (isNaN(n)) return null;
+  return n.toFixed(2);
+}

--- a/src/lib/import/resolve-case.ts
+++ b/src/lib/import/resolve-case.ts
@@ -1,0 +1,91 @@
+import { db } from "@/lib/db";
+import { cases } from "@/lib/db/schema";
+import { eq, sql } from "drizzle-orm";
+
+/**
+ * Resolves a raw CSV identifier to a cases.clientId.
+ *
+ * Priority:
+ *  1. If the value is a pure integer string → match cases.client_id directly.
+ *  2. Otherwise → case-insensitive match on "firstName lastName" or "lastName, firstName".
+ *
+ * Returns { caseId } on success or { error } on failure (not found / ambiguous).
+ */
+export async function resolveCaseId(
+  value: string,
+): Promise<{ caseId: number } | { error: string }> {
+  const trimmed = value.trim();
+  if (!trimmed) return { error: "Client ID / name is required" };
+
+  // Integer path
+  if (/^\d+$/.test(trimmed)) {
+    const id = parseInt(trimmed, 10);
+    const rows = await db
+      .select({ clientId: cases.clientId })
+      .from(cases)
+      .where(eq(cases.clientId, id))
+      .limit(1);
+    if (!rows.length) return { error: `No case found with client ID ${id}` };
+    return { caseId: rows[0].clientId };
+  }
+
+  // Name path — try "First Last" and "Last, First"
+  const normalised = trimmed.toLowerCase();
+
+  const byFullName = await db
+    .select({ clientId: cases.clientId })
+    .from(cases)
+    .where(
+      sql`LOWER(${cases.firstName} || ' ' || ${cases.lastName}) = ${normalised}`,
+    );
+
+  if (byFullName.length === 1) return { caseId: byFullName[0].clientId };
+  if (byFullName.length > 1) {
+    return {
+      error: `Multiple cases match "${trimmed}" — use client ID instead`,
+    };
+  }
+
+  // Try "Last, First"
+  const commaIdx = trimmed.indexOf(",");
+  if (commaIdx !== -1) {
+    const last = trimmed.slice(0, commaIdx).trim().toLowerCase();
+    const first = trimmed.slice(commaIdx + 1).trim().toLowerCase();
+    const byLastFirst = await db
+      .select({ clientId: cases.clientId })
+      .from(cases)
+      .where(
+        sql`LOWER(${cases.firstName}) = ${first} AND LOWER(${cases.lastName}) = ${last}`,
+      );
+    if (byLastFirst.length === 1) return { caseId: byLastFirst[0].clientId };
+    if (byLastFirst.length > 1) {
+      return {
+        error: `Multiple cases match "${trimmed}" — use client ID instead`,
+      };
+    }
+  }
+
+  // MyCase title path — "YYYY.MM.DD Last, First v. ALJ ..."
+  // Strip the date prefix and everything from " v. " onward, leaving "Last, First".
+  const mycaseMatch = trimmed.match(/^\d{4}\.\d{2}\.\d{2}\s+(.+?)\s+v\.?\s+/i);
+  if (mycaseMatch) {
+    const namePart = mycaseMatch[1].trim();
+    const ci = namePart.indexOf(",");
+    if (ci !== -1) {
+      const last = namePart.slice(0, ci).trim().toLowerCase();
+      const first = namePart.slice(ci + 1).trim().toLowerCase();
+      const rows = await db
+        .select({ clientId: cases.clientId })
+        .from(cases)
+        .where(
+          sql`LOWER(${cases.firstName}) = ${first} AND LOWER(${cases.lastName}) = ${last}`,
+        );
+      if (rows.length === 1) return { caseId: rows[0].clientId };
+      if (rows.length > 1) {
+        return { error: `Multiple cases match "${namePart}" — use client ID instead` };
+      }
+    }
+  }
+
+  return { error: `No case found matching "${trimmed}"` };
+}


### PR DESCRIPTION
Merges all changes from `develop` into `main`.

## Included since last main sync

- **feat: csv import** — bulk CSV import for fee petitions, overpaid cases, scoreboard, and inbound calls (PR #96)
- **feat: fees closed checkbox, win sheet link editing, nav fixes** (PR #94)
- **remove: push to sheets** — button, modal, and API route removed (PR #92)
- **feat: move summary cards to reports page** (PR #91)
- **feat: duplicate case indicator and capabilities stale-token fix** (PR #89)
- **feat: activity log → notifications, reports tab consolidation, inbound call count fix** (PR #88)
- **feat: daily filter on agent tracking in reports** (PR #87)
- **feat: scoreboard week navigation** (PR #86)