### PR TITLE
fix: abort stale fetch in useDashboard finally blocks

### DIFF
--- a/src/hooks/useDashboard.ts
+++ b/src/hooks/useDashboard.ts
@@ -126,6 +126,7 @@ export const useDashboard = (): DashboardData => {
           if (!cancelledRef.current) setError((err as Error).message);
         })
         .finally(() => {
+          // cancelledRef resets on re-mount (Strict Mode) before this fires; signal stays aborted
           if (!controller.signal.aborted && !cancelledRef.current) setLoading(false);
         }),
       casesTask
@@ -134,6 +135,7 @@ export const useDashboard = (): DashboardData => {
           if (!cancelledRef.current) setError((err as Error).message);
         })
         .finally(() => {
+          // same Strict Mode guard as summaryTask above
           if (!controller.signal.aborted && !cancelledRef.current) setCasesLoading(false);
         }),
     ]);

--- a/src/hooks/useDashboard.ts
+++ b/src/hooks/useDashboard.ts
@@ -126,7 +126,7 @@ export const useDashboard = (): DashboardData => {
           if (!cancelledRef.current) setError((err as Error).message);
         })
         .finally(() => {
-          if (!cancelledRef.current) setLoading(false);
+          if (!controller.signal.aborted && !cancelledRef.current) setLoading(false);
         }),
       casesTask
         .catch((err: unknown) => {
@@ -134,7 +134,7 @@ export const useDashboard = (): DashboardData => {
           if (!cancelledRef.current) setError((err as Error).message);
         })
         .finally(() => {
-          if (!cancelledRef.current) setCasesLoading(false);
+          if (!controller.signal.aborted && !cancelledRef.current) setCasesLoading(false);
         }),
     ]);
   }, []);


### PR DESCRIPTION
Guards `setLoading` / `setCasesLoading` in the `finally` blocks against React Strict Mode's double-invoke pattern, where `cancelledRef` is reset by the second `fetchAll` call before the first controller's `finally` fires. The aborted controller's signal remains `true`, so pairing `!controller.signal.aborted` with `!cancelledRef.current` closes the gap.

Added inline comments on both `finally` blocks explaining the invariant.