### PR TITLE
feat: exclude team leads from scoreboard/agent tracking rows

### DIFF
--- a/src/app/api/scoreboard/route.ts
+++ b/src/app/api/scoreboard/route.ts
@@ -58,6 +58,7 @@ export const GET = async (req: NextRequest) => {
       SELECT
         tm.name AS agent,
         tm.team AS team,
+        tm.role AS role,
 
         -- Cases assigned (current snapshot)
         (SELECT COUNT(*) FROM fee_records fr WHERE fr.assigned_to = tm.name) AS cases_assigned,
@@ -237,6 +238,7 @@ export const GET = async (req: NextRequest) => {
       (r) => ({
         agent: String(r.agent),
         team: r.team ? String(r.team) : null,
+        role: r.role ? String(r.role) : null,
         casesAssigned: Number(r.cases_assigned),
         openCases: Number(r.open_cases),
         casesClosed: Number(r.cases_closed),

--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -301,7 +301,12 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
       const json = await res.json();
       if (cancelledRef.current) return;
       setData({
-        agents: (json.agents ?? []).map((a: AgentScore) => ({
+        // Team leads are counted in data.teams' financial rollups (computed
+        // server-side from the full roster) but excluded from this per-agent
+        // breakdown — they aren't scored individually like line agents.
+        agents: (json.agents ?? [])
+          .filter((a: AgentScore & { role?: string | null }) => a.role !== "team_lead")
+          .map((a: AgentScore) => ({
           ...a,
           unpaidT2Over90:   a.unpaidT2Over90   ?? 0,
           unpaidT16Over90:  a.unpaidT16Over90  ?? 0,

--- a/src/components/scoreboard/Scoreboard.tsx
+++ b/src/components/scoreboard/Scoreboard.tsx
@@ -13,6 +13,7 @@ import { parseDate, parseNonNegativeInt } from "@/lib/import/csv-parser";
 interface AgentWeekData {
   agent: string;
   team: string;
+  role: string | null;
   casesClosed: number;
 }
 
@@ -133,6 +134,7 @@ export const Scoreboard = () => {
             agents: (json.agents ?? []).map((a: AgentWeekData) => ({
               agent: a.agent,
               team: a.team ?? "",
+              role: a.role ?? null,
               casesClosed: a.casesClosed ?? 0,
             })),
           }))
@@ -156,7 +158,7 @@ export const Scoreboard = () => {
   const currentWeekMax = Math.max(
     ...TEAMS.flatMap(({ key }) =>
       (weeks[0]?.agents ?? [])
-        .filter((a) => a.team === key)
+        .filter((a) => a.team === key && a.role !== "team_lead")
         .map((a) => a.casesClosed)
     ),
     1
@@ -246,7 +248,12 @@ export const Scoreboard = () => {
       {!loading && !error && weeks.length > 0 && (
         <div>
           {TEAMS.map(({ key, label, headerBg }) => {
-            const currentAgents = (weeks[0]?.agents ?? []).filter((a) => a.team === key);
+            // Team leads (e.g. supervisors) are excluded from the per-agent
+            // ranking rows — they're still counted in team-level financial
+            // totals elsewhere (Reports), just not scored individually here.
+            const currentAgents = (weeks[0]?.agents ?? []).filter(
+              (a) => a.team === key && a.role !== "team_lead",
+            );
             const rows = currentAgents
               .map((a) => ({
                 agent: a.agent,

--- a/src/components/team/TeamManagement.tsx
+++ b/src/components/team/TeamManagement.tsx
@@ -38,6 +38,7 @@ interface TeamMemberFull {
 
 const ROLES = [
   { value: "collections_specialist", label: "Collections Specialist" },
+  { value: "team_lead", label: "Team Lead" },
   { value: "collections_manager", label: "Collections Manager" },
   { value: "paralegal", label: "Paralegal" },
   { value: "attorney", label: "Attorney" },


### PR DESCRIPTION
## Summary
- Adds a "Team Lead" role option on the Team page (Georgia and DeeAnn had no proper way to be marked as leads — one was `collections_specialist`, the other an unlisted `supervisor` value set directly in the data)
- Scoreboard page and Reports agent tracking table now exclude `team_lead` rows from the per-agent performance listing, since leads aren't scored on case-closing like line agents
- Team-level financial rollups (Reports summary cards) are unaffected — computed server-side from the full roster before the role filter applies, so leads' case/collection contributions still count there