### PR TITLE
feat: approver filter on master fees page

### DIFF
--- a/src/app/(dashboard)/master-fees/page.tsx
+++ b/src/app/(dashboard)/master-fees/page.tsx
@@ -9,11 +9,19 @@ import { themeClasses } from "@/lib/theme-classes";
 import { RefreshCw, AlertCircle } from "lucide-react";
 
 type AgingFilter = "all" | "unpaid_60" | "unpaid_90";
+type ApproverFilter = "all" | "georgia" | "lori" | "deanne";
 
 const AGING_OPTIONS: { value: AgingFilter; label: string }[] = [
   { value: "all", label: "All" },
   { value: "unpaid_60", label: "Unpaid >60d" },
   { value: "unpaid_90", label: "Unpaid >90d" },
+];
+
+const APPROVER_OPTIONS: { value: ApproverFilter; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "georgia", label: "Georgia" },
+  { value: "lori", label: "Lori" },
+  { value: "deanne", label: "DeAnne" },
 ];
 
 export default function MasterFeesPage() {
@@ -31,6 +39,7 @@ export default function MasterFeesPage() {
   const t = themeClasses(dark);
 
   const [agingFilter, setAgingFilter] = useState<AgingFilter>("all");
+  const [approverFilter, setApproverFilter] = useState<ApproverFilter>("all");
 
   if (error) {
     return (
@@ -56,16 +65,21 @@ export default function MasterFeesPage() {
     );
   }
 
-  const nonPetitionCases = cases.filter((c) => c.level !== "FEE_PETITION");
-
-  const displayCases =
+  const agingFiltered =
     agingFilter === "all"
-      ? nonPetitionCases
-      : nonPetitionCases.filter(
+      ? cases
+      : cases.filter(
           (c) =>
             c.paid === 0 &&
             c.daysAfterApproval != null &&
             c.daysAfterApproval > (agingFilter === "unpaid_60" ? 60 : 90),
+        );
+
+  const displayCases =
+    approverFilter === "all"
+      ? agingFiltered
+      : agingFiltered.filter((c) =>
+          c.approvedBy?.toLowerCase().includes(approverFilter),
         );
 
   const presetBase = `px-3 py-1 rounded-full text-[11px] font-medium border transition-colors`;
@@ -75,6 +89,9 @@ export default function MasterFeesPage() {
   const presetInactive = dark
     ? "border-neutral-700 text-neutral-400 hover:border-neutral-500"
     : "border-neutral-200 text-neutral-500 hover:border-neutral-400";
+  const approverActive = dark
+    ? "bg-emerald-800 border-emerald-600 text-white"
+    : "bg-emerald-50 border-emerald-400 text-emerald-800";
 
   return (
     <div className="space-y-3">
@@ -92,7 +109,27 @@ export default function MasterFeesPage() {
             {label}
           </button>
         ))}
-        {agingFilter !== "all" && (
+        {agingFilter !== "all" && approverFilter === "all" && (
+          <span className={`ml-auto text-[11px] ${t.textMuted}`}>
+            {displayCases.length} case{displayCases.length !== 1 ? "s" : ""}
+          </span>
+        )}
+      </div>
+      <div className={`rounded-xl border ${t.card} px-4 py-2.5 flex items-center gap-2 flex-wrap`}>
+        <span className={`text-[10px] font-semibold uppercase tracking-wider ${t.textMuted} shrink-0`}>
+          Ready to Close:
+        </span>
+        {APPROVER_OPTIONS.map(({ value, label }) => (
+          <button
+            key={value}
+            onClick={() => setApproverFilter(value)}
+            aria-pressed={approverFilter === value}
+            className={`${presetBase} ${approverFilter === value ? (value === "all" ? presetInactive : approverActive) : presetInactive}`}
+          >
+            {label}
+          </button>
+        ))}
+        {approverFilter !== "all" && (
           <span className={`ml-auto text-[11px] ${t.textMuted}`}>
             {displayCases.length} case{displayCases.length !== 1 ? "s" : ""}
           </span>


### PR DESCRIPTION
Adds a "Ready to Close" approver filter bar to the master fees page, letting the team quickly view cases approved by a specific approver.

- `ApproverFilter` type + `APPROVER_OPTIONS` config array (Georgia, Lori, DeAnne)
- Approver filter pills with `aria-pressed` for accessibility
- Filter chain: aging filter → approver filter → `displayCases`; approver match uses case-insensitive substring on `approvedBy`
- Count badge shows the result count whenever either filter is active
- Fee Petition cases (`level === "FEE_PETITION"`) are intentionally included — the previous exclusion has been removed