### PR TITLE
feat: url inputs for missing mycase links in sheet sync

### DIFF
--- a/src/app/api/sheets/sync/route.ts
+++ b/src/app/api/sheets/sync/route.ts
@@ -6,6 +6,7 @@ import { cases, feeRecords, activityLog } from "@/lib/db/schema";
 import { requireAdmin } from "@/lib/auth-helpers";
 import {
   mapSheetRows,
+  MYCASE_URL_RE,
   MOCK_SHEET_ROWS,
   SYNTHETIC_ID_BASE,
   type SheetRow,
@@ -396,14 +397,17 @@ export const POST = async (req: NextRequest) => {
       : await Promise.all([fetchMasterListRows(), fetchFeesClosedSheetRows()]);
     if (!cached) sheetCache = { masterRows: rawRows, feesClosedRows: feesClosedRaw, ts: Date.now() };
 
-    const MYCASE_URL_RE = /mycase\.com\/court_cases\/(\d+)/i;
     const patchedRows = rawRows.map((r, i) => {
       const override = rawOverrides[String(i + 2)];
       if (!override) return r;
-      const match = override.match(MYCASE_URL_RE);
-      if (!match) return r;
-      selectedSet.add(Number(match[1]));
+      if (!MYCASE_URL_RE.test(override)) return r;
       return { ...r, "CASE LINK_url": override };
+    });
+    rawRows.forEach((_, i) => {
+      const override = rawOverrides[String(i + 2)];
+      if (!override) return;
+      const match = override.match(MYCASE_URL_RE);
+      if (match) selectedSet.add(Number(match[1]));
     });
 
     const { rows: parsed } = mapSheetRows(patchedRows);

--- a/src/app/api/sheets/sync/route.ts
+++ b/src/app/api/sheets/sync/route.ts
@@ -352,9 +352,9 @@ export const POST = async (req: NextRequest) => {
     }
 
     // upsert mode
-    let body: { selectedClientIds: unknown };
+    let body: { selectedClientIds: unknown; linkOverrides?: unknown };
     try {
-      body = (await req.json()) as { selectedClientIds: unknown };
+      body = (await req.json()) as { selectedClientIds: unknown; linkOverrides?: unknown };
     } catch {
       return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
     }
@@ -379,6 +379,15 @@ export const POST = async (req: NextRequest) => {
       );
     }
 
+    const rawOverrides: Record<string, string> =
+      body.linkOverrides != null && typeof body.linkOverrides === "object" && !Array.isArray(body.linkOverrides)
+        ? Object.fromEntries(
+            Object.entries(body.linkOverrides as Record<string, unknown>).filter(
+              (entry): entry is [string, string] => typeof entry[1] === "string",
+            ),
+          )
+        : {};
+
     const selectedSet = new Set(ids);
 
     const cached = sheetCache && Date.now() - sheetCache.ts < SHEET_CACHE_TTL ? sheetCache : null;
@@ -386,7 +395,18 @@ export const POST = async (req: NextRequest) => {
       ? [{ rows: cached.masterRows }, cached.feesClosedRows]
       : await Promise.all([fetchMasterListRows(), fetchFeesClosedSheetRows()]);
     if (!cached) sheetCache = { masterRows: rawRows, feesClosedRows: feesClosedRaw, ts: Date.now() };
-    const { rows: parsed } = mapSheetRows(rawRows);
+
+    const MYCASE_URL_RE = /mycase\.com\/court_cases\/(\d+)/i;
+    const patchedRows = rawRows.map((r, i) => {
+      const override = rawOverrides[String(i + 2)];
+      if (!override) return r;
+      const match = override.match(MYCASE_URL_RE);
+      if (!match) return r;
+      selectedSet.add(Number(match[1]));
+      return { ...r, "CASE LINK_url": override };
+    });
+
+    const { rows: parsed } = mapSheetRows(patchedRows);
     const { rows: feesClosedParsed } = mapFeesClosedRows(feesClosedRaw);
 
     const seenCandidates = new Set<number>();

--- a/src/components/modals/SheetSyncModal.tsx
+++ b/src/components/modals/SheetSyncModal.tsx
@@ -194,6 +194,7 @@ export default function SheetSyncModal({
   const [selectedMissing, setSelectedMissing] = useState<Set<number>>(new Set());
   const [selectedMissingClosed, setSelectedMissingClosed] = useState<Set<number>>(new Set());
   const [archiving, setArchiving] = useState<"active" | "closed" | null>(null);
+  const [linkOverrides, setLinkOverrides] = useState<Record<number, string>>({});
 
   const doFetch = async () => {
     setFetching(true);
@@ -417,7 +418,12 @@ export default function SheetSyncModal({
       const res = await fetch("/api/sheets/sync?mode=upsert", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ selectedClientIds: [...selected] }),
+        body: JSON.stringify({
+          selectedClientIds: [...selected],
+          linkOverrides: Object.fromEntries(
+            Object.entries(linkOverrides).filter(([, v]) => v.trim() !== ""),
+          ),
+        }),
         signal: controller.signal,
       });
       let json: Record<string, unknown> = {};
@@ -695,14 +701,26 @@ export default function SheetSyncModal({
                         <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
                         {needsLinkRows.length} row{needsLinkRows.length === 1 ? "" : "s"} {needsLinkRows.length === 1 ? "has" : "have"} no MyCase link — skipped
                       </div>
-                      <p className="opacity-80 mb-2">These rows will not be synced until a valid MyCase URL is added to the sheet.</p>
-                      <ul className="space-y-0.5 max-h-36 overflow-y-auto">
-                        {needsLinkRows.slice(0, 25).map((r, i) => (
-                          <li key={i}>Row {r.row}: {r.caseLink}</li>
+                      <p className="opacity-80 mb-2">Paste a MyCase URL to include the row in this sync — leave blank to skip.</p>
+                      <ul className="space-y-1.5 max-h-48 overflow-y-auto">
+                        {needsLinkRows.slice(0, 25).map((r) => (
+                          <li key={r.row} className="flex flex-col gap-0.5">
+                            <span className="opacity-80">Row {r.row}: {r.caseLink}</span>
+                            <input
+                              type="url"
+                              aria-label={`MyCase URL for row ${r.row}: ${r.caseLink}`}
+                              placeholder="https://app.mycase.com/court_cases/…"
+                              value={linkOverrides[r.row] ?? ""}
+                              onChange={(e) =>
+                                setLinkOverrides((prev) => ({ ...prev, [r.row]: e.target.value }))
+                              }
+                              className={`w-full h-6 px-2 rounded border text-[10px] outline-none focus:ring-1 focus:ring-neutral-400 dark:focus:ring-neutral-500 ${dark ? "bg-neutral-800 border-neutral-700 text-neutral-200 placeholder:text-neutral-600" : "bg-white border-neutral-300 text-neutral-800 placeholder:text-neutral-400"}`}
+                            />
+                          </li>
                         ))}
                       </ul>
                       {needsLinkRows.length > 25 && (
-                        <p className="mt-1 opacity-70">…and {needsLinkRows.length - 25} more</p>
+                        <p className="mt-1 opacity-70">…and {needsLinkRows.length - 25} more (add URLs directly in the sheet)</p>
                       )}
                     </div>
                   )}

--- a/src/components/modals/SheetSyncModal.tsx
+++ b/src/components/modals/SheetSyncModal.tsx
@@ -204,6 +204,7 @@ export default function SheetSyncModal({
     setFcPreviewError(null);
     setSelectedMissing(new Set());
     setSelectedMissingClosed(new Set());
+    setLinkOverrides({});
 
     const mainController = new AbortController();
     const fcController = new AbortController();
@@ -707,7 +708,7 @@ export default function SheetSyncModal({
                           <li key={r.row} className="flex flex-col gap-0.5">
                             <span className="opacity-80">Row {r.row}: {r.caseLink}</span>
                             <input
-                              type="url"
+                              type="text"
                               aria-label={`MyCase URL for row ${r.row}: ${r.caseLink}`}
                               placeholder="https://app.mycase.com/court_cases/…"
                               value={linkOverrides[r.row] ?? ""}

--- a/src/lib/import/sheets-mapper.ts
+++ b/src/lib/import/sheets-mapper.ts
@@ -3,7 +3,7 @@ import type { ParsedCaseRow } from "./xlsx-mapper";
 export type SheetRow = Record<string, string | number | null | undefined>;
 
 export const SYNTHETIC_ID_BASE = 900_000_000;
-const MYCASE_URL_RE = /mycase\.com\/court_cases\/(\d+)/i;
+export const MYCASE_URL_RE = /mycase\.com\/court_cases\/(\d+)/i;
 
 const num = (v: unknown): string => {
   if (v === null || v === undefined || v === "") return "0";


### PR DESCRIPTION
## Summary

- Skipped rows in the Sheets sync preview (those missing a MyCase URL) now show a URL input next to each case name
- If a valid MyCase URL is pasted, the row is included in the sync — URL is resolved server-side and the case is upserted normally
- If left blank, the row is skipped as before
- Override values are validated on the server: only string values matching the MyCase URL pattern are applied; invalid or non-string entries are ignored safely