### PR TITLE
feat: add color coding across dashboard for team, agents, and dropdowns

### DIFF
--- a/src/app/(dashboard)/fees-closed/page.tsx
+++ b/src/app/(dashboard)/fees-closed/page.tsx
@@ -25,6 +25,9 @@ export default function FeesClosedPage() {
   const [closedTo, setClosedTo] = useState("");
   const [dropdownOptions, setDropdownOptions] = useState<DropdownOptionsByCategory>({});
   const [approvedByOptions, setApprovedByOptions] = useState<ApprovedByOption[]>([]);
+  const [teamMembers, setTeamMembers] = useState<
+    { name: string; team: string | null; role: string }[]
+  >([]);
   const controllerRef = useRef<AbortController | null>(null);
 
   const fetchClosed = useCallback(async () => {
@@ -60,6 +63,18 @@ export default function FeesClosedPage() {
       // Includes AbortError on unmount — fetchDropdownOptions doesn't catch
       // it internally, so it lands here and we correctly skip the setState
       // calls above instead of firing them after unmount.
+      .catch(() => {});
+    return () => controller.abort();
+  }, []);
+
+  // Colors the Assigned dropdown by team — master-fees gets this for free via
+  // useDashboard(); fees-closed needs its own fetch same as the dropdown
+  // options above.
+  useEffect(() => {
+    const controller = new AbortController();
+    fetch("/api/team-members", { signal: controller.signal })
+      .then((res) => (res.ok ? res.json() : { data: [] }))
+      .then((json) => setTeamMembers(json.data || []))
       .catch(() => {});
     return () => controller.abort();
   }, []);
@@ -181,6 +196,7 @@ export default function FeesClosedPage() {
         onImported={fetchClosed}
         dropdownOptions={dropdownOptions}
         approvedByOptions={approvedByOptions}
+        teamMembers={teamMembers}
       />
     </div>
   );

--- a/src/app/(dashboard)/master-fees/page.tsx
+++ b/src/app/(dashboard)/master-fees/page.tsx
@@ -19,12 +19,18 @@ const AGING_OPTIONS: { value: AgingFilter; label: string }[] = [
 export default function MasterFeesPage() {
   const {
     cases,
+    team,
     approvedByOptions,
     dropdownOptions,
     casesLoading,
     error,
     refresh,
   } = useDashboard();
+  const teamMembers = team.map((m) => ({
+    name: m.name,
+    team: m.team,
+    role: m.role,
+  }));
   const { dateRange } = useDateRange();
   const { resolvedTheme } = useTheme();
   const dark = resolvedTheme === "dark";
@@ -110,6 +116,7 @@ export default function MasterFeesPage() {
         onImported={refresh}
         approvedByOptions={approvedByOptions}
         dropdownOptions={dropdownOptions}
+        teamMembers={teamMembers}
         approverFilter={approverFilter}
         onApproverFilterChange={setApproverFilter}
       />

--- a/src/components/cases/CaseDetailSheet.tsx
+++ b/src/components/cases/CaseDetailSheet.tsx
@@ -44,6 +44,9 @@ import type {
   ApprovedByOption,
 } from "@/types";
 import type { DropdownOptionsByCategory } from "@/hooks/useDashboard";
+import { Listbox } from "@/components/shared/Listbox";
+import { buildListboxOptions } from "@/lib/listbox-options";
+import { caseLevelVisual } from "@/lib/case-level-icons";
 
 interface CaseDetailSheetProps {
   caseId: number;
@@ -724,13 +727,24 @@ export default function CaseDetailSheet({
                     </div>
                     <div>
                       <p className={lbl}>Level Won</p>
-                      <select
+                      <Listbox
                         value={editValues.levelWon}
-                        onChange={(e) => setEditValues((v) => ({ ...v, levelWon: e.target.value }))}
-                        className={inp}
-                      >
-                        {dropdownOptionEls(caseLevelOptions, editValues.levelWon)}
-                      </select>
+                        onChange={(v) => setEditValues((val) => ({ ...val, levelWon: v }))}
+                        dark={dark}
+                        t={t}
+                        aria-label="Level Won"
+                        className="mt-1 w-full"
+                        options={buildListboxOptions(
+                          caseLevelOptions,
+                          editValues.levelWon,
+                          (name) => {
+                            const visual = caseLevelVisual(name, dark);
+                            return visual
+                              ? { icon: visual.Icon, iconBg: visual.bg, iconFg: visual.fg }
+                              : undefined;
+                          },
+                        )}
+                      />
                     </div>
                     <div>
                       <p className={lbl}>T2 Decision</p>

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -43,12 +43,17 @@ import MyCaseSyncModal from "@/components/modals/MyCaseSyncModal";
 import NotesModal from "@/components/modals/NotesModal";
 import { ArchiveConfirmDialog } from "./ArchiveConfirmDialog";
 import { FeesClosedConfirmDialog } from "./FeesClosedConfirmDialog";
+import { Listbox } from "@/components/shared/Listbox";
+import { caseLevelVisual } from "@/lib/case-level-icons";
+import { buildListboxOptions } from "@/lib/listbox-options";
+import { teamRowTint } from "@/lib/team-colors";
+import { memberRowTint } from "@/lib/member-colors";
 
 const FEES_CONF_COLORS: Record<string, { badge: string; badgeDark: string }> = {
   "Paid In Full":           { badge: "bg-emerald-50 text-emerald-700 border-emerald-300",  badgeDark: "bg-emerald-900/40 text-emerald-300 border-emerald-700" },
   "Partial Payment":        { badge: "bg-red-50 text-red-700 border-red-300",              badgeDark: "bg-red-900/40 text-red-300 border-red-700"             },
   "Pending (full/partial)": { badge: "bg-blue-50 text-blue-700 border-blue-300",           badgeDark: "bg-blue-900/40 text-blue-300 border-blue-700"          },
-  "No Fees Due":            { badge: "bg-purple-50 text-purple-700 border-purple-300",     badgeDark: "bg-purple-900/40 text-purple-300 border-purple-700"    },
+  "No Fees Due":            { badge: "bg-neutral-100 text-black border-neutral-400",        badgeDark: "bg-neutral-800 text-white border-neutral-600"          },
   "Overpaid":               { badge: "bg-amber-50 text-amber-700 border-amber-300",        badgeDark: "bg-amber-900/40 text-amber-300 border-amber-700"       },
 };
 const FEES_CONF_FALLBACK = { badge: "bg-neutral-100 text-neutral-500 border-neutral-300", badgeDark: "bg-neutral-700 text-neutral-300 border-neutral-600" };
@@ -153,6 +158,10 @@ interface FeeRecordsTableProps {
   // Fees Confirmation, Case Status). Optional — an empty list just yields
   // an empty dropdown with the current value preserved as a fallback.
   dropdownOptions?: DropdownOptionsByCategory;
+  // Team members (name + team + role) — colors the Assigned dropdown by
+  // team, and highlights team_lead members by team in the Approved By
+  // dropdown so it's obvious who can actually sign off on closing a case.
+  teamMembers?: { name: string; team: string | null; role: string }[];
   // Optional approver filter rendered in the toolbar before the Sync button.
   // Only the master-fees page passes this; fees-closed omits it.
   approverFilter?: string;
@@ -245,6 +254,7 @@ export const FeeRecordsTable = ({
   mode = "active",
   approvedByOptions = [],
   dropdownOptions = {},
+  teamMembers = [],
   approverFilter,
   onApproverFilterChange,
 }: FeeRecordsTableProps) => {
@@ -266,6 +276,7 @@ export const FeeRecordsTable = ({
   const caseLevelOptions = dropdownOptions.case_level ?? [];
   const claimTypeOptions = dropdownOptions.claim_type ?? [];
   const winSheetStatusOptions = dropdownOptions.win_sheet_status ?? [];
+  const leaders = teamMembers.filter((m) => m.role === "team_lead");
 
   // Keys for varchar cells that support inline-edit dropdowns. `status` is
   // the win_sheet_status row field; `level`/`claim` live on the cases row.
@@ -1276,48 +1287,34 @@ export const FeeRecordsTable = ({
                       className={`${tdBase} ${t.textSub} ${stickyTd2}`}
                       onClick={(e) => e.stopPropagation()}
                     >
-                      <select
-                          value={cellValue(c, "assigned")}
-                          onClick={(e) => e.stopPropagation()}
-                          onChange={(e) =>
-                            handleVarcharChange(
-                              c,
-                              "fee",
-                              "assignedTo",
-                              "assigned",
-                              "Assigned To",
-                              e.target.value,
-                            )
-                          }
-                          className={`w-full h-7 px-2 rounded-md border text-[11px] outline-none cursor-pointer ${t.inputBg}`}
-                          title={
-                            assignedOptions.length === 0
-                              ? "No options configured — add them in Settings"
-                              : undefined
-                          }
-                        >
-                          <option value="">— Select —</option>
-                          {(() => {
-                            const v = cellValue(c, "assigned");
-                            return (
-                              v &&
-                              !assignedOptions.some((o) => o.name === v) && (
-                                <option value={v}>{v}</option>
-                              )
-                            );
-                          })()}
-                          {assignedOptions
-                            .filter(
-                              (o) =>
-                                o.isActive ||
-                                o.name === cellValue(c, "assigned"),
-                            )
-                            .map((o) => (
-                              <option key={o.id} value={o.name}>
-                                {o.name}
-                              </option>
-                            ))}
-                        </select>
+                      <Listbox
+                        value={cellValue(c, "assigned")}
+                        onChange={(v) =>
+                          handleVarcharChange(
+                            c,
+                            "fee",
+                            "assignedTo",
+                            "assigned",
+                            "Assigned To",
+                            v,
+                          )
+                        }
+                        dark={dark}
+                        t={t}
+                        aria-label="Assigned To"
+                        className="w-full"
+                        title={
+                          assignedOptions.length === 0
+                            ? "No options configured — add them in Settings"
+                            : undefined
+                        }
+                        options={buildListboxOptions(
+                          assignedOptions,
+                          cellValue(c, "assigned"),
+                          undefined,
+                          (name) => memberRowTint(name, dark),
+                        )}
+                      />
                     </td>
                     {/* Fees Confirmation — 3rd frozen column */}
                     <td
@@ -1413,47 +1410,37 @@ export const FeeRecordsTable = ({
                       className={`${tdBase}`}
                       onClick={(e) => e.stopPropagation()}
                     >
-                      <select
-                          value={cellValue(c, "level")}
-                          onClick={(e) => e.stopPropagation()}
-                          onChange={(e) =>
-                            handleVarcharChange(
-                              c,
-                              "case",
-                              "levelWon",
-                              "level",
-                              "Case Level",
-                              e.target.value,
-                            )
-                          }
-                          className={`h-7 px-2 rounded-md border text-[11px] outline-none cursor-pointer ${t.inputBg}`}
-                          title={
-                            caseLevelOptions.length === 0
-                              ? "No options configured — add them in Settings"
-                              : undefined
-                          }
-                        >
-                          <option value="">— Select —</option>
-                          {(() => {
-                            const v = cellValue(c, "level");
-                            return (
-                              v &&
-                              !caseLevelOptions.some((o) => o.name === v) && (
-                                <option value={v}>{v}</option>
-                              )
-                            );
-                          })()}
-                          {caseLevelOptions
-                            .filter(
-                              (o) =>
-                                o.isActive || o.name === cellValue(c, "level"),
-                            )
-                            .map((o) => (
-                              <option key={o.id} value={o.name}>
-                                {o.name}
-                              </option>
-                            ))}
-                        </select>
+                      <Listbox
+                        value={cellValue(c, "level")}
+                        onChange={(v) =>
+                          handleVarcharChange(
+                            c,
+                            "case",
+                            "levelWon",
+                            "level",
+                            "Case Level",
+                            v,
+                          )
+                        }
+                        dark={dark}
+                        t={t}
+                        aria-label="Case Level"
+                        title={
+                          caseLevelOptions.length === 0
+                            ? "No options configured — add them in Settings"
+                            : undefined
+                        }
+                        options={buildListboxOptions(
+                          caseLevelOptions,
+                          cellValue(c, "level"),
+                          (name) => {
+                            const visual = caseLevelVisual(name, dark);
+                            return visual
+                              ? { icon: visual.Icon, iconBg: visual.bg, iconFg: visual.fg }
+                              : undefined;
+                          },
+                        )}
+                      />
                     </td>
                     {/* Claim — varchar; lives on the cases row. */}
                     <td
@@ -1933,48 +1920,36 @@ export const FeeRecordsTable = ({
                       {mode === "closed" || !canFinalize ? (
                         cellValue(c, "approvedBy") || "—"
                       ) : (
-                        <select
+                        <Listbox
                           value={cellValue(c, "approvedBy")}
-                          onClick={(e) => e.stopPropagation()}
-                          onChange={(e) =>
+                          onChange={(v) =>
                             handleVarcharChange(
                               c,
                               "fee",
                               "approvedBy",
                               "approvedBy",
                               "Approved By",
-                              e.target.value,
+                              v,
                             )
                           }
-                          className={`h-7 px-2 rounded-md border text-[11px] outline-none cursor-pointer ${t.inputBg}`}
+                          dark={dark}
+                          t={t}
+                          aria-label="Approved By"
                           title={
                             approvedByOptions.length === 0
                               ? "No options configured — add them in Settings"
                               : undefined
                           }
-                        >
-                          <option value="">— Select —</option>
-                          {(() => {
-                            const v = cellValue(c, "approvedBy");
-                            return (
-                              v &&
-                              !approvedByOptions.some((o) => o.name === v) && (
-                                <option value={v}>{v}</option>
-                              )
-                            );
-                          })()}
-                          {approvedByOptions
-                            .filter(
-                              (o) =>
-                                o.isActive ||
-                                o.name === cellValue(c, "approvedBy"),
-                            )
-                            .map((o) => (
-                              <option key={o.id} value={o.name}>
-                                {o.name}
-                              </option>
-                            ))}
-                        </select>
+                          options={buildListboxOptions(
+                            approvedByOptions,
+                            cellValue(c, "approvedBy"),
+                            undefined,
+                            (name) => {
+                              const leader = leaders.find((l) => l.name === name);
+                              return leader ? teamRowTint(leader.team, dark) : undefined;
+                            },
+                          )}
+                        />
                       )}
                     </td>
                     {/* Remarks */}

--- a/src/components/cases/StatCards.tsx
+++ b/src/components/cases/StatCards.tsx
@@ -31,6 +31,7 @@ export const StatCards = ({ stats }: StatCardsProps) => {
     sub?: string;
     detail: string;
     detailTone: "up" | "down" | "warn" | "neutral";
+    accent: string;
   };
 
   const cards: CardSpec[] = [
@@ -41,6 +42,7 @@ export const StatCards = ({ stats }: StatCardsProps) => {
       sub: "Active (non-closed)",
       detail: `${stats.pif} marked PIF`,
       detailTone: "neutral",
+      accent: "#7c3aed",
     },
     {
       icon: DollarSign,
@@ -49,6 +51,7 @@ export const StatCards = ({ stats }: StatCardsProps) => {
       sub: "Current calendar month",
       detail: stats.feesCollectedMTD > 0 ? "Collected this month" : "None yet this month",
       detailTone: stats.feesCollectedMTD > 0 ? "up" : "neutral",
+      accent: "#059669",
     },
     {
       icon: CalendarCheck,
@@ -57,6 +60,7 @@ export const StatCards = ({ stats }: StatCardsProps) => {
       sub: "Current calendar month",
       detail: stats.casesClosedMTD > 0 ? "Closed this month" : "None yet this month",
       detailTone: stats.casesClosedMTD > 0 ? "up" : "neutral",
+      accent: "#d97706",
     },
     {
       icon: RefreshCw,
@@ -66,6 +70,7 @@ export const StatCards = ({ stats }: StatCardsProps) => {
       detail:
         stats.syncErrors > 0 ? `${stats.syncErrors} error(s)` : "All clear",
       detailTone: stats.syncErrors > 0 ? "down" : "up",
+      accent: "#0284c7",
     },
   ];
 
@@ -86,13 +91,17 @@ export const StatCards = ({ stats }: StatCardsProps) => {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 md:gap-4">
       {cards.map((s, i) => (
-        <div key={i} className={`rounded-xl border p-4 ${t.card}`}>
+        <div
+          key={i}
+          className={`rounded-xl border p-4 border-l-[3px] ${t.card}`}
+          style={{ borderLeftColor: s.accent }}
+        >
           <div className="flex items-start justify-between">
             <div>
               <div
                 className={`flex items-center gap-1.5 text-xs ${t.textSub} font-medium`}
               >
-                <s.icon className="h-3.5 w-3.5" aria-hidden="true" /> {s.label}
+                <s.icon className="h-3.5 w-3.5" style={{ color: s.accent }} aria-hidden="true" /> {s.label}
               </div>
               <div className={`text-2xl font-extrabold ${t.text} mt-1`}>
                 {s.value}

--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -24,6 +24,7 @@ import {
 import { useSession } from "next-auth/react";
 import { themeClasses } from "@/lib/theme-classes";
 import { fmt, fmtDate } from "@/lib/formatters";
+import { teamBadgeClasses } from "@/lib/team-colors";
 import {
   ScoreboardSummaryCards,
   ScoreboardSummary,
@@ -875,7 +876,14 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                     </tr>
                   ) : filteredAgents.map((a) => (
                     <tr key={a.agent} className={`border-b ${rowBorder} ${rowHover} transition-colors`}>
-                      <td className={`${tdBase} ${t.text} font-semibold`}>{a.agent}</td>
+                      <td className={`${tdBase} ${t.text} font-semibold`}>
+                        <span
+                          className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 ${teamBadgeClasses(a.team, dark)}`}
+                        >
+                          <span className="w-1.5 h-1.5 rounded-full bg-current shrink-0" aria-hidden="true" />
+                          {a.agent}
+                        </span>
+                      </td>
                       {showCol("cases")       && <td className={`${tdBase} text-right ${t.text}`}>{a.openCases}</td>}
                       {showCol("closedcases") && <td className={`${tdBase} text-right ${t.textSub}`}>{a.casesClosed}</td>}
                       {showCol("ssacalls")    && <td className={`${tdBase} text-right ${t.textSub}`}>{a.weekSsaCalls}</td>}

--- a/src/components/scoreboard/Scoreboard.tsx
+++ b/src/components/scoreboard/Scoreboard.tsx
@@ -7,6 +7,7 @@ import { themeClasses } from "@/lib/theme-classes";
 import CsvImportModal, { type ColumnDef } from "@/components/modals/CsvImportModal";
 import { bulkImportDailyMetrics } from "@/app/(dashboard)/scoreboard/actions";
 import { parseDate, parseNonNegativeInt } from "@/lib/import/csv-parser";
+import { teamHeaderBg } from "@/lib/team-colors";
 
 // ---------- types ----------
 
@@ -50,9 +51,9 @@ const thisWeekCellColor = (value: number, max: number): string => {
 };
 
 const TEAMS = [
-  { key: "Concurrent", label: "Concurrent Team", headerBg: "bg-teal-700" },
-  { key: "T2",         label: "T2 Team",         headerBg: "bg-blue-800" },
-  { key: "T16",        label: "T16 Team",         headerBg: "bg-red-700"  },
+  { key: "Concurrent", label: "Concurrent Team", headerBg: teamHeaderBg("Concurrent") },
+  { key: "T2",         label: "T2 Team",         headerBg: teamHeaderBg("T2") },
+  { key: "T16",        label: "T16 Team",         headerBg: teamHeaderBg("T16") },
 ];
 
 // ---------- state ----------

--- a/src/components/scoreboard/ScoreboardSummaryCards.tsx
+++ b/src/components/scoreboard/ScoreboardSummaryCards.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { themeClasses } from "@/lib/theme-classes";
 import { fmt } from "@/lib/formatters";
+import { teamCardClasses, teamAccentText, teamLabel } from "@/lib/team-colors";
 
 export interface ScoreboardSummary {
   totalCasesAssigned: number;
@@ -62,9 +63,12 @@ export function ScoreboardSummaryCards({
   const [t16Days, setT16Days] = useState<60 | 90>(60);
   const [concDays, setConcDays] = useState<60 | 90>(60);
 
-  const stats: { label: string; value: string | number; onClick?: () => void; toggled?: boolean }[] = [
-    { label: "Cases Assigned", value: summary.totalCasesAssigned },
-    { label: "Win Sheets", value: summary.totalCompletedWinSheets },
+  // Quiet per-metric accent (border + tint) on the plain cards — not used on
+  // the T2/T16/CONC toggle cards below, whose violet highlight is a state
+  // indicator (90D vs 60D), not a metric identity.
+  const stats: { label: string; value: string | number; onClick?: () => void; toggled?: boolean; accent?: string }[] = [
+    { label: "Cases Assigned", value: summary.totalCasesAssigned, accent: "#7c3aed" },
+    { label: "Win Sheets", value: summary.totalCompletedWinSheets, accent: "#0284c7" },
     {
       label: `T2 >${t2Days}D`,
       value: t2Days === 60 ? summary.totalUnpaidT2Over60 : summary.totalUnpaidT2Over90,
@@ -83,10 +87,10 @@ export function ScoreboardSummaryCards({
       onClick: () => setConcDays((v) => v === 60 ? 90 : 60),
       toggled: concDays === 90,
     },
-    { label: "Collected", value: fmt(summary.totalCollected) },
-    { label: "Full Fee", value: summary.totalCasesFullFee },
-    { label: "SSA Calls", value: summary.totalSsaCalls },
-    { label: "Client Calls", value: summary.totalClientCalls },
+    { label: "Collected", value: fmt(summary.totalCollected), accent: "#059669" },
+    { label: "Full Fee", value: summary.totalCasesFullFee, accent: "#d97706" },
+    { label: "SSA Calls", value: summary.totalSsaCalls, accent: "#7c3aed" },
+    { label: "Client Calls", value: summary.totalClientCalls, accent: "#0284c7" },
   ];
 
   return (
@@ -118,8 +122,19 @@ export function ScoreboardSummaryCards({
                 </p>
               </button>
             ) : (
-              <div key={item.label} className={`rounded-lg border p-3 ${t.card}`}>
-                <p className={`text-[10px] font-medium ${t.textMuted} uppercase`}>
+              <div
+                key={item.label}
+                className={`rounded-lg border p-3 border-l-[3px] ${t.card}`}
+                style={item.accent ? { borderLeftColor: item.accent } : undefined}
+              >
+                <p className={`flex items-center gap-1.5 text-[10px] font-medium ${t.textMuted} uppercase`}>
+                  {item.accent && (
+                    <span
+                      aria-hidden="true"
+                      className="w-1.5 h-1.5 rounded-full shrink-0"
+                      style={{ background: item.accent }}
+                    />
+                  )}
                   {item.label}
                 </p>
                 <p className={`text-lg font-bold ${t.text} mt-1`}>{item.value}</p>
@@ -137,41 +152,13 @@ export function ScoreboardSummaryCards({
           </p>
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
             {teams.map((team) => {
-              const teamColor =
-                team.team === "T2"
-                  ? dark
-                    ? "border-blue-700/50 bg-blue-900/10"
-                    : "border-blue-200 bg-blue-50/60"
-                  : team.team === "T16"
-                    ? dark
-                      ? "border-purple-700/50 bg-purple-900/10"
-                      : "border-purple-200 bg-purple-50/60"
-                    : dark
-                      ? "border-teal-700/50 bg-teal-900/10"
-                      : "border-teal-200 bg-teal-50/60";
-              const teamLabel =
-                team.team === "T2"
-                  ? "T2 Team"
-                  : team.team === "T16"
-                    ? "T16 Team"
-                    : "Concurrent Team";
-              const accentText =
-                team.team === "T2"
-                  ? dark
-                    ? "text-blue-400"
-                    : "text-blue-700"
-                  : team.team === "T16"
-                    ? dark
-                      ? "text-purple-400"
-                      : "text-purple-700"
-                    : dark
-                      ? "text-teal-400"
-                      : "text-teal-700";
+              const teamColor = teamCardClasses(team.team, dark);
+              const accentText = teamAccentText(team.team, dark);
               return (
                 <div key={team.team} className={`rounded-lg border p-4 ${teamColor}`}>
                   <div className="flex items-center justify-between mb-3">
                     <span className={`text-xs font-bold ${accentText}`}>
-                      {teamLabel}
+                      {teamLabel(team.team)}
                     </span>
                     <span className={`text-[10px] ${t.textMuted}`}>
                       {team.agentCount} agent{team.agentCount !== 1 ? "s" : ""}

--- a/src/components/shared/Listbox.tsx
+++ b/src/components/shared/Listbox.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { Check, ChevronDown, type LucideIcon } from "lucide-react";
+import type { themeClasses } from "@/lib/theme-classes";
+
+export interface ListboxOption {
+  value: string;
+  label: string;
+  icon?: LucideIcon;
+  iconBg?: string;
+  iconFg?: string;
+  // Full bg/text/hover className override for this option's row — e.g. a
+  // team-tinted row for team leads in "Approved By". Falls back to the
+  // default row styling when omitted.
+  tint?: string;
+}
+
+interface ListboxProps {
+  value: string;
+  options: ListboxOption[];
+  onChange: (value: string) => void;
+  dark: boolean;
+  t: ReturnType<typeof themeClasses>;
+  placeholder?: string;
+  title?: string;
+  "aria-label"?: string;
+  className?: string;
+}
+
+// Drop-in replacement for a plain <select> where the value needs an icon or
+// the open list needs to highlight specific options — neither is reliably
+// stylable on a native <option> across browsers. Renders the open panel via
+// a portal positioned from the trigger's bounding rect so it isn't clipped
+// by the fee table's scroll containers or sticky columns.
+export function Listbox({
+  value,
+  options,
+  onChange,
+  dark,
+  t,
+  placeholder = "— Select —",
+  title,
+  "aria-label": ariaLabel,
+  className = "",
+}: ListboxProps) {
+  const [open, setOpen] = useState(false);
+  const [rect, setRect] = useState<{ top: number; left: number; width: number } | null>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  const selected = options.find((o) => o.value === value);
+
+  useEffect(() => {
+    if (!open) return;
+    const close = () => setOpen(false);
+    const onClickAway = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (triggerRef.current?.contains(target) || panelRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    // Scroll happens inside the fee table's own overflow containers, so this
+    // needs the capture phase to hear it — repositioning on every scroll
+    // isn't worth the complexity here, closing is enough.
+    window.addEventListener("scroll", close, true);
+    window.addEventListener("resize", close);
+    document.addEventListener("mousedown", onClickAway);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("scroll", close, true);
+      window.removeEventListener("resize", close);
+      document.removeEventListener("mousedown", onClickAway);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const toggle = () => {
+    if (!open) {
+      const r = triggerRef.current?.getBoundingClientRect();
+      if (r) setRect({ top: r.bottom + 4, left: r.left, width: Math.max(r.width, 170) });
+    }
+    setOpen((v) => !v);
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        ref={triggerRef}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={ariaLabel}
+        title={title}
+        onClick={(e) => {
+          e.stopPropagation();
+          toggle();
+        }}
+        className={`h-7 px-2 rounded-md border text-[11px] outline-none flex items-center justify-between gap-1.5 cursor-pointer ${selected?.tint ?? t.inputBg} ${className}`}
+      >
+        <span className="flex items-center gap-1.5 truncate">
+          {selected?.icon && (
+            <span
+              className="w-4 h-4 rounded flex items-center justify-center shrink-0"
+              style={{ background: selected.iconBg, color: selected.iconFg }}
+            >
+              <selected.icon className="h-2.5 w-2.5" aria-hidden="true" />
+            </span>
+          )}
+          <span className="truncate">{selected?.label ?? placeholder}</span>
+        </span>
+        <ChevronDown
+          aria-hidden="true"
+          className={`h-3 w-3 shrink-0 ${t.textMuted} transition-transform ${open ? "rotate-180" : ""}`}
+        />
+      </button>
+      {open && rect && typeof document !== "undefined"
+        ? createPortal(
+            <div
+              ref={panelRef}
+              role="listbox"
+              style={{ position: "fixed", top: rect.top, left: rect.left, width: rect.width, zIndex: 9999 }}
+              className={`rounded-lg border shadow-lg p-1 max-h-64 overflow-auto ${t.card}`}
+            >
+              {options.length === 0 ? (
+                <div className={`px-2 py-1.5 text-[11px] ${t.textMuted}`}>
+                  No options configured — add them in Settings
+                </div>
+              ) : (
+                options.map((o) => {
+                  const isSelected = o.value === value;
+                  const rowTone = o.tint
+                    ? o.tint
+                    : isSelected
+                      ? dark
+                        ? "bg-neutral-800 text-neutral-100"
+                        : "bg-neutral-100 text-neutral-900"
+                      : dark
+                        ? "text-neutral-200 hover:bg-neutral-800"
+                        : "text-neutral-700 hover:bg-neutral-50";
+                  return (
+                    <button
+                      key={o.value}
+                      type="button"
+                      role="option"
+                      aria-selected={isSelected}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onChange(o.value);
+                        setOpen(false);
+                      }}
+                      className={`w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-[11px] font-medium text-left ${rowTone}`}
+                    >
+                      {o.icon && (
+                        <span
+                          className="w-4 h-4 rounded flex items-center justify-center shrink-0"
+                          style={{ background: o.iconBg, color: o.iconFg }}
+                        >
+                          <o.icon className="h-2.5 w-2.5" aria-hidden="true" />
+                        </span>
+                      )}
+                      <span className="truncate">{o.label}</span>
+                      {isSelected && (
+                        <Check className="ml-auto h-3 w-3 shrink-0" aria-hidden="true" />
+                      )}
+                    </button>
+                  );
+                })
+              )}
+            </div>,
+            document.body,
+          )
+        : null}
+    </>
+  );
+}

--- a/src/components/shared/Listbox.tsx
+++ b/src/components/shared/Listbox.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type KeyboardEvent } from "react";
 import { createPortal } from "react-dom";
 import { Check, ChevronDown, type LucideIcon } from "lucide-react";
 import type { themeClasses } from "@/lib/theme-classes";
@@ -34,6 +34,10 @@ interface ListboxProps {
 // stylable on a native <option> across browsers. Renders the open panel via
 // a portal positioned from the trigger's bounding rect so it isn't clipped
 // by the fee table's scroll containers or sticky columns.
+// Type-ahead resets the buffer if the user pauses this long between keys —
+// matches native <select> behavior closely enough without a debounce lib.
+const TYPEAHEAD_RESET_MS = 350;
+
 export function Listbox({
   value,
   options,
@@ -47,8 +51,11 @@ export function Listbox({
 }: ListboxProps) {
   const [open, setOpen] = useState(false);
   const [rect, setRect] = useState<{ top: number; left: number; width: number } | null>(null);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
+  const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const typeaheadRef = useRef({ buffer: "", timer: null as ReturnType<typeof setTimeout> | null });
 
   const selected = options.find((o) => o.value === value);
 
@@ -60,30 +67,123 @@ export function Listbox({
       if (triggerRef.current?.contains(target) || panelRef.current?.contains(target)) return;
       setOpen(false);
     };
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
-    };
     // Scroll happens inside the fee table's own overflow containers, so this
     // needs the capture phase to hear it — repositioning on every scroll
     // isn't worth the complexity here, closing is enough.
     window.addEventListener("scroll", close, true);
     window.addEventListener("resize", close);
     document.addEventListener("mousedown", onClickAway);
-    document.addEventListener("keydown", onKey);
     return () => {
       window.removeEventListener("scroll", close, true);
       window.removeEventListener("resize", close);
       document.removeEventListener("mousedown", onClickAway);
-      document.removeEventListener("keydown", onKey);
     };
   }, [open]);
 
-  const toggle = () => {
-    if (!open) {
-      const r = triggerRef.current?.getBoundingClientRect();
-      if (r) setRect({ top: r.bottom + 4, left: r.left, width: Math.max(r.width, 170) });
+  // Roving focus: whichever option is "highlighted" actually holds DOM focus,
+  // so arrow keys/type-ahead work the way a native <select> or an ARIA
+  // listbox would, instead of every option being its own Tab stop.
+  useEffect(() => {
+    if (open && highlightedIndex >= 0) {
+      optionRefs.current[highlightedIndex]?.focus();
     }
-    setOpen((v) => !v);
+  }, [open, highlightedIndex]);
+
+  const openAt = (index: number) => {
+    const r = triggerRef.current?.getBoundingClientRect();
+    if (r) setRect({ top: r.bottom + 4, left: r.left, width: Math.max(r.width, 170) });
+    optionRefs.current = [];
+    setHighlightedIndex(index);
+    setOpen(true);
+  };
+
+  const close = () => setOpen(false);
+
+  const closeAndRefocus = () => {
+    setOpen(false);
+    triggerRef.current?.focus();
+  };
+
+  const initialIndex = () => {
+    if (options.length === 0) return -1;
+    const i = options.findIndex((o) => o.value === value);
+    return i >= 0 ? i : 0;
+  };
+
+  const commit = (index: number) => {
+    const o = options[index];
+    if (!o) return;
+    onChange(o.value);
+    closeAndRefocus();
+  };
+
+  const typeahead = (char: string) => {
+    const ta = typeaheadRef.current;
+    if (ta.timer) clearTimeout(ta.timer);
+    ta.buffer += char.toLowerCase();
+    ta.timer = setTimeout(() => {
+      ta.buffer = "";
+    }, TYPEAHEAD_RESET_MS);
+    const n = options.length;
+    if (n === 0) return;
+    const start = highlightedIndex >= 0 ? highlightedIndex : -1;
+    for (let step = 1; step <= n; step++) {
+      const i = (start + step) % n;
+      if (options[i].label.toLowerCase().startsWith(ta.buffer)) {
+        setHighlightedIndex(i);
+        return;
+      }
+    }
+  };
+
+  const onPanelKeyDown = (e: KeyboardEvent) => {
+    const n = options.length;
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        if (n > 0) setHighlightedIndex((i) => (i + 1) % n);
+        return;
+      case "ArrowUp":
+        e.preventDefault();
+        if (n > 0) setHighlightedIndex((i) => (i - 1 + n) % n);
+        return;
+      case "Home":
+        e.preventDefault();
+        if (n > 0) setHighlightedIndex(0);
+        return;
+      case "End":
+        e.preventDefault();
+        if (n > 0) setHighlightedIndex(n - 1);
+        return;
+      case "Enter":
+      case " ":
+        e.preventDefault();
+        commit(highlightedIndex);
+        return;
+      case "Escape":
+        e.preventDefault();
+        closeAndRefocus();
+        return;
+      case "Tab":
+        // Portal content isn't next to the trigger in DOM order, so letting
+        // Tab run its default course would jump focus somewhere unrelated —
+        // close and land back on the trigger instead.
+        e.preventDefault();
+        closeAndRefocus();
+        return;
+      default:
+        if (e.key.length === 1 && !e.altKey && !e.ctrlKey && !e.metaKey) {
+          typeahead(e.key);
+        }
+    }
+  };
+
+  const onTriggerKeyDown = (e: KeyboardEvent) => {
+    if (open) return;
+    if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+      e.preventDefault();
+      openAt(initialIndex());
+    }
   };
 
   return (
@@ -97,8 +197,10 @@ export function Listbox({
         title={title}
         onClick={(e) => {
           e.stopPropagation();
-          toggle();
+          if (open) close();
+          else openAt(initialIndex());
         }}
+        onKeyDown={onTriggerKeyDown}
         className={`h-7 px-2 rounded-md border text-[11px] outline-none flex items-center justify-between gap-1.5 cursor-pointer ${selected?.tint ?? t.inputBg} ${className}`}
       >
         <span className="flex items-center gap-1.5 truncate">
@@ -122,6 +224,7 @@ export function Listbox({
             <div
               ref={panelRef}
               role="listbox"
+              onKeyDown={onPanelKeyDown}
               style={{ position: "fixed", top: rect.top, left: rect.left, width: rect.width, zIndex: 9999 }}
               className={`rounded-lg border shadow-lg p-1 max-h-64 overflow-auto ${t.card}`}
             >
@@ -130,7 +233,7 @@ export function Listbox({
                   No options configured — add them in Settings
                 </div>
               ) : (
-                options.map((o) => {
+                options.map((o, i) => {
                   const isSelected = o.value === value;
                   const rowTone = o.tint
                     ? o.tint
@@ -144,9 +247,12 @@ export function Listbox({
                   return (
                     <button
                       key={o.value}
+                      ref={(el) => { optionRefs.current[i] = el; }}
                       type="button"
                       role="option"
+                      tabIndex={-1}
                       aria-selected={isSelected}
+                      onMouseEnter={() => setHighlightedIndex(i)}
                       onClick={(e) => {
                         e.stopPropagation();
                         onChange(o.value);

--- a/src/components/team/TeamManagement.tsx
+++ b/src/components/team/TeamManagement.tsx
@@ -18,6 +18,7 @@ import {
   X,
 } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
+import { teamBadgeClasses } from "@/lib/team-colors";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -452,13 +453,7 @@ export const TeamManagement = () => {
                     <td className="px-4 py-2.5">
                       {m.team ? (
                         <span
-                          className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold ${
-                            m.team === "T2"
-                              ? dark ? "bg-blue-900/30 text-blue-400" : "bg-blue-50 text-blue-700"
-                              : m.team === "T16"
-                              ? dark ? "bg-purple-900/30 text-purple-400" : "bg-purple-50 text-purple-700"
-                              : dark ? "bg-teal-900/30 text-teal-400" : "bg-teal-50 text-teal-700"
-                          }`}
+                          className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold ${teamBadgeClasses(m.team, dark)}`}
                         >
                           {m.team}
                         </span>

--- a/src/lib/case-level-icons.ts
+++ b/src/lib/case-level-icons.ts
@@ -1,0 +1,51 @@
+import {
+  FileText,
+  Gavel,
+  RotateCcw,
+  Receipt,
+  Scale,
+  Landmark,
+  type LucideIcon,
+} from "lucide-react";
+
+interface CaseLevelVisual {
+  Icon: LucideIcon;
+  bg: string;
+  fg: string;
+}
+
+const VISUALS: Record<
+  string,
+  { Icon: LucideIcon; light: [string, string]; dark: [string, string] }
+> = {
+  INITIAL: { Icon: FileText, light: ["#f1f5f9", "#475569"], dark: ["rgba(51,65,85,0.35)", "#94a3b8"] },
+  HEARING: { Icon: Gavel, light: ["#ede9fe", "#6d28d9"], dark: ["rgba(76,29,149,0.35)", "#a78bfa"] },
+  // Seed data used "RECON"; the live Settings-managed list has since been
+  // renamed to "RECONSIDERATION" — keep both so either spelling gets the icon.
+  RECON: { Icon: RotateCcw, light: ["#ecfeff", "#0e7490"], dark: ["rgba(22,78,99,0.35)", "#22d3ee"] },
+  RECONSIDERATION: { Icon: RotateCcw, light: ["#ecfeff", "#0e7490"], dark: ["rgba(22,78,99,0.35)", "#22d3ee"] },
+  "FEE PETITION": { Icon: Receipt, light: ["#ecfdf5", "#047857"], dark: ["rgba(6,78,59,0.35)", "#34d399"] },
+  AC: { Icon: Scale, light: ["#eef2ff", "#4338ca"], dark: ["rgba(49,46,129,0.35)", "#818cf8"] },
+  "FEDERAL COURT": { Icon: Landmark, light: ["#fffbeb", "#b45309"], dark: ["rgba(120,53,15,0.35)", "#fbbf24"] },
+};
+
+// dropdown_options.case_level rows are free-text (admin-managed in Settings),
+// so normalize before matching — seed data uses "FEE PETITION" but the list
+// could just as easily contain "Fee_Petition" or "fee petition".
+function normalize(level: string): string {
+  return level.trim().toUpperCase().replace(/[_\s]+/g, " ");
+}
+
+// Returns null for anything unrecognized (a level an admin added that isn't
+// one of the seeded ones) — callers should render without an icon chip
+// rather than guess.
+export function caseLevelVisual(
+  level: string | null | undefined,
+  dark: boolean,
+): CaseLevelVisual | null {
+  if (!level) return null;
+  const v = VISUALS[normalize(level)];
+  if (!v) return null;
+  const [bg, fg] = dark ? v.dark : v.light;
+  return { Icon: v.Icon, bg, fg };
+}

--- a/src/lib/listbox-options.ts
+++ b/src/lib/listbox-options.ts
@@ -1,0 +1,29 @@
+import type { ApprovedByOption } from "@/types";
+import type { ListboxOption } from "@/components/shared/Listbox";
+
+// Shared shape for admin-managed dropdown lists rendered as a Listbox: an
+// empty "clear" option, the row's current value if it's since fallen out of
+// the admin-managed list, then the active admin options — same precedence
+// the native <select> version used. `visual` adds an icon chip (Case Level);
+// `tint` colors an option's whole row (Approved By leaders, by team).
+export function buildListboxOptions(
+  adminOptions: ApprovedByOption[],
+  current: string,
+  visual?: (name: string) => Partial<ListboxOption> | undefined,
+  tint?: (name: string) => string | undefined,
+): ListboxOption[] {
+  const active = adminOptions.filter((o) => o.isActive || o.name === current);
+  const opts: ListboxOption[] = [{ value: "", label: "— Select —" }];
+  if (current && !active.some((o) => o.name === current)) {
+    opts.push({ value: current, label: current, ...visual?.(current) });
+  }
+  for (const o of active) {
+    opts.push({
+      value: o.name,
+      label: o.name,
+      tint: tint?.(o.name),
+      ...visual?.(o.name),
+    });
+  }
+  return opts;
+}

--- a/src/lib/member-colors.ts
+++ b/src/lib/member-colors.ts
@@ -1,0 +1,31 @@
+// Distinct per-person color for the Assigned dropdown — team coloring (see
+// team-colors.ts) makes everyone on the same team blend together, which
+// defeats the point of scanning a list of individual assignees at a glance.
+const PALETTE: { light: string; dark: string }[] = [
+  { light: "bg-blue-50 text-blue-800 border-blue-200 hover:bg-blue-100", dark: "bg-blue-900/20 text-blue-300 border-blue-800/60 hover:bg-blue-900/30" },
+  { light: "bg-red-50 text-red-800 border-red-200 hover:bg-red-100", dark: "bg-red-900/20 text-red-300 border-red-800/60 hover:bg-red-900/30" },
+  { light: "bg-emerald-50 text-emerald-800 border-emerald-200 hover:bg-emerald-100", dark: "bg-emerald-900/20 text-emerald-300 border-emerald-800/60 hover:bg-emerald-900/30" },
+  { light: "bg-amber-50 text-amber-800 border-amber-200 hover:bg-amber-100", dark: "bg-amber-900/20 text-amber-300 border-amber-800/60 hover:bg-amber-900/30" },
+  { light: "bg-violet-50 text-violet-800 border-violet-200 hover:bg-violet-100", dark: "bg-violet-900/20 text-violet-300 border-violet-800/60 hover:bg-violet-900/30" },
+  { light: "bg-pink-50 text-pink-800 border-pink-200 hover:bg-pink-100", dark: "bg-pink-900/20 text-pink-300 border-pink-800/60 hover:bg-pink-900/30" },
+  { light: "bg-cyan-50 text-cyan-800 border-cyan-200 hover:bg-cyan-100", dark: "bg-cyan-900/20 text-cyan-300 border-cyan-800/60 hover:bg-cyan-900/30" },
+  { light: "bg-orange-50 text-orange-800 border-orange-200 hover:bg-orange-100", dark: "bg-orange-900/20 text-orange-300 border-orange-800/60 hover:bg-orange-900/30" },
+  { light: "bg-teal-50 text-teal-800 border-teal-200 hover:bg-teal-100", dark: "bg-teal-900/20 text-teal-300 border-teal-800/60 hover:bg-teal-900/30" },
+  { light: "bg-indigo-50 text-indigo-800 border-indigo-200 hover:bg-indigo-100", dark: "bg-indigo-900/20 text-indigo-300 border-indigo-800/60 hover:bg-indigo-900/30" },
+  { light: "bg-fuchsia-50 text-fuchsia-800 border-fuchsia-200 hover:bg-fuchsia-100", dark: "bg-fuchsia-900/20 text-fuchsia-300 border-fuchsia-800/60 hover:bg-fuchsia-900/30" },
+  { light: "bg-lime-50 text-lime-800 border-lime-200 hover:bg-lime-100", dark: "bg-lime-900/20 text-lime-300 border-lime-800/60 hover:bg-lime-900/30" },
+];
+
+function hashString(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) | 0;
+  return Math.abs(h);
+}
+
+// Deterministic per-name color — the same person always lands on the same
+// tint across renders and pages, since it's derived from the name itself
+// rather than list position.
+export function memberRowTint(name: string, dark: boolean): string {
+  const entry = PALETTE[hashString(name) % PALETTE.length];
+  return dark ? entry.dark : entry.light;
+}

--- a/src/lib/team-colors.ts
+++ b/src/lib/team-colors.ts
@@ -1,0 +1,69 @@
+// Single source of truth for team coloring — Concurrent/green, T2/blue,
+// T16/red — so Scoreboard, Reports, and Team Management can't drift out of
+// sync with each other the way they previously did (teal vs. purple vs. red
+// for the same team across different files).
+type Tone = "blue" | "red" | "emerald" | "neutral";
+
+function toneFor(team: string | null | undefined): Tone {
+  if (team === "T2") return "blue";
+  if (team === "T16") return "red";
+  if (team) return "emerald"; // Concurrent (or any future team) reads as the "everyone else" tone
+  return "neutral";
+}
+
+export function teamLabel(team: string | null | undefined): string {
+  if (team === "T2") return "T2 Team";
+  if (team === "T16") return "T16 Team";
+  return "Concurrent Team";
+}
+
+// Solid header bars (Scoreboard team columns).
+export function teamHeaderBg(team: string | null | undefined): string {
+  switch (toneFor(team)) {
+    case "blue": return "bg-blue-800";
+    case "red": return "bg-red-700";
+    default: return "bg-emerald-700";
+  }
+}
+
+// Accent text (team card headings).
+export function teamAccentText(team: string | null | undefined, dark: boolean): string {
+  switch (toneFor(team)) {
+    case "blue": return dark ? "text-blue-400" : "text-blue-700";
+    case "red": return dark ? "text-red-400" : "text-red-700";
+    default: return dark ? "text-emerald-400" : "text-emerald-700";
+  }
+}
+
+// Tinted card border + background (Scoreboard team breakdown cards).
+export function teamCardClasses(team: string | null | undefined, dark: boolean): string {
+  switch (toneFor(team)) {
+    case "blue": return dark ? "border-blue-700/50 bg-blue-900/10" : "border-blue-200 bg-blue-50/60";
+    case "red": return dark ? "border-red-700/50 bg-red-900/10" : "border-red-200 bg-red-50/60";
+    default: return dark ? "border-emerald-700/50 bg-emerald-900/10" : "border-emerald-200 bg-emerald-50/60";
+  }
+}
+
+// Full-row tint (background + text + border + hover) — team leads in the
+// Approved By listbox and assignees in the Assigned listbox, so both read at
+// a glance by team. The border classes are inert on listbox option rows
+// (no `border` width utility there) but matter when this same string is
+// applied to a Listbox trigger button, which does have one.
+export function teamRowTint(team: string | null | undefined, dark: boolean): string {
+  switch (toneFor(team)) {
+    case "blue": return dark ? "bg-blue-900/20 text-blue-300 border-blue-800/60 hover:bg-blue-900/30" : "bg-blue-50 text-blue-800 border-blue-200 hover:bg-blue-100";
+    case "red": return dark ? "bg-red-900/20 text-red-300 border-red-800/60 hover:bg-red-900/30" : "bg-red-50 text-red-800 border-red-200 hover:bg-red-100";
+    case "emerald": return dark ? "bg-emerald-900/20 text-emerald-300 border-emerald-800/60 hover:bg-emerald-900/30" : "bg-emerald-50 text-emerald-800 border-emerald-200 hover:bg-emerald-100";
+    default: return dark ? "text-neutral-200 hover:bg-neutral-800" : "text-neutral-700 hover:bg-neutral-50";
+  }
+}
+
+// Pill badge — agent names in Reports rows and the Team Management roster.
+export function teamBadgeClasses(team: string | null | undefined, dark: boolean): string {
+  switch (toneFor(team)) {
+    case "blue": return dark ? "bg-blue-900/30 text-blue-400 border-blue-800/60" : "bg-blue-50 text-blue-700 border-blue-200";
+    case "red": return dark ? "bg-red-900/30 text-red-400 border-red-800/60" : "bg-red-50 text-red-700 border-red-200";
+    case "emerald": return dark ? "bg-emerald-900/30 text-emerald-400 border-emerald-800/60" : "bg-emerald-50 text-emerald-700 border-emerald-200";
+    default: return dark ? "bg-neutral-800 text-neutral-500 border-neutral-700" : "bg-neutral-100 text-neutral-500 border-neutral-200";
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -135,6 +135,7 @@ export interface MonthlyData {
 export interface TeamMember {
   name: string;
   role: string;
+  team: string | null;
   cases: number;
   collected: string;
 }


### PR DESCRIPTION
## Summary
- Standardize team colors to green (Concurrent) / blue (T2) / red (T16) across Scoreboard, Reports, and Team Management — replaces the previous inconsistent teal/purple scheme
- Colored accents on dashboard and Scoreboard stat cards
- New custom `Listbox` component replacing the native `<select>` for Case Level (with an icon per level) and Approved By/Assigned (colored rows) — icons/colors aren't reliably stylable on native `<option>`
- Team leads tinted by team in Approved By; each assigned agent gets a distinct color in Assigned so individuals stand out instead of blending by team
- `Listbox` supports arrow keys, Home/End, type-ahead, and Enter/Escape, with roving focus (one Tab stop, like a native select)
- Fixed missing icon for the case level renamed to "RECONSIDERATION" in Settings
- Changed "No Fees Due" badge from purple to black

## Test plan
- [x] `npm run lint` / `npm test` (62/62) / `npm run build` all pass
- [x] Manually verified in browser against live data: dashboard, Scoreboard, Reports, Team Management, Master Fees, Fees Closed
- [x] Verified Listbox keyboard nav (arrows, type-ahead, Enter, Escape) and focus return to trigger