### PR TITLE
fix: dropdown closes when scrolling its own option list

### DIFF
--- a/src/components/shared/Listbox.tsx
+++ b/src/components/shared/Listbox.tsx
@@ -61,21 +61,32 @@ export function Listbox({
 
   useEffect(() => {
     if (!open) return;
-    const close = () => setOpen(false);
+    const closeOnResize = () => setOpen(false);
+    // Scroll happens inside the fee table's own overflow containers, so this
+    // needs the capture phase to hear it — repositioning on every scroll
+    // isn't worth the complexity here, closing is enough. But capture-phase
+    // listeners on window also intercept scroll events from the option list's
+    // own overflow-auto (a real scroll never bubbles there, capture still
+    // sees it on the way down) — ignore those so scrolling to reach an option
+    // further down the list, or the browser auto-scrolling the selected
+    // option into view on open, doesn't slam the panel shut.
+    const closeOnOutsideScroll = (e: Event) => {
+      if (panelRef.current && e.target instanceof Node && panelRef.current.contains(e.target)) {
+        return;
+      }
+      setOpen(false);
+    };
     const onClickAway = (e: MouseEvent) => {
       const target = e.target as Node;
       if (triggerRef.current?.contains(target) || panelRef.current?.contains(target)) return;
       setOpen(false);
     };
-    // Scroll happens inside the fee table's own overflow containers, so this
-    // needs the capture phase to hear it — repositioning on every scroll
-    // isn't worth the complexity here, closing is enough.
-    window.addEventListener("scroll", close, true);
-    window.addEventListener("resize", close);
+    window.addEventListener("scroll", closeOnOutsideScroll, true);
+    window.addEventListener("resize", closeOnResize);
     document.addEventListener("mousedown", onClickAway);
     return () => {
-      window.removeEventListener("scroll", close, true);
-      window.removeEventListener("resize", close);
+      window.removeEventListener("scroll", closeOnOutsideScroll, true);
+      window.removeEventListener("resize", closeOnResize);
       document.removeEventListener("mousedown", onClickAway);
     };
   }, [open]);


### PR DESCRIPTION
## Summary
- The custom Listbox (Case Level / Approved By / Assigned) closes on scroll so it doesn't stay stuck to a stale position when the underlying table scrolls — but that listener is capture-phase on `window`, which also intercepts scroll events from the dropdown's own `overflow-auto` option list, even though those don't bubble
- For a long list like Assigned (~35 agents), that meant scrolling to reach an option further down closed the dropdown, and the browser auto-scrolling the current selection into view on open did the same thing immediately
- Reported by Ms. Jazz: "When I try to select it won't allow me, even when scrolling below I can't use it"
- Fix: ignore scroll events whose target is inside the dropdown panel itself; only scrolling the underlying page still closes it

## Test plan
- [x] `npm run lint` / `npm test` (62/62) / `npm run build` all pass
- [x] Verified live via Playwright: dropdown stays open while scrolling inside it, and selecting an option only visible after scrolling (e.g. "Annie") works correctly