### PR TITLE
fix: reset New User and Reset Password dialogs on the right trigger

### DIFF
--- a/src/components/admin/UsersTable.tsx
+++ b/src/components/admin/UsersTable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTheme } from "next-themes";
 import {
   UserPlus,
@@ -424,8 +424,12 @@ function NewUserDialog({
   const [mustChangePassword, setMustChangePassword] = useState(true);
   const [submitting, setSubmitting] = useState(false);
 
-  const handleOpenChange = (v: boolean) => {
-    if (v) {
+  // `open` is set externally (the "New user" button calls onOpenChange
+  // directly), so this dialog never unmounts — reset on the `open` prop
+  // itself rather than a Dialog onOpenChange callback, which only fires for
+  // interactions inside the dialog (Escape, overlay click), not this one.
+  useEffect(() => {
+    if (open) {
       setEmail("");
       setName("");
       setPassword(generatePassword());
@@ -434,8 +438,7 @@ function NewUserDialog({
       setRole("member");
       setMustChangePassword(true);
     }
-    onOpenChange(v);
-  };
+  }, [open]);
 
   const handleCopy = () => {
     navigator.clipboard.writeText(password).then(() => {
@@ -456,7 +459,7 @@ function NewUserDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>New user</DialogTitle>
@@ -604,15 +607,17 @@ function ResetPasswordDialog({
   const [mustChangePassword, setMustChangePassword] = useState(true);
   const [submitting, setSubmitting] = useState(false);
 
-  const handleOpenChange = (v: boolean) => {
-    if (!v) onClose();
-    if (v) {
+  // `target` is set externally via a row action, not through Dialog's own
+  // onOpenChange — reset on `target` itself so switching straight from one
+  // user's reset dialog to another's doesn't carry over the old password.
+  useEffect(() => {
+    if (target) {
       setPassword(generatePassword());
       setShowPassword(false);
       setCopied(false);
       setMustChangePassword(true);
     }
-  };
+  }, [target]);
 
   const handleCopy = () => {
     navigator.clipboard.writeText(password).then(() => {
@@ -633,7 +638,7 @@ function ResetPasswordDialog({
   };
 
   return (
-    <Dialog open={target != null} onOpenChange={handleOpenChange}>
+    <Dialog open={target != null} onOpenChange={(o) => !o && onClose()}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>Reset password</DialogTitle>


### PR DESCRIPTION
## Summary
Fixes the reported bug: creating a new user shows the previous user's typed values.

Root cause: `NewUserDialog` and `ResetPasswordDialog` (in `UsersTable.tsx`) both reset their form state inside a Radix `Dialog`'s `onOpenChange` callback — but the actual open trigger is external (`setNewOpen(true)` from the "New user" button; `setResetTarget(user)` from a row action), neither of which goes through `onOpenChange`. Since these dialog components never unmount, their internal state (name, email, password, role, mustChangePassword) persisted across every open. Same bug affected `ResetPasswordDialog`: switching from resetting one user's password straight to another's carried over the previous password/checkbox state.

Fix: reset on the `open`/`target` prop itself via `useEffect`, matching the pattern `EditUserDialog` and `AccessOverridesDialog` already use correctly in this same admin feature.

Verified live for both dialogs — Cancel-only, no real writes: typed a name/email into New User, cancelled, reopened → blank, password regenerated. Opened Reset Password for one user, cancelled, opened for a different user → fresh password, checkbox reset to checked.