### PR TITLE
fix: stop sheet/MyCase sync from blanking out Fees Confirmation

### DIFF
--- a/src/app/api/mycase/sync/route.ts
+++ b/src/app/api/mycase/sync/route.ts
@@ -454,7 +454,7 @@ export const POST = async (req: NextRequest) => {
               win_sheet_link           = COALESCE(fee_records.win_sheet_link, EXCLUDED.win_sheet_link),
               win_sheet_link_text      = COALESCE(fee_records.win_sheet_link_text, EXCLUDED.win_sheet_link_text),
               case_status              = EXCLUDED.case_status,
-              fees_confirmation        = EXCLUDED.fees_confirmation,
+              fees_confirmation        = CASE WHEN EXCLUDED.fees_confirmation IS NOT NULL THEN EXCLUDED.fees_confirmation ELSE fee_records.fees_confirmation END,
               date_assigned_to_agent   = COALESCE(fee_records.date_assigned_to_agent, EXCLUDED.date_assigned_to_agent),
               approved_by              = COALESCE(fee_records.approved_by, EXCLUDED.approved_by),
               t16_retro                = EXCLUDED.t16_retro,

--- a/src/app/api/sheets/sync/route.ts
+++ b/src/app/api/sheets/sync/route.ts
@@ -208,6 +208,12 @@ export const POST = async (req: NextRequest) => {
         const s = (field: string, a: string | null | undefined, b: string | null | undefined) => {
           if ((a ?? null) !== (b ?? null)) f.push({ field, sheet: String(a ?? ""), db: String(b ?? "") });
         };
+        // Like `s`, but for fields the upsert preserves rather than blanks
+        // when the sheet has no value — a blank sheet cell isn't a "change"
+        // since the DB value survives the sync untouched.
+        const sPreserveOnBlank = (field: string, a: string | null | undefined, b: string | null | undefined) => {
+          if (a != null && a !== (b ?? null)) f.push({ field, sheet: String(a), db: String(b ?? "") });
+        };
         // Compare monetary amounts with 1-cent tolerance. The sheet formula (0.25 × retro)
         // produces sub-cent values like 4760.695. Postgres decimal(12,2) stores 4760.70 (rounds
         // up), but JavaScript IEEE 754 stores 4760.695 as 4760.6949... and any JS rounding
@@ -233,7 +239,7 @@ export const POST = async (req: NextRequest) => {
         s("assignedTo", r.assignedTo, db.assignedTo);
         s("winSheetStatus", r.winSheetStatus, db.winSheetStatus ?? "not_started");
         s("caseStatus", r.caseStatus, db.caseStatus);
-        s("feesConfirmation", r.feesConfirmation, db.feesConfirmation);
+        sPreserveOnBlank("feesConfirmation", r.feesConfirmation, db.feesConfirmation);
         s("dateAssignedToAgent", r.dateAssignedToAgent, db.dateAssignedToAgent);
         s("approvedBy", r.approvedBy, db.approvedBy);
         n("t16Retro", r.t16Retro, db.t16Retro);

--- a/src/app/api/sheets/sync/route.ts
+++ b/src/app/api/sheets/sync/route.ts
@@ -624,7 +624,7 @@ export const POST = async (req: NextRequest) => {
               win_sheet_link           = COALESCE(fee_records.win_sheet_link, EXCLUDED.win_sheet_link),
               win_sheet_link_text      = EXCLUDED.win_sheet_link_text,
               case_status              = EXCLUDED.case_status,
-              fees_confirmation        = EXCLUDED.fees_confirmation,
+              fees_confirmation        = CASE WHEN EXCLUDED.fees_confirmation IS NOT NULL THEN EXCLUDED.fees_confirmation ELSE fee_records.fees_confirmation END,
               date_assigned_to_agent   = EXCLUDED.date_assigned_to_agent,
               approved_by              = EXCLUDED.approved_by,
               t16_retro                = EXCLUDED.t16_retro,


### PR DESCRIPTION
## Summary
Root-caused Ms. Jazz's report of Reports' Pending/Partial and No Fees counts not matching her sheet tracker: `fees_confirmation` was unconditionally set to `EXCLUDED.fees_confirmation` on every sheet/MyCase sync. A blank "FEES CONFIRMATION" cell in the source sheet would silently wipe out any value already in the DB — whether it came from a previous sync or a manual Fees Conf edit on the Master Fees dashboard.

- `src/app/api/sheets/sync/route.ts` and `src/app/api/mycase/sync/route.ts`: `fees_confirmation` now only overwrites when the incoming sheet/MyCase value is non-null, otherwise preserves the existing DB value — mirroring the exact `CASE WHEN ... != 0 THEN EXCLUDED... ELSE fee_records...` pattern already used for `t16_pending`/`t2_pending`/`aux_pending` in these same upserts (which exists for the same class of problem: unreliable/partial data from the sheet webhook).
- Left `src/app/api/sheets/fees-closed/sync/route.ts` untouched — it has an explicit "always overwrite with latest sheet values" comment (intentional for closed-case records), and its rows are excluded from the affected Reports stats anyway (`is_closed = false` scoped).

Verified the CASE WHEN syntax read-only against the real schema/data (no writes) — confirmed it correctly preserves the existing value on NULL input and takes the new value when present.