### PR TITLE
feat: expand note fields on click for readability

### DIFF
--- a/src/components/fee-petitions/CompletedPetitions.tsx
+++ b/src/components/fee-petitions/CompletedPetitions.tsx
@@ -21,6 +21,7 @@ import {
 import { themeClasses } from "@/lib/theme-classes";
 import { fmt, fmtDate } from "@/lib/formatters";
 import { upsertFeePetition } from "@/app/(dashboard)/fee-petitions/actions";
+import { NoteField } from "@/components/shared/NoteField";
 
 interface CompletedRow {
   id: number;
@@ -636,29 +637,14 @@ export const CompletedPetitions = ({ dark, canFinalize }: Props) => {
                           </td>
                         ))}
                         <td className={`${tdBase}`}>
-                          <div className="relative">
-                            <input
-                              type="text"
-                              value={row.updateNote}
-                              onChange={(e) => setNoteLocal(row.id, e.target.value)}
-                              onBlur={() => persistNote(row)}
-                              placeholder="Add a note..."
-                              maxLength={5000}
-                              className={`w-full h-7 pl-2 pr-7 rounded-md border text-[11px] outline-none focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-600 ${t.inputBg}`}
-                            />
-                            {noteState[row.id] === "saving" && (
-                              <Loader2
-                                aria-hidden="true"
-                                className={`absolute right-2 top-1/2 -translate-y-1/2 h-3 w-3 animate-spin ${t.textMuted}`}
-                              />
-                            )}
-                            {noteState[row.id] === "saved" && (
-                              <Check
-                                aria-hidden="true"
-                                className={`absolute right-2 top-1/2 -translate-y-1/2 h-3 w-3 ${dark ? "text-emerald-400" : "text-emerald-600"}`}
-                              />
-                            )}
-                          </div>
+                          <NoteField
+                            value={row.updateNote}
+                            onChange={(v) => setNoteLocal(row.id, v)}
+                            onSave={() => persistNote(row)}
+                            dark={dark}
+                            t={t}
+                            status={noteState[row.id]}
+                          />
                         </td>
                       </tr>
                     );

--- a/src/components/fee-petitions/FeePetitions.tsx
+++ b/src/components/fee-petitions/FeePetitions.tsx
@@ -28,6 +28,7 @@ import { CompletedPetitions } from "./CompletedPetitions";
 import { useCapabilities } from "@/hooks/useCapabilities";
 import CsvImportModal, { type ColumnDef } from "@/components/modals/CsvImportModal";
 import { parseBool } from "@/lib/import/csv-parser";
+import { NoteField } from "@/components/shared/NoteField";
 
 // ---------- types ----------
 interface FeePetitionRow {
@@ -1196,23 +1197,14 @@ export const FeePetitions = () => {
                         </td>
                       ))}
                       <td className={`${tdBase}`}>
-                        <div className="relative">
-                          <input
-                            type="text"
-                            value={row.updateNote}
-                            onChange={(e) => setUpdateNoteLocal(row.id, e.target.value)}
-                            onBlur={() => persistUpdateNote(row)}
-                            placeholder="Add a note..."
-                            maxLength={5000}
-                            className={`w-full h-7 pl-2 pr-7 rounded-md border text-[11px] outline-none focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-600 ${t.inputBg}`}
-                          />
-                          {noteState[row.id] === "saving" && (
-                            <Loader2 aria-hidden="true" className={`absolute right-2 top-1/2 -translate-y-1/2 h-3 w-3 animate-spin ${t.textMuted}`} />
-                          )}
-                          {noteState[row.id] === "saved" && (
-                            <Check aria-hidden="true" className={`absolute right-2 top-1/2 -translate-y-1/2 h-3 w-3 ${dark ? "text-emerald-400" : "text-emerald-600"}`} />
-                          )}
-                        </div>
+                        <NoteField
+                          value={row.updateNote}
+                          onChange={(v) => setUpdateNoteLocal(row.id, v)}
+                          onSave={() => persistUpdateNote(row)}
+                          dark={dark}
+                          t={t}
+                          status={noteState[row.id]}
+                        />
                       </td>
                     </tr>
                   );

--- a/src/components/overpaid-cases/OverpaidCases.tsx
+++ b/src/components/overpaid-cases/OverpaidCases.tsx
@@ -28,6 +28,7 @@ import CsvImportModal, { type ColumnDef } from "@/components/modals/CsvImportMod
 import AddCaseModal from "@/components/modals/AddCaseModal";
 import { parseBool, parseDate, parseDecimalString } from "@/lib/import/csv-parser";
 import { fetchDropdownOptions, type DropdownOptionsByCategory } from "@/lib/dropdown-options";
+import { NoteField } from "@/components/shared/NoteField";
 
 // ---------- types ----------
 interface OverpaidCaseRow {
@@ -1479,23 +1480,14 @@ export const OverpaidCases = () => {
                         </div>
                       </td>
                       <td className={`${tdBase}`}>
-                        <div className="relative">
-                          <input
-                            type="text"
-                            value={row.updateNote}
-                            onChange={(e) => setUpdateNoteLocal(row.id, e.target.value)}
-                            onBlur={() => persistUpdateNote(row)}
-                            placeholder="Add a note..."
-                            maxLength={5000}
-                            className={`w-full h-7 pl-2 pr-7 rounded-md border text-[11px] outline-none focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-600 ${t.inputBg}`}
-                          />
-                          {noteState[row.id] === "saving" && (
-                            <Loader2 aria-hidden="true" className={`absolute right-2 top-1/2 -translate-y-1/2 h-3 w-3 animate-spin ${t.textMuted}`} />
-                          )}
-                          {noteState[row.id] === "saved" && (
-                            <Check aria-hidden="true" className={`absolute right-2 top-1/2 -translate-y-1/2 h-3 w-3 ${dark ? "text-emerald-400" : "text-emerald-600"}`} />
-                          )}
-                        </div>
+                        <NoteField
+                          value={row.updateNote}
+                          onChange={(v) => setUpdateNoteLocal(row.id, v)}
+                          onSave={() => persistUpdateNote(row)}
+                          dark={dark}
+                          t={t}
+                          status={noteState[row.id]}
+                        />
                       </td>
                       <td className={`${tdBase} text-center`}>
                         <div className="flex flex-col items-center gap-0.5">

--- a/src/components/shared/NoteField.tsx
+++ b/src/components/shared/NoteField.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2, Check } from "lucide-react";
+import type { themeClasses } from "@/lib/theme-classes";
+
+interface NoteFieldProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSave: () => void;
+  dark: boolean;
+  t: ReturnType<typeof themeClasses>;
+  placeholder?: string;
+  maxLength?: number;
+  status?: "saving" | "saved";
+  "aria-label"?: string;
+}
+
+// Single-line by default, so it fits inline like the plain <input> it
+// replaces — but expands into a taller, wrapped textarea on focus/click so a
+// long note is actually readable while editing, then collapses back (and
+// saves) on blur. Used anywhere a per-row "update note" field is edited:
+// Fee Petitions, Completed Petitions, Overpaid Cases.
+export function NoteField({
+  value,
+  onChange,
+  onSave,
+  dark,
+  t,
+  placeholder = "Add a note...",
+  maxLength = 5000,
+  status,
+  "aria-label": ariaLabel,
+}: NoteFieldProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="relative">
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onFocus={() => setExpanded(true)}
+        onBlur={() => {
+          setExpanded(false);
+          onSave();
+        }}
+        placeholder={placeholder}
+        maxLength={maxLength}
+        rows={expanded ? 5 : 1}
+        aria-label={ariaLabel}
+        className={`w-full pl-2 pr-7 py-1 rounded-md border text-[11px] outline-none resize-none transition-[height] focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-600 ${
+          expanded ? "" : "h-7 overflow-hidden whitespace-nowrap"
+        } ${t.inputBg}`}
+      />
+      {status === "saving" && (
+        <Loader2
+          aria-hidden="true"
+          className={`absolute right-2 top-1/2 -translate-y-1/2 h-3 w-3 animate-spin ${t.textMuted}`}
+        />
+      )}
+      {status === "saved" && (
+        <Check
+          aria-hidden="true"
+          className={`absolute right-2 top-1/2 -translate-y-1/2 h-3 w-3 ${dark ? "text-emerald-400" : "text-emerald-600"}`}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/shared/NoteField.tsx
+++ b/src/components/shared/NoteField.tsx
@@ -48,8 +48,8 @@ export function NoteField({
         maxLength={maxLength}
         rows={expanded ? 5 : 1}
         aria-label={ariaLabel}
-        className={`w-full pl-2 pr-7 py-1 rounded-md border text-[11px] outline-none resize-none transition-[height] focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-600 ${
-          expanded ? "" : "h-7 overflow-hidden whitespace-nowrap"
+        className={`pl-2 pr-7 py-1 rounded-md border text-[11px] outline-none resize-none transition-[height] focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-600 ${
+          expanded ? "w-full min-w-80" : "w-full h-7 overflow-hidden whitespace-nowrap"
         } ${t.inputBg}`}
       />
       {status === "saving" && (


### PR DESCRIPTION
## Summary
- Fee Petitions "Update" and Overpaid Cases "Notes" (Completed Petitions shares the same Fee Petitions data) were single-line inputs that clipped long notes with no way to read them without scrolling inside the box
- Extracted a shared `NoteField` component: compact single line when idle, expands taller (5 rows) and wider (min 320px) on click/focus so the full note is readable, collapses back and saves on blur — same save behavior as before
- Master Fees / Fees Closed's "Recent Update" column already had a hover-tooltip solution and was left untouched