### PR TITLE
fix: base Reports partial/pending on Fees Conf value, not fee amounts

### DIFF
--- a/src/app/api/scoreboard/route.ts
+++ b/src/app/api/scoreboard/route.ts
@@ -196,14 +196,7 @@ export const GET = async (req: NextRequest) => {
          WHERE fr.assigned_to = tm.name
          AND fr.is_closed = FALSE
          AND fr.pif_ready_to_close IS NOT TRUE
-         AND NOT (
-           COALESCE(fr.t16_fee_due, 0)::numeric = 0
-           AND COALESCE(fr.t2_fee_due, 0)::numeric = 0
-           AND COALESCE(fr.aux_fee_due, 0)::numeric = 0
-           AND COALESCE(fr.t16_fee_received, 0)::numeric = 0
-           AND COALESCE(fr.t2_fee_received, 0)::numeric = 0
-           AND COALESCE(fr.aux_fee_received, 0)::numeric = 0
-         )
+         AND fr.fees_confirmation IN ('Partial Payment', 'Pending (full/partial)')
         )::int AS open_partial,
 
         (SELECT COUNT(*) FROM fee_records fr
@@ -339,14 +332,7 @@ export const GET = async (req: NextRequest) => {
         )::int AS no_fees_count,
         COUNT(*) FILTER (
           WHERE pif_ready_to_close IS NOT TRUE
-            AND NOT (
-              COALESCE(t16_fee_due, 0)::numeric = 0
-              AND COALESCE(t2_fee_due, 0)::numeric = 0
-              AND COALESCE(aux_fee_due, 0)::numeric = 0
-              AND COALESCE(t16_fee_received, 0)::numeric = 0
-              AND COALESCE(t2_fee_received, 0)::numeric = 0
-              AND COALESCE(aux_fee_received, 0)::numeric = 0
-            )
+            AND fees_confirmation IN ('Partial Payment', 'Pending (full/partial)')
         )::int AS partial_count
       FROM fee_records
       WHERE is_closed = false


### PR DESCRIPTION
## Summary
- The Reports/Scoreboard "Partial/Pending" bucket (both the top-level stat and each agent's per-row count) previously inferred "partial" from a numeric heuristic — any open, non-PIF case with a nonzero fee due/received amount across T16/T2/AUX.
- Changed it to count cases whose `fees_confirmation` is exactly `"Partial Payment"` or `"Pending (full/partial)"` — the same values entered on the Master Fees page's Fees Conf column, per Ms. Jazz's request.
- "No Fees" and "PIF" buckets are untouched.

Verified against production: new count (145) = 111 "Partial Payment" + 34 "Pending (full/partial)", cross-checked directly against `fee_records`. Old numeric heuristic returned 355 for the same window — confirms this was previously over-counting cases that had a nonzero amount but weren't actually marked partial/pending on Master Fees.