### PR TITLE
feat: no fees cases + new cases tabs, fee petition totals, overpaid manual-add

### DIFF
--- a/src/app/(dashboard)/notifications/page.tsx
+++ b/src/app/(dashboard)/notifications/page.tsx
@@ -21,6 +21,7 @@ import {
 import { themeClasses } from "@/lib/theme-classes";
 import { AuditLogTab } from "@/components/notifications/AuditLogTab";
 import { RecentActivityTab } from "@/components/notifications/RecentActivityTab";
+import { NewCasesTab } from "@/components/notifications/NewCasesTab";
 
 // ============================================================================
 // Types
@@ -40,7 +41,7 @@ interface Notification {
 }
 
 type FilterType = "all" | Notification["type"];
-type PageTab = "notifications" | "audit_logs" | "recent_activity";
+type PageTab = "notifications" | "audit_logs" | "recent_activity" | "new_cases";
 
 const TYPE_META: Record<
   Notification["type"],
@@ -93,6 +94,7 @@ const PAGE_TABS: { key: PageTab; label: string; icon: React.ElementType }[] = [
   { key: "notifications",   label: "Notifications",   icon: Bell },
   { key: "audit_logs",      label: "Audit Logs",      icon: ClipboardList },
   { key: "recent_activity", label: "Recent Activity", icon: Activity },
+  { key: "new_cases",       label: "New Cases",       icon: UserPlus },
 ];
 
 // ============================================================================
@@ -274,6 +276,9 @@ export default function NotificationsPage() {
 
       {/* Recent Activity tab */}
       {pageTab === "recent_activity" && <RecentActivityTab dark={dark} t={t} />}
+
+      {/* New Cases tab */}
+      {pageTab === "new_cases" && <NewCasesTab dark={dark} t={t} />}
 
       {/* Notifications tab */}
       {pageTab === "notifications" && <>

--- a/src/app/api/cases-added/route.ts
+++ b/src/app/api/cases-added/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { db } from "@/lib/db";
+import { sql } from "drizzle-orm";
+
+// GET /api/cases-added?week=YYYY-MM-DD
+// Returns the actual cases whose `created_at` falls within that Mon-Sun week
+// — i.e. new cases added to this database, regardless of import source
+// (manual add, Sheets sync, MyCase sync, CSV import). Synced cases use
+// onConflictDoNothing on re-sync, so created_at reliably reflects first-insert
+// day, not the most recent sync. `data` (per-day counts, zero-filled for all
+// 7 days) is derived from the same `cases` list returned below, so the count
+// and the name list can never disagree.
+export async function GET(req: NextRequest) {
+  try {
+    const session = await auth();
+    if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    const { searchParams } = req.nextUrl;
+    const week = searchParams.get("week") ?? new Date().toISOString().split("T")[0];
+
+    const caseRows = await db.execute(sql`
+      SELECT
+        c.client_id AS id,
+        c.first_name AS first_name,
+        c.last_name AS last_name,
+        c.external_id AS external_id,
+        c.created_at AS created_at
+      FROM cases c
+      WHERE c.created_at >= ${week}::date
+        AND c.created_at < ${week}::date + INTERVAL '7 days'
+      ORDER BY c.created_at ASC
+    `) as unknown as {
+      id: number;
+      first_name: string | null;
+      last_name: string | null;
+      external_id: string | null;
+      created_at: string;
+    }[];
+
+    const cases = caseRows.map((r) => ({
+      id: r.id,
+      name: `${r.last_name ?? ""}, ${r.first_name ?? ""}`,
+      externalId: r.external_id,
+      createdAt: r.created_at,
+      date: new Date(r.created_at).toISOString().split("T")[0],
+    }));
+
+    const countByDate = new Map<string, number>();
+    for (const c of cases) countByDate.set(c.date, (countByDate.get(c.date) ?? 0) + 1);
+
+    const monday = new Date(`${week}T00:00:00Z`);
+    const data = Array.from({ length: 7 }, (_, i) => {
+      const d = new Date(monday);
+      d.setUTCDate(d.getUTCDate() + i);
+      const date = d.toISOString().split("T")[0];
+      return { date, count: countByDate.get(date) ?? 0 };
+    });
+
+    return NextResponse.json({ week, data, cases });
+  } catch (error) {
+    console.error("GET /api/cases-added error:", error);
+    return NextResponse.json(
+      { error: (error as Error).message },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/fee-petitions/route.ts
+++ b/src/app/api/fee-petitions/route.ts
@@ -94,12 +94,16 @@ export const GET = async (req: NextRequest) => {
       ${agingClause}
     `;
 
-    // Single aggregate for stats + count
+    // Single aggregate for stats + count. Fee totals sum across the FULL
+    // filtered set (not just the current page), so they stay accurate
+    // regardless of pagination.
     const [agg] = await db
       .select({
         total: sql<number>`COUNT(*)::int`,
         completeCount: sql<number>`COUNT(*) FILTER (WHERE ${allChecked})::int`,
         neverTouchedCount: sql<number>`COUNT(*) FILTER (WHERE ${feePetitions.updatedAt} IS NULL)::int`,
+        totalFeeRequested: sql<number>`COALESCE(SUM(${feeRecords.totalFeesExpected}), 0)::numeric`,
+        totalFeesReceived: sql<number>`COALESCE(SUM(${feeRecords.totalFeesPaid}), 0)::numeric`,
       })
       .from(cases)
       .leftJoin(feePetitions, eq(feePetitions.caseId, cases.clientId))
@@ -110,6 +114,8 @@ export const GET = async (req: NextRequest) => {
     const completeCount = agg?.completeCount ?? 0;
     const incompleteCount = total - completeCount;
     const neverTouchedCount = agg?.neverTouchedCount ?? 0;
+    const totalFeeRequested = Number(agg?.totalFeeRequested) || 0;
+    const totalFeesReceived = Number(agg?.totalFeesReceived) || 0;
 
     const orderClause =
       sort === "claimant"
@@ -163,7 +169,17 @@ export const GET = async (req: NextRequest) => {
       updateNote: r.updateNote ?? "",
     }));
 
-    return NextResponse.json({ data, page, limit, total, completeCount, incompleteCount, neverTouchedCount });
+    return NextResponse.json({
+      data,
+      page,
+      limit,
+      total,
+      completeCount,
+      incompleteCount,
+      neverTouchedCount,
+      totalFeeRequested,
+      totalFeesReceived,
+    });
   } catch (error) {
     console.error("GET /api/fee-petitions error:", error);
     return NextResponse.json(

--- a/src/app/api/scoreboard/route.ts
+++ b/src/app/api/scoreboard/route.ts
@@ -356,6 +356,60 @@ export const GET = async (req: NextRequest) => {
       pif:     Number(feesStatus?.pif_count)        || 0,
     };
 
+    // No Fees Cases — open cases with zero fees due/received (same predicate
+    // as openCasesFeesStatus.noFees above), aged over 60 days by approval_date.
+    // Returns the actual case rows (not just a count) so the Reports page can
+    // list them for reporting; over60/over90 counts are derived from this
+    // same list below so the card and the table can never disagree.
+    const noFeesCaseRows = await db.execute(sql`
+      SELECT
+        c.client_id AS id,
+        c.first_name AS first_name,
+        c.last_name AS last_name,
+        c.external_id AS external_id,
+        fr.assigned_to AS assigned,
+        c.claim_type_label AS claim_type_label,
+        c.approval_date AS approval_date,
+        (CURRENT_DATE - c.approval_date)::int AS days_since_approval
+      FROM fee_records fr
+      JOIN cases c ON c.client_id = fr.case_id
+      WHERE fr.is_closed = FALSE
+        AND fr.pif_ready_to_close IS NOT TRUE
+        AND COALESCE(fr.t16_fee_due, 0)::numeric = 0
+        AND COALESCE(fr.t2_fee_due, 0)::numeric = 0
+        AND COALESCE(fr.aux_fee_due, 0)::numeric = 0
+        AND COALESCE(fr.t16_fee_received, 0)::numeric = 0
+        AND COALESCE(fr.t2_fee_received, 0)::numeric = 0
+        AND COALESCE(fr.aux_fee_received, 0)::numeric = 0
+        AND c.approval_date IS NOT NULL
+        AND c.approval_date < CURRENT_DATE - INTERVAL '60 days'
+      ORDER BY c.approval_date ASC
+    `) as unknown as {
+      id: number;
+      first_name: string | null;
+      last_name: string | null;
+      external_id: string | null;
+      assigned: string | null;
+      claim_type_label: string | null;
+      approval_date: string | null;
+      days_since_approval: number;
+    }[];
+
+    const noFeesCases = noFeesCaseRows.map((r) => ({
+      id: r.id,
+      name: `${r.last_name ?? ""}, ${r.first_name ?? ""}`,
+      externalId: r.external_id,
+      assigned: r.assigned || "—",
+      claim: r.claim_type_label === "T2_T16" ? "CONC" : r.claim_type_label || "—",
+      approvalDate: r.approval_date,
+      daysSinceApproval: Number(r.days_since_approval) || 0,
+    }));
+
+    const noFeesAging = {
+      over60: noFeesCases.length,
+      over90: noFeesCases.filter((c) => c.daysSinceApproval > 90).length,
+    };
+
     return NextResponse.json({
       week: monday,
       start: startDate,
@@ -365,6 +419,8 @@ export const GET = async (req: NextRequest) => {
       teams,
       daily,
       openCasesFeesStatus,
+      noFeesAging,
+      noFeesCases,
     });
   } catch (error) {
     console.error("GET /api/scoreboard error:", error);

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -234,7 +234,8 @@ type SortKey =
   | "date"
   | "expected"
   | "paid"
-  | "daysAfterApproval";
+  | "daysAfterApproval"
+  | "closedAt";
 type SortDir = "asc" | "desc";
 
 export const FeeRecordsTable = ({
@@ -528,6 +529,10 @@ export const FeeRecordsTable = ({
         case "daysAfterApproval":
           av = a.daysAfterApproval ?? 0;
           bv = b.daysAfterApproval ?? 0;
+          break;
+        case "closedAt":
+          av = a.closedAt || "";
+          bv = b.closedAt || "";
           break;
       }
       if (av < bv) return sortDir === "asc" ? -1 : 1;
@@ -847,17 +852,6 @@ export const FeeRecordsTable = ({
             />
           </div>
           <select
-            value={statusFilter}
-            onChange={(e) => setStatusFilter(e.target.value)}
-            className={`h-8 px-2 rounded-md border text-xs outline-none cursor-pointer ${t.inputBg}`}
-          >
-            <option value="all">All Status</option>
-            <option value="not_started">Not Started</option>
-            <option value="started">Started</option>
-            <option value="finished">Finished</option>
-            <option value="closed">Closed</option>
-          </select>
-          <select
             value={assignedFilter}
             onChange={(e) => setAssignedFilter(e.target.value)}
             className={`h-8 px-2 rounded-md border text-xs outline-none cursor-pointer ${t.inputBg}`}
@@ -892,13 +886,24 @@ export const FeeRecordsTable = ({
             <option value="T16">T16</option>
             <option value="CONC">CONC</option>
           </select>
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+            className={`h-8 px-2 rounded-md border text-xs outline-none cursor-pointer ${t.inputBg}`}
+          >
+            <option value="all">All Status</option>
+            <option value="not_started">Not Started</option>
+            <option value="started">Started</option>
+            <option value="finished">Finished</option>
+            <option value="closed">Closed</option>
+          </select>
           {onApproverFilterChange && (
             <select
               value={approverFilter ?? "all"}
               onChange={(e) => onApproverFilterChange(e.target.value)}
               className={`h-8 px-2 rounded-md border text-xs outline-none cursor-pointer ${t.inputBg}`}
             >
-              <option value="all">All Approvers</option>
+              <option value="all">Cases Approved</option>
               <option value="georgia">Georgia</option>
               <option value="lori">Lori</option>
               <option value="deanne">DeAnne</option>
@@ -1179,11 +1184,12 @@ export const FeeRecordsTable = ({
                 </th>
                 <th className={`${thBase} ${t.textSub} text-center`}>Notes</th>
                 <th
-                  className={`${thBase} ${t.textSub} text-right ${mode !== "closed" ? "cursor-pointer" : ""}`}
-                  onClick={mode !== "closed" ? () => toggleSort("daysAfterApproval") : undefined}
+                  className={`${thBase} ${t.textSub} text-right cursor-pointer`}
+                  onClick={() => toggleSort(mode === "closed" ? "closedAt" : "daysAfterApproval")}
                 >
                   <span className="flex items-center justify-end gap-1">
-                    {mode === "closed" ? "Closed On" : <>Days <ArrowUpDown className="h-3 w-3" aria-hidden="true" /></>}
+                    {mode === "closed" ? "Closed On" : "Days"}
+                    <ArrowUpDown className="h-3 w-3" aria-hidden="true" />
                   </span>
                 </th>
               </tr>
@@ -1364,7 +1370,7 @@ export const FeeRecordsTable = ({
                               </option>
                             ))}
                         </select>
-                      ) : isAdmin && mode !== "closed" ? (
+                      ) : isAdmin ? (
                         <button
                           type="button"
                           onClick={(e) => { e.stopPropagation(); setFeesConfEditId(c.id); }}

--- a/src/components/fee-petitions/CompletedPetitions.tsx
+++ b/src/components/fee-petitions/CompletedPetitions.tsx
@@ -73,6 +73,7 @@ export const CompletedPetitions = ({ dark, canFinalize }: Props) => {
   const [expanded, setExpanded] = useState(false);
   const [rows, setRows] = useState<CompletedRow[]>([]);
   const [total, setTotal] = useState<number | null>(null);
+  const [totals, setTotals] = useState({ feeRequested: 0, feesReceived: 0 });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
@@ -160,6 +161,10 @@ export const CompletedPetitions = ({ dark, canFinalize }: Props) => {
       const data: CompletedRow[] = json.data || [];
       setRows(data);
       setTotal(typeof json.total === "number" ? json.total : 0);
+      setTotals({
+        feeRequested: typeof json.totalFeeRequested === "number" ? json.totalFeeRequested : 0,
+        feesReceived: typeof json.totalFeesReceived === "number" ? json.totalFeesReceived : 0,
+      });
       noteSnapshot.current = new Map(data.map((r) => [r.id, r.updateNote]));
     } catch (err) {
       if ((err as Error).name === "AbortError") return;
@@ -313,7 +318,12 @@ export const CompletedPetitions = ({ dark, canFinalize }: Props) => {
   const colSpan = CHECKBOX_COLUMNS.length + 7;
 
   return (
-    <div className={`rounded-xl border ${t.card}`}>
+    // contain:layout stops the sticky frozen-column/header cells in the table
+    // below from leaking their scroll overflow into <main>'s ancestor chain
+    // (a Chromium quirk where nested position:sticky cells inflate the
+    // document's scrollHeight past the viewport, leaving a blank gap below
+    // the dashboard shell once this section is expanded and scrolled).
+    <div className={`rounded-xl border ${t.card} [contain:layout]`}>
       <button
         type="button"
         onClick={() => setExpanded((v) => !v)}
@@ -413,6 +423,11 @@ export const CompletedPetitions = ({ dark, canFinalize }: Props) => {
                       ? "0 petitions"
                       : `Showing ${rangeStart}–${rangeEnd} of ${safeTotal} petitions`}
                   </p>
+                  {safeTotal > 0 && (
+                    <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
+                      Fees Requested {fmt(totals.feeRequested)} · Fees Received {fmt(totals.feesReceived)}
+                    </p>
+                  )}
                 </>
               )}
             </div>
@@ -482,7 +497,7 @@ export const CompletedPetitions = ({ dark, canFinalize }: Props) => {
             <table className="w-full min-w-250">
               <thead>
                 <tr className={`border-b ${t.borderLight}`}>
-                  <th className={`${thBase} w-10 text-center sticky left-0 top-0 z-30 ${stickyHeaderBg}`}>
+                  <th className={`${thBase} w-10 min-w-10 max-w-10 text-center sticky left-0 top-0 z-30 ${stickyHeaderBg}`}>
                     <input
                       ref={selectAllRef}
                       type="checkbox"
@@ -493,7 +508,7 @@ export const CompletedPetitions = ({ dark, canFinalize }: Props) => {
                   </th>
                   <th
                     aria-sort={sortKey === "claimant" ? (sortDir === "asc" ? "ascending" : "descending") : "none"}
-                    className={`${thBase} w-40 ${t.textSub} text-left sticky left-10 top-0 z-30 ${stickyHeaderBg}`}
+                    className={`${thBase} w-40 min-w-40 max-w-40 ${t.textSub} text-left sticky left-10 top-0 z-30 ${stickyHeaderBg}`}
                   >
                     <button
                       type="button"
@@ -503,7 +518,7 @@ export const CompletedPetitions = ({ dark, canFinalize }: Props) => {
                       Claimant {sortIcon("claimant")}
                     </button>
                   </th>
-                  <th className={`${thBase} w-24 ${t.textSub} text-right sticky left-[200px] top-0 z-30 ${stickyHeaderBg}`}>
+                  <th className={`${thBase} w-24 min-w-24 max-w-24 ${t.textSub} text-right sticky left-[200px] top-0 z-30 ${stickyHeaderBg}`}>
                     Fee Requested
                   </th>
                   <th className={`${thBase} w-24 ${t.textSub} text-right sticky top-0 z-20 ${stickyHeaderBg}`}>
@@ -577,7 +592,7 @@ export const CompletedPetitions = ({ dark, canFinalize }: Props) => {
                         key={row.id}
                         className={`group/row border-b ${rowBorder} ${dark ? "bg-emerald-900/40" : "bg-emerald-100/80"} ${rowHover} transition-colors`}
                       >
-                        <td className={`${tdBase} text-center sticky left-0 z-10 ${stickyBg} ${stickyHover}`}>
+                        <td className={`${tdBase} w-10 min-w-10 max-w-10 text-center sticky left-0 z-10 ${stickyBg} ${stickyHover}`}>
                           <input
                             type="checkbox"
                             checked={isSelected}
@@ -587,7 +602,7 @@ export const CompletedPetitions = ({ dark, canFinalize }: Props) => {
                           />
                         </td>
                         <td
-                          className={`${tdBase} ${t.text} font-semibold w-40 sticky left-10 z-10 ${stickyBg} ${stickyHover}`}
+                          className={`${tdBase} ${t.text} font-semibold w-40 min-w-40 max-w-40 sticky left-10 z-10 ${stickyBg} ${stickyHover}`}
                           title={row.claimant}
                         >
                           <Link
@@ -603,7 +618,7 @@ export const CompletedPetitions = ({ dark, canFinalize }: Props) => {
                           )}
                         </td>
                         <td
-                          className={`${tdBase} w-24 ${t.text} text-right font-medium tabular-nums sticky left-[200px] z-10 ${stickyBg} ${stickyHover}`}
+                          className={`${tdBase} w-24 min-w-24 max-w-24 ${t.text} text-right font-medium tabular-nums sticky left-[200px] z-10 ${stickyBg} ${stickyHover}`}
                         >
                           {row.feeAmount != null ? fmt(row.feeAmount) : "—"}
                         </td>

--- a/src/components/fee-petitions/FeePetitions.tsx
+++ b/src/components/fee-petitions/FeePetitions.tsx
@@ -168,7 +168,13 @@ export const FeePetitions = () => {
   const [rows, setRows] = useState<FeePetitionRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [stats, setStats] = useState({ completeCount: 0, incompleteCount: 0, neverTouchedCount: 0 });
+  const [stats, setStats] = useState({
+    completeCount: 0,
+    incompleteCount: 0,
+    neverTouchedCount: 0,
+    totalFeeRequested: 0,
+    totalFeesReceived: 0,
+  });
 
   const [search, setSearch] = useState(initialState.search);
   const [appliedSearch, setAppliedSearch] = useState(initialState.search);
@@ -321,6 +327,8 @@ export const FeePetitions = () => {
         completeCount: typeof json.completeCount === "number" ? json.completeCount : 0,
         incompleteCount: typeof json.incompleteCount === "number" ? json.incompleteCount : 0,
         neverTouchedCount: typeof json.neverTouchedCount === "number" ? json.neverTouchedCount : 0,
+        totalFeeRequested: typeof json.totalFeeRequested === "number" ? json.totalFeeRequested : 0,
+        totalFeesReceived: typeof json.totalFeesReceived === "number" ? json.totalFeesReceived : 0,
       });
       noteSnapshot.current = new Map(data.map((r) => [r.id, r.updateNote]));
     } catch (err) {
@@ -716,10 +724,12 @@ export const FeePetitions = () => {
       </div>
 
       {/* Stats bar */}
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
         {[
           { label: "Pending", value: isInitialLoad ? "—" : String(total), sub: "incomplete petitions" },
           { label: "Never Touched", value: isInitialLoad ? "—" : String(stats.neverTouchedCount), sub: "not yet started" },
+          { label: "Fees Requested", value: isInitialLoad ? "—" : fmt(stats.totalFeeRequested), sub: "across pending petitions" },
+          { label: "Fees Received", value: isInitialLoad ? "—" : fmt(stats.totalFeesReceived), sub: "across pending petitions" },
         ].map((s) => (
           <div key={s.label} className={`${sectionCard} p-4`}>
             <p className={`text-[10px] font-semibold uppercase tracking-wider ${t.textMuted}`}>{s.label}</p>

--- a/src/components/modals/AddCaseModal.tsx
+++ b/src/components/modals/AddCaseModal.tsx
@@ -13,7 +13,10 @@ import type { DropdownOptionsByCategory } from "@/hooks/useDashboard";
 interface AddCaseModalProps {
   dark: boolean;
   onClose: () => void;
-  onCreated: () => Promise<void> | void;
+  // Receives the newly created case's Client ID — e.g. so a caller can chain
+  // a follow-up action (Overpaid Cases marks the new case overpaid) before
+  // refreshing its own list.
+  onCreated: (clientId: number) => Promise<void> | void;
   dropdownOptions?: DropdownOptionsByCategory;
 }
 
@@ -178,8 +181,12 @@ export default function AddCaseModal({
       });
       const json = await res.json();
       if (!res.ok) throw new Error(json.error || `Failed (${res.status})`);
+      // Run the caller's follow-up before showing success, so a failure in it
+      // (e.g. a chained "mark overpaid" call) surfaces as an error instead of
+      // a false "done" — the case row was created either way, but the caller
+      // may not have finished what it needed to do with it yet.
+      await onCreated(json.clientId);
       setDone(true);
-      await onCreated();
     } catch (e) {
       setError((e as Error).message);
     } finally {

--- a/src/components/notifications/AuditLogTab.tsx
+++ b/src/components/notifications/AuditLogTab.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef, Fragment } from "react";
 import { ChevronLeft, ChevronRight, RefreshCw, ClipboardList, AlertCircle } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
+import { getMonday, formatWeekLabel } from "@/lib/formatters";
 
 interface DailyMetricRow {
   agent: string;
@@ -18,21 +19,6 @@ interface AuditLogTabProps {
   dark: boolean;
   t: ReturnType<typeof themeClasses>;
 }
-
-const getMonday = (offset = 0): string => {
-  const d = new Date();
-  const day = d.getDay();
-  d.setDate(d.getDate() - day + (day === 0 ? -6 : 1) + offset * 7);
-  return d.toISOString().split("T")[0];
-};
-
-const formatWeekLabel = (monday: string): string => {
-  const start = new Date(monday + "T00:00:00");
-  const end = new Date(monday + "T00:00:00");
-  end.setDate(end.getDate() + 4);
-  const opts: Intl.DateTimeFormatOptions = { month: "short", day: "numeric" };
-  return `${start.toLocaleDateString("en-US", opts)} – ${end.toLocaleDateString("en-US", { ...opts, year: "numeric" })}`;
-};
 
 const fmtDate = (iso: string): string =>
   new Date(`${iso}T00:00:00`).toLocaleDateString("en-US", {

--- a/src/components/notifications/NewCasesTab.tsx
+++ b/src/components/notifications/NewCasesTab.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, Fragment } from "react";
 import Link from "next/link";
 import { ChevronLeft, ChevronRight, RefreshCw, UserPlus, AlertCircle, ExternalLink } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
+import { getMonday, formatWeekLabel as formatWeekLabelBase } from "@/lib/formatters";
 
 interface DayCount {
   date: string;
@@ -23,20 +24,10 @@ interface NewCasesTabProps {
   t: ReturnType<typeof themeClasses>;
 }
 
-const getMonday = (offset = 0): string => {
-  const d = new Date();
-  const day = d.getDay();
-  d.setDate(d.getDate() - day + (day === 0 ? -6 : 1) + offset * 7);
-  return d.toISOString().split("T")[0];
-};
-
-const formatWeekLabel = (monday: string): string => {
-  const start = new Date(monday + "T00:00:00");
-  const end = new Date(monday + "T00:00:00");
-  end.setDate(end.getDate() + 6);
-  const opts: Intl.DateTimeFormatOptions = { month: "short", day: "numeric" };
-  return `${start.toLocaleDateString("en-US", opts)} – ${end.toLocaleDateString("en-US", { ...opts, year: "numeric" })}`;
-};
+// New cases land every day, not just weekdays, so this tab spans the full
+// Mon-Sun week (6 days past Monday) rather than the Mon-Fri default used by
+// Audit Log / Recent Activity.
+const formatWeekLabel = (monday: string): string => formatWeekLabelBase(monday, 6);
 
 const fmtDate = (iso: string): string =>
   new Date(`${iso}T00:00:00`).toLocaleDateString("en-US", {

--- a/src/components/notifications/NewCasesTab.tsx
+++ b/src/components/notifications/NewCasesTab.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import { useState, useEffect, useRef, Fragment } from "react";
+import Link from "next/link";
+import { ChevronLeft, ChevronRight, RefreshCw, UserPlus, AlertCircle, ExternalLink } from "lucide-react";
+import { themeClasses } from "@/lib/theme-classes";
+
+interface DayCount {
+  date: string;
+  count: number;
+}
+
+interface NewCaseRow {
+  id: number;
+  name: string;
+  externalId: string | null;
+  createdAt: string;
+  date: string;
+}
+
+interface NewCasesTabProps {
+  dark: boolean;
+  t: ReturnType<typeof themeClasses>;
+}
+
+const getMonday = (offset = 0): string => {
+  const d = new Date();
+  const day = d.getDay();
+  d.setDate(d.getDate() - day + (day === 0 ? -6 : 1) + offset * 7);
+  return d.toISOString().split("T")[0];
+};
+
+const formatWeekLabel = (monday: string): string => {
+  const start = new Date(monday + "T00:00:00");
+  const end = new Date(monday + "T00:00:00");
+  end.setDate(end.getDate() + 6);
+  const opts: Intl.DateTimeFormatOptions = { month: "short", day: "numeric" };
+  return `${start.toLocaleDateString("en-US", opts)} – ${end.toLocaleDateString("en-US", { ...opts, year: "numeric" })}`;
+};
+
+const fmtDate = (iso: string): string =>
+  new Date(`${iso}T00:00:00`).toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+
+const isToday = (iso: string): boolean =>
+  iso === new Date().toISOString().split("T")[0];
+
+const fmtTime = (iso: string): string =>
+  new Date(iso).toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
+
+const thBase = "px-3 py-2 text-[11px] font-semibold uppercase tracking-wide";
+const tdBase = "px-3 py-2 text-xs";
+
+export function NewCasesTab({ dark, t }: NewCasesTabProps) {
+  const [weekOffset, setWeekOffset] = useState(0);
+  const [days, setDays] = useState<DayCount[]>([]);
+  const [cases, setCases] = useState<NewCaseRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const monday = getMonday(weekOffset);
+
+  useEffect(() => {
+    let cancelled = false;
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setLoading(true);
+    setError(null);
+
+    fetch(`/api/cases-added?week=${monday}`, { signal: controller.signal })
+      .then((res) => {
+        if (!res.ok) throw new Error(`Failed to load new cases (${res.status})`);
+        return res.json();
+      })
+      .then((json) => {
+        if (cancelled) return;
+        setDays(json.data ?? []);
+        setCases(json.cases ?? []);
+      })
+      .catch((err) => {
+        if (cancelled || (err as Error).name === "AbortError") return;
+        setError((err as Error).message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+      abortRef.current?.abort();
+    };
+  }, [monday]);
+
+  const weekTotal = days.reduce((sum, d) => sum + d.count, 0);
+  const maxCount = Math.max(1, ...days.map((d) => d.count));
+
+  const casesByDate = cases.reduce<Record<string, NewCaseRow[]>>((acc, c) => {
+    (acc[c.date] ??= []).push(c);
+    return acc;
+  }, {});
+  const caseDates = Object.keys(casesByDate).sort((a, b) => b.localeCompare(a));
+
+  const rowDivide = dark ? "border-neutral-800/40" : "border-neutral-100";
+  const rowHover = dark ? "hover:bg-neutral-800/30" : "hover:bg-neutral-50";
+  const todayBg = dark ? "bg-indigo-900/20" : "bg-indigo-50/60";
+  const barBg = dark ? "bg-indigo-500/30" : "bg-indigo-200";
+  const dateBg = dark ? "bg-neutral-800/60" : "bg-neutral-50";
+
+  return (
+    <div className="space-y-4">
+    <div className={`rounded-xl border ${t.card}`}>
+      {/* Header */}
+      <div className={`p-4 flex flex-col sm:flex-row sm:items-center justify-between gap-3 border-b ${t.borderLight}`}>
+        <div className="flex items-center gap-3">
+          <div className={`w-10 h-10 rounded-lg flex items-center justify-center ${dark ? "bg-indigo-900/40" : "bg-indigo-50"}`}>
+            <UserPlus className={`h-5 w-5 ${dark ? "text-indigo-400" : "text-indigo-600"}`} aria-hidden="true" />
+          </div>
+          <div>
+            <h3 className={`text-sm font-bold ${t.text}`}>New Cases</h3>
+            <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
+              {weekTotal} added — {formatWeekLabel(monday)}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={() => setWeekOffset((v) => v - 1)}
+            className={`h-8 w-8 rounded-md flex items-center justify-center transition-colors ${t.hover} ${t.textSub}`}
+            aria-label="Previous week"
+          >
+            <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+          </button>
+          <span className={`text-[11px] font-medium ${t.textSub} whitespace-nowrap px-2`}>
+            {formatWeekLabel(monday)}
+          </span>
+          <button
+            onClick={() => setWeekOffset((v) => v + 1)}
+            disabled={weekOffset >= 0}
+            className={`h-8 w-8 rounded-md flex items-center justify-center transition-colors ${t.hover} ${t.textSub} disabled:opacity-40`}
+            aria-label="Next week"
+          >
+            <ChevronRight className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div
+          className={`m-4 rounded-lg border p-3 flex items-center gap-2 text-xs ${dark ? "bg-red-900/20 border-red-800 text-red-400" : "bg-red-50 border-red-200 text-red-700"}`}
+          role="alert"
+        >
+          <AlertCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
+          {error}
+        </div>
+      )}
+
+      {/* Loading */}
+      {loading && (
+        <div className="flex items-center justify-center py-16">
+          <RefreshCw className={`h-5 w-5 animate-spin ${t.textMuted}`} aria-hidden="true" />
+          <span className={`ml-2 text-sm ${t.textSub}`}>Loading new cases...</span>
+        </div>
+      )}
+
+      {/* Empty */}
+      {!loading && !error && days.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-16">
+          <UserPlus className={`h-8 w-8 ${t.textMuted} mb-3`} aria-hidden="true" />
+          <p className={`text-sm font-medium ${t.text}`}>No cases added this week</p>
+        </div>
+      )}
+
+      {/* Table */}
+      {!loading && !error && days.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-100">
+            <thead>
+              <tr className={`border-b ${t.borderLight}`}>
+                <th className={`${thBase} ${t.textSub} text-left`}>Day</th>
+                <th className={`${thBase} ${t.textSub} text-right`}>New Cases</th>
+                <th className={`${thBase} ${t.textSub} text-left`}></th>
+              </tr>
+            </thead>
+            <tbody>
+              {days.map((d) => (
+                <tr
+                  key={d.date}
+                  className={`border-b ${rowDivide} ${rowHover} transition-colors ${isToday(d.date) ? todayBg : ""}`}
+                >
+                  <td className={`${tdBase} ${t.text} font-medium`}>
+                    {fmtDate(d.date)}
+                    {isToday(d.date) && (
+                      <span className={`ml-1.5 text-[10px] font-semibold ${dark ? "text-indigo-400" : "text-indigo-600"}`}>
+                        Today
+                      </span>
+                    )}
+                  </td>
+                  <td className={`${tdBase} text-right font-semibold tabular-nums ${d.count > 0 ? t.text : t.textMuted}`}>
+                    {d.count || "—"}
+                  </td>
+                  <td className={`${tdBase} w-1/2`}>
+                    <div className={`h-2 rounded-full ${dark ? "bg-neutral-800" : "bg-neutral-100"}`}>
+                      <div
+                        className={`h-2 rounded-full ${barBg}`}
+                        style={{ width: `${(d.count / maxCount) * 100}%` }}
+                      />
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              <tr className={dark ? "bg-neutral-800/60" : "bg-neutral-50"}>
+                <td className={`${tdBase} font-semibold ${t.text}`}>Week Total</td>
+                <td className={`${tdBase} text-right font-bold tabular-nums ${t.text}`}>{weekTotal}</td>
+                <td className={tdBase}></td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      )}
+    </div>
+
+    {/* Cases Added — actual case names, separate from the daily count table above */}
+    {!loading && !error && cases.length > 0 && (
+      <div className={`rounded-xl border ${t.card} overflow-hidden`}>
+        <div className={`px-4 py-2.5 ${t.text} text-xs font-bold border-b ${t.borderLight}`}>
+          Cases Added — {formatWeekLabel(monday)}
+        </div>
+        <div className="overflow-x-auto max-h-100 overflow-y-auto">
+          <table className="w-full">
+            <thead>
+              <tr className={`border-b ${t.borderLight}`}>
+                <th className={`${thBase} ${t.textSub} text-left`}>Case Name</th>
+                <th className={`${thBase} ${t.textSub} text-left`}>Added</th>
+              </tr>
+            </thead>
+            <tbody>
+              {caseDates.map((date) => (
+                <Fragment key={date}>
+                  <tr className={dateBg}>
+                    <td colSpan={2} className={`${tdBase} font-semibold ${t.textSub}`}>
+                      {fmtDate(date)}
+                    </td>
+                  </tr>
+                  {casesByDate[date].map((c) => (
+                    <tr
+                      key={c.id}
+                      className={`border-b ${rowDivide} ${rowHover} transition-colors`}
+                    >
+                      <td className={`${tdBase} ${t.text} font-medium pl-6`}>
+                        {c.externalId ? (
+                          <a
+                            href={c.externalId}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="inline-flex items-center gap-1 hover:underline"
+                          >
+                            {c.name}
+                            <ExternalLink className="h-3 w-3 opacity-50" aria-hidden="true" />
+                          </a>
+                        ) : (
+                          <Link href={`/cases/${c.id}`} className="hover:underline">
+                            {c.name}
+                          </Link>
+                        )}
+                      </td>
+                      <td className={`${tdBase} ${t.textMuted}`}>{fmtTime(c.createdAt)}</td>
+                    </tr>
+                  ))}
+                </Fragment>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    )}
+    </div>
+  );
+}

--- a/src/components/notifications/RecentActivityTab.tsx
+++ b/src/components/notifications/RecentActivityTab.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef, Fragment } from "react";
 import { ChevronLeft, ChevronRight, RefreshCw, Clock, AlertCircle } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
+import { getMonday, formatWeekLabel } from "@/lib/formatters";
 
 interface ActivityEntry {
   id: string;
@@ -17,21 +18,6 @@ interface RecentActivityTabProps {
   dark: boolean;
   t: ReturnType<typeof themeClasses>;
 }
-
-const getMonday = (offset = 0): string => {
-  const d = new Date();
-  const day = d.getDay();
-  d.setDate(d.getDate() - day + (day === 0 ? -6 : 1) + offset * 7);
-  return d.toISOString().split("T")[0];
-};
-
-const formatWeekLabel = (monday: string): string => {
-  const start = new Date(monday + "T00:00:00");
-  const end = new Date(monday + "T00:00:00");
-  end.setDate(end.getDate() + 4);
-  const opts: Intl.DateTimeFormatOptions = { month: "short", day: "numeric" };
-  return `${start.toLocaleDateString("en-US", opts)} – ${end.toLocaleDateString("en-US", { ...opts, year: "numeric" })}`;
-};
 
 const fmtDateOnly = (iso: string): string =>
   new Date(iso).toLocaleDateString("en-US", {

--- a/src/components/overpaid-cases/OverpaidCases.tsx
+++ b/src/components/overpaid-cases/OverpaidCases.tsx
@@ -17,6 +17,7 @@ import {
   ChevronRight,
   Download,
   Upload,
+  Plus,
   X,
   Undo2,
 } from "lucide-react";
@@ -24,7 +25,10 @@ import { themeClasses } from "@/lib/theme-classes";
 import { fmt, fmtFull } from "@/lib/formatters";
 import { upsertOverpaidCase, updateFeesConfirmation, bulkMarkCleared, bulkRestoreCleared, bulkImportOverpaidCases } from "@/app/(dashboard)/overpaid-cases/actions";
 import CsvImportModal, { type ColumnDef } from "@/components/modals/CsvImportModal";
+import AddCaseModal from "@/components/modals/AddCaseModal";
 import { parseBool, parseDate, parseDecimalString } from "@/lib/import/csv-parser";
+import type { DropdownOptionsByCategory } from "@/hooks/useDashboard";
+import type { ApprovedByOption } from "@/types";
 
 // ---------- types ----------
 interface OverpaidCaseRow {
@@ -687,6 +691,48 @@ export const OverpaidCases = () => {
 
   const [exporting, setExporting] = useState(false);
   const [csvImportOpen, setCsvImportOpen] = useState(false);
+  const [addCaseOpen, setAddCaseOpen] = useState(false);
+  const [dropdownOptions, setDropdownOptions] = useState<DropdownOptionsByCategory>({});
+
+  // Lazy-loaded the first time the Add Case modal opens — this page doesn't
+  // otherwise need the full dropdown-options set, so there's no reason to
+  // fetch it on every page load.
+  const openAddCase = async () => {
+    if (Object.keys(dropdownOptions).length === 0) {
+      try {
+        const res = await fetch("/api/settings/dropdown-options");
+        if (res.ok) {
+          const json = await res.json();
+          const all: (ApprovedByOption & { category: string })[] = json.data || [];
+          const grouped: DropdownOptionsByCategory = {};
+          for (const o of all) {
+            (grouped[o.category as keyof DropdownOptionsByCategory] ||= []).push(o);
+          }
+          setDropdownOptions(grouped);
+        }
+      } catch {
+        /* non-critical — modal falls back to empty dropdowns */
+      }
+    }
+    setAddCaseOpen(true);
+  };
+
+  // A manually-added case has no fee_records row marked overpaid yet (it
+  // isn't part of a Sheets/MyCase sync, just created bare via AddCaseModal),
+  // so flip that flag right after creation — this is what actually makes it
+  // show up in this page's own list.
+  const markNewCaseOverpaid = async (clientId: number) => {
+    const res = await fetch("/api/cases/bulk-overpaid", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ caseIds: [clientId], markedOverpaid: true }),
+    });
+    if (!res.ok) {
+      const json = await res.json().catch(() => ({}));
+      throw new Error(json.error || `Failed to mark case overpaid (${res.status})`);
+    }
+    await fetchCases();
+  };
 
   const downloadCsv = async () => {
     setExporting(true);
@@ -785,6 +831,14 @@ export const OverpaidCases = () => {
           onImport={bulkImportOverpaidCases}
           onClose={() => setCsvImportOpen(false)}
           onSuccess={fetchCases}
+        />
+      )}
+      {addCaseOpen && (
+        <AddCaseModal
+          dark={dark}
+          dropdownOptions={dropdownOptions}
+          onClose={() => setAddCaseOpen(false)}
+          onCreated={markNewCaseOverpaid}
         />
       )}
       <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
@@ -1036,6 +1090,15 @@ export const OverpaidCases = () => {
             >
               <Upload aria-hidden="true" className="h-3.5 w-3.5" />
               <span className="hidden sm:inline">Import</span>
+            </button>
+            <button
+              onClick={openAddCase}
+              className={`h-8 px-2.5 rounded-md border text-xs font-medium flex items-center gap-1.5 ${t.outlineBtn}`}
+              aria-label="Manually add an overpaid case"
+              title="For cases handled here that never came through Master Fees"
+            >
+              <Plus aria-hidden="true" className="h-3.5 w-3.5" />
+              <span className="hidden sm:inline">Add Case</span>
             </button>
           </div>
         </div>

--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -19,10 +19,11 @@ import {
   Save,
   X,
   Check,
+  ExternalLink,
 } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { themeClasses } from "@/lib/theme-classes";
-import { fmt } from "@/lib/formatters";
+import { fmt, fmtDate } from "@/lib/formatters";
 import {
   ScoreboardSummaryCards,
   ScoreboardSummary,
@@ -67,12 +68,24 @@ interface DailyEntry {
   notes: string | null;
 }
 
+interface NoFeesCaseRow {
+  id: number;
+  name: string;
+  externalId: string | null;
+  assigned: string;
+  claim: string;
+  approvalDate: string | null;
+  daysSinceApproval: number;
+}
+
 interface TrackerData {
   agents: AgentScore[];
   daily: DailyEntry[];
   summary: ScoreboardSummary | null;
   teams: ScoreboardTeam[];
   openCasesFeesStatus: { noFees: number; partial: number; pif: number };
+  noFeesAging: { over60: number; over90: number };
+  noFeesCases: NoFeesCaseRow[];
 }
 
 type CellKey = `${string}|${string}`;
@@ -302,6 +315,8 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
         summary: json.summary ?? null,
         teams: json.teams ?? [],
         openCasesFeesStatus: json.openCasesFeesStatus ?? { noFees: 0, partial: 0, pif: 0 },
+        noFeesAging: json.noFeesAging ?? { over60: 0, over90: 0 },
+        noFeesCases: json.noFeesCases ?? [],
       });
       const map = new Map<CellKey, CellValues>();
       for (const d of (json.daily ?? []) as DailyEntry[]) {
@@ -489,6 +504,70 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
               </div>
             ))}
           </div>
+        </div>
+      )}
+
+      {/* No Fees Cases — actual aging cases, for reporting */}
+      {data?.noFeesAging && (
+        <div className={`rounded-xl border ${t.card} overflow-hidden`}>
+          <div className={`px-4 py-2.5 flex items-center justify-between border-b ${t.borderLight}`}>
+            <span className={`text-xs font-bold ${t.text}`}>No Fees Cases</span>
+            <span className="text-[11px] font-medium tabular-nums">
+              <span className={dark ? "text-amber-400" : "text-amber-600"}>{data.noFeesAging.over60} over 60 days</span>
+              <span className={t.textMuted}> · </span>
+              <span className={dark ? "text-red-400" : "text-red-600"}>{data.noFeesAging.over90} over 90 days</span>
+            </span>
+          </div>
+          {data.noFeesCases.length === 0 ? (
+            <div className={`py-6 text-center text-xs ${t.textMuted}`}>No aging no-fee cases.</div>
+          ) : (
+            <div className="overflow-x-auto max-h-80 overflow-y-auto">
+              <table className="w-full">
+                <thead>
+                  <tr className={`border-b ${t.borderLight}`}>
+                    <th className={`${thBase} ${t.textSub} text-left`}>Case Name</th>
+                    <th className={`${thBase} ${t.textSub} text-left`}>Assigned</th>
+                    <th className={`${thBase} ${t.textSub} text-left`}>Claim</th>
+                    <th className={`${thBase} ${t.textSub} text-left`}>Approval</th>
+                    <th className={`${thBase} ${t.textSub} text-right`}>Days</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.noFeesCases.map((c) => (
+                    <tr key={c.id} className={`border-b ${rowBorder} ${rowHover}`}>
+                      <td className={`${tdBase} ${t.text} font-medium`}>
+                        {c.externalId ? (
+                          <a
+                            href={c.externalId}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="inline-flex items-center gap-1 hover:underline"
+                          >
+                            {c.name}
+                            <ExternalLink className="h-3 w-3 opacity-50" aria-hidden="true" />
+                          </a>
+                        ) : (
+                          c.name
+                        )}
+                      </td>
+                      <td className={`${tdBase} ${t.textSub}`}>{c.assigned}</td>
+                      <td className={`${tdBase} ${t.textSub}`}>{c.claim}</td>
+                      <td className={`${tdBase} ${t.textSub}`}>{fmtDate(c.approvalDate)}</td>
+                      <td
+                        className={`${tdBase} text-right font-semibold ${
+                          c.daysSinceApproval > 90
+                            ? dark ? "text-red-400" : "text-red-600"
+                            : dark ? "text-amber-400" : "text-amber-600"
+                        }`}
+                      >
+                        {c.daysSinceApproval}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
         </div>
       )}
 

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -19,6 +19,27 @@ export const fmtDate = (d: string | null | undefined): string => {
   return `${m}/${day}/${y}`;
 };
 
+// Monday (YYYY-MM-DD) of the current week, shifted by `offset` weeks.
+// Shared by the week-nav tabs on Notifications and Reports.
+export const getMonday = (offset = 0): string => {
+  const d = new Date();
+  const day = d.getDay();
+  d.setDate(d.getDate() - day + (day === 0 ? -6 : 1) + offset * 7);
+  return d.toISOString().split("T")[0];
+};
+
+// "Jun 29 – Jul 3, 2026"-style label for the week starting at `monday`.
+// `spanDays` is the offset to the END of the displayed week — 4 for a
+// Mon-Fri business week (Audit Log, Recent Activity), 6 for a full Mon-Sun
+// week (New Cases, which counts cases added every day, not just weekdays).
+export const formatWeekLabel = (monday: string, spanDays = 4): string => {
+  const start = new Date(monday + "T00:00:00");
+  const end = new Date(monday + "T00:00:00");
+  end.setDate(end.getDate() + spanDays);
+  const opts: Intl.DateTimeFormatOptions = { month: "short", day: "numeric" };
+  return `${start.toLocaleDateString("en-US", opts)} – ${end.toLocaleDateString("en-US", { ...opts, year: "numeric" })}`;
+};
+
 // Timestamp for notes/activity — e.g. "May 3, 8:00 PM". Takes a full ISO
 // timestamp (with time), unlike fmtDate which takes a date-only string.
 export const fmtDateTime = (iso: string | null | undefined): string => {


### PR DESCRIPTION
## Summary
- Adds a "No Fees Cases" aging table (>60/>90d) to the Reports page — lists actual cases, not just counts
- Adds a "New Cases" tab to Notifications — per-day counts plus the actual case names added each day
- Adds Fees Requested/Fees Received totals to the Fee Petitions page (active list + Completed Petitions), summed across the full filtered set
- Adds an "Add Case" button to Overpaid Cases for cases the team handles that never came through Master Fees sync — reuses `AddCaseModal`, then marks the new case overpaid
- Fees Closed page: "Closed On" column is now sortable, and "Fees Confirmation" is now editable (both were previously Master-Fees-only)
- Small toolbar tweaks: renamed "All Approvers" → "Cases Approved", moved "All Status" filter next to "All Claims"
- Fixes two Completed Petitions bugs: frozen Claimant/Fee Requested columns could overlap on long claimant names; expanding the panel could leave a blank gap below the dashboard shell (Chromium sticky-column scrollHeight quirk)
- Dedupes `getMonday`/`formatWeekLabel` week-nav helpers (previously copy-pasted across 3 notification tabs) into `lib/formatters.ts`

## Notes
- Overpaid Cases manual-add was verified short of actual submission (would have written a real case into production) — please do one real end-to-end test before relying on it.
- The Completed Petitions overlap fix was verified via an isolated reproduction, since production currently has 0 completed petitions to test against directly — please confirm visually once one exists with a longer claimant name.