### PR TITLE
feat: sort agent tracking table alphabetically by name

### DIFF
--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -362,12 +362,17 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
 
   const filteredAgents = useMemo(() => {
     const q = agentSearch.trim().toLowerCase();
-    return (data?.agents ?? []).filter((a) => {
-      if (q && !a.agent.toLowerCase().includes(q)) return false;
-      if (teamFilter !== "all" && a.team !== teamFilter) return false;
-      if (needsAttention && !hasOverdue(a, t2Days, t16Days, concDays)) return false;
-      return true;
-    });
+    return (data?.agents ?? [])
+      .filter((a) => {
+        if (q && !a.agent.toLowerCase().includes(q)) return false;
+        if (teamFilter !== "all" && a.team !== teamFilter) return false;
+        if (needsAttention && !hasOverdue(a, t2Days, t16Days, concDays)) return false;
+        return true;
+      })
+      // Alphabetical by name — the underlying query orders by team then
+      // name, which left agents with no team (a handful of departed staff)
+      // clustered at the very bottom instead of sorted in with everyone else.
+      .sort((a, b) => a.agent.localeCompare(b.agent));
   }, [data, agentSearch, teamFilter, t2Days, t16Days, concDays, needsAttention]);
 
   const filteredTotals = useMemo(() => ({


### PR DESCRIPTION
## Summary
- Reports agent tracking table now sorts alphabetically by agent name, instead of team-then-name — agents with no team assigned previously formed their own cluster at the very bottom rather than sorting in with everyone else
- Scoped to Reports only; the standalone /scoreboard page's ranking sort (by cases closed) is unchanged and out of scope

## Note
Darrell, Drake, Nelia, and Shane (previously showing at the bottom, no team assigned) were also deactivated as team members since they've left — that's a data change made directly via the Team page, not part of this diff.