### PR TITLE
fix: fees-closed page missing dropdown options

### DIFF
--- a/src/app/(dashboard)/fees-closed/page.tsx
+++ b/src/app/(dashboard)/fees-closed/page.tsx
@@ -6,7 +6,8 @@ import { RefreshCw, AlertCircle, CheckCircle2 } from "lucide-react";
 import { FeeRecordsTable } from "@/components/cases/FeeRecordsTable";
 import { useDateRange } from "@/lib/date-range-context";
 import { themeClasses } from "@/lib/theme-classes";
-import type { CaseRow } from "@/types";
+import type { CaseRow, ApprovedByOption } from "@/types";
+import type { DropdownOptionsByCategory } from "@/hooks/useDashboard";
 
 type LevelFilter = "all" | "fee_petition";
 
@@ -22,6 +23,8 @@ export default function FeesClosedPage() {
   const [levelFilter, setLevelFilter] = useState<LevelFilter>("all");
   const [closedFrom, setClosedFrom] = useState("");
   const [closedTo, setClosedTo] = useState("");
+  const [dropdownOptions, setDropdownOptions] = useState<DropdownOptionsByCategory>({});
+  const [approvedByOptions, setApprovedByOptions] = useState<ApprovedByOption[]>([]);
   const controllerRef = useRef<AbortController | null>(null);
 
   const fetchClosed = useCallback(async () => {
@@ -40,6 +43,29 @@ export default function FeesClosedPage() {
     } finally {
       if (!controller.signal.aborted) setLoading(false);
     }
+  }, []);
+
+  // Powers the inline-editable dropdowns (Fees Conf, Claim, Level, Assigned,
+  // Win Sheet Status, Approved By) — FeeRecordsTable renders those as
+  // "— Select —" plus only the current value when this is empty. Master Fees
+  // gets this for free via useDashboard(); fees-closed fetches its own case
+  // list instead, so it needs this separately.
+  useEffect(() => {
+    const controller = new AbortController();
+    fetch("/api/settings/dropdown-options", { signal: controller.signal })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((json) => {
+        if (!json) return;
+        const all: (ApprovedByOption & { category: string })[] = json.data || [];
+        const grouped: DropdownOptionsByCategory = {};
+        for (const o of all) {
+          (grouped[o.category as keyof DropdownOptionsByCategory] ||= []).push(o);
+        }
+        setDropdownOptions(grouped);
+        setApprovedByOptions(grouped.approved_by || []);
+      })
+      .catch(() => {});
+    return () => controller.abort();
   }, []);
 
   useEffect(() => {
@@ -157,6 +183,8 @@ export default function FeesClosedPage() {
         dateRange={dateRange}
         mode="closed"
         onImported={fetchClosed}
+        dropdownOptions={dropdownOptions}
+        approvedByOptions={approvedByOptions}
       />
     </div>
   );

--- a/src/app/(dashboard)/fees-closed/page.tsx
+++ b/src/app/(dashboard)/fees-closed/page.tsx
@@ -7,7 +7,7 @@ import { FeeRecordsTable } from "@/components/cases/FeeRecordsTable";
 import { useDateRange } from "@/lib/date-range-context";
 import { themeClasses } from "@/lib/theme-classes";
 import type { CaseRow, ApprovedByOption } from "@/types";
-import type { DropdownOptionsByCategory } from "@/hooks/useDashboard";
+import { fetchDropdownOptions, type DropdownOptionsByCategory } from "@/lib/dropdown-options";
 
 type LevelFilter = "all" | "fee_petition";
 
@@ -52,18 +52,14 @@ export default function FeesClosedPage() {
   // list instead, so it needs this separately.
   useEffect(() => {
     const controller = new AbortController();
-    fetch("/api/settings/dropdown-options", { signal: controller.signal })
-      .then((res) => (res.ok ? res.json() : null))
-      .then((json) => {
-        if (!json) return;
-        const all: (ApprovedByOption & { category: string })[] = json.data || [];
-        const grouped: DropdownOptionsByCategory = {};
-        for (const o of all) {
-          (grouped[o.category as keyof DropdownOptionsByCategory] ||= []).push(o);
-        }
+    fetchDropdownOptions(controller.signal)
+      .then((grouped) => {
         setDropdownOptions(grouped);
         setApprovedByOptions(grouped.approved_by || []);
       })
+      // Includes AbortError on unmount — fetchDropdownOptions doesn't catch
+      // it internally, so it lands here and we correctly skip the setState
+      // calls above instead of firing them after unmount.
       .catch(() => {});
     return () => controller.abort();
   }, []);

--- a/src/components/overpaid-cases/OverpaidCases.tsx
+++ b/src/components/overpaid-cases/OverpaidCases.tsx
@@ -27,8 +27,7 @@ import { upsertOverpaidCase, updateFeesConfirmation, bulkMarkCleared, bulkRestor
 import CsvImportModal, { type ColumnDef } from "@/components/modals/CsvImportModal";
 import AddCaseModal from "@/components/modals/AddCaseModal";
 import { parseBool, parseDate, parseDecimalString } from "@/lib/import/csv-parser";
-import type { DropdownOptionsByCategory } from "@/hooks/useDashboard";
-import type { ApprovedByOption } from "@/types";
+import { fetchDropdownOptions, type DropdownOptionsByCategory } from "@/lib/dropdown-options";
 
 // ---------- types ----------
 interface OverpaidCaseRow {
@@ -700,16 +699,7 @@ export const OverpaidCases = () => {
   const openAddCase = async () => {
     if (Object.keys(dropdownOptions).length === 0) {
       try {
-        const res = await fetch("/api/settings/dropdown-options");
-        if (res.ok) {
-          const json = await res.json();
-          const all: (ApprovedByOption & { category: string })[] = json.data || [];
-          const grouped: DropdownOptionsByCategory = {};
-          for (const o of all) {
-            (grouped[o.category as keyof DropdownOptionsByCategory] ||= []).push(o);
-          }
-          setDropdownOptions(grouped);
-        }
+        setDropdownOptions(await fetchDropdownOptions());
       } catch {
         /* non-critical — modal falls back to empty dropdowns */
       }

--- a/src/hooks/useDashboard.ts
+++ b/src/hooks/useDashboard.ts
@@ -9,10 +9,12 @@ import type {
   ApprovedByOption,
 } from "@/types";
 import type { DropdownCategory } from "@/lib/dropdown-categories";
+import type { DropdownOptionsByCategory } from "@/lib/dropdown-options";
 
-export type DropdownOptionsByCategory = Partial<
-  Record<DropdownCategory, ApprovedByOption[]>
->;
+// Re-exported for the many existing `from "@/hooks/useDashboard"` imports —
+// the type itself now lives in lib/dropdown-options.ts alongside the fetch
+// helper other pages use instead of pulling in this whole hook.
+export type { DropdownOptionsByCategory };
 
 interface DashboardData {
   cases: CaseRow[];
@@ -90,7 +92,13 @@ export const useDashboard = (): DashboardData => {
         const optJson = await optRes.json();
         const all: (ApprovedByOption & { category: DropdownCategory })[] =
           optJson.data || [];
-        // Group by category for fast per-cell lookup in the table.
+        // Grouped inline rather than via the shared groupDropdownOptions()
+        // helper — routing this specific assignment through a function call
+        // trips a false-positive react-hooks/set-state-in-effect on this
+        // effect's deeply-nested async IIFE (verified: reverting to the
+        // inline loop, byte-for-byte the same result, makes the lint error
+        // disappear). Keep this in sync with lib/dropdown-options.ts's
+        // groupDropdownOptions if the category-key logic ever changes.
         const grouped: DropdownOptionsByCategory = {};
         for (const o of all) {
           (grouped[o.category] ||= []).push(o);

--- a/src/lib/dropdown-options.ts
+++ b/src/lib/dropdown-options.ts
@@ -1,0 +1,35 @@
+import type { ApprovedByOption } from "@/types";
+import type { DropdownCategory } from "@/lib/dropdown-categories";
+
+export type DropdownOptionsByCategory = Partial<
+  Record<DropdownCategory, ApprovedByOption[]>
+>;
+
+// Groups the flat /api/settings/dropdown-options row list by category, for
+// fast per-cell lookup in inline-editable dropdowns.
+export const groupDropdownOptions = (
+  rows: (ApprovedByOption & { category: DropdownCategory })[],
+): DropdownOptionsByCategory => {
+  const grouped: DropdownOptionsByCategory = {};
+  for (const o of rows) {
+    (grouped[o.category] ||= []).push(o);
+  }
+  return grouped;
+};
+
+// Fetches every dropdown-option category in one round trip and groups it.
+// Returns {} on a non-OK response — callers treat an empty category as "no
+// options configured yet", which every inline dropdown already renders
+// gracefully (just "— Select —" plus the current value). Does NOT catch
+// fetch errors itself (including AbortError) — that's left to the caller,
+// which needs to distinguish "aborted, don't touch state" from "real
+// failure, fall back to {}" per this codebase's AbortController convention.
+export const fetchDropdownOptions = async (
+  signal?: AbortSignal,
+): Promise<DropdownOptionsByCategory> => {
+  const res = await fetch("/api/settings/dropdown-options", { signal });
+  if (!res.ok) return {};
+  const json = await res.json();
+  const rows: (ApprovedByOption & { category: DropdownCategory })[] = json.data || [];
+  return groupDropdownOptions(rows);
+};


### PR DESCRIPTION
## Summary
- Fees Closed page never fetched `dropdownOptions`/`approvedByOptions` and never passed them to `FeeRecordsTable`, so every inline-editable dropdown there (Fees Conf, Claim, Level, Assigned, Win Sheet Status) only showed "— Select —" plus the current value instead of the real option list
- Extracted the fetch-then-group-by-category logic (previously copy-pasted in `useDashboard.ts` and `OverpaidCases.tsx`) into a shared `src/lib/dropdown-options.ts` helper, now used by Fees Closed and Overpaid Cases