### PR TITLE
fix: count all fee sources in Fees Collected (MTD)

### DIFF
--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -46,12 +46,24 @@ export const GET = async () => {
     const paid = Number(stats.totalPaid);
 
     // MTD: fees collected and cases closed in the current calendar month.
+    // fees_collected_mtd reads each benefit type's own received-date column
+    // on fee_records rather than the fee_payments ledger — that ledger only
+    // gets a row when someone uses the "Add Payment" button on the case
+    // detail page, so a month where fees arrived via MyCase/Sheets sync or a
+    // CSV import (which write t16/t2/aux_fee_received directly) showed $0
+    // here even with real money recorded.
     const [mtd] = await db.execute(sql`
       SELECT
         (
-          SELECT COALESCE(SUM(amount::numeric), 0)
-          FROM fee_payments
-          WHERE DATE_TRUNC('month', received_date::date) = DATE_TRUNC('month', CURRENT_DATE)
+          SELECT COALESCE(SUM(
+            CASE WHEN DATE_TRUNC('month', t16_fee_received_date) = DATE_TRUNC('month', CURRENT_DATE)
+              THEN COALESCE(t16_fee_received, 0)::numeric ELSE 0 END
+            + CASE WHEN DATE_TRUNC('month', t2_fee_received_date) = DATE_TRUNC('month', CURRENT_DATE)
+              THEN COALESCE(t2_fee_received, 0)::numeric ELSE 0 END
+            + CASE WHEN DATE_TRUNC('month', aux_fee_received_date) = DATE_TRUNC('month', CURRENT_DATE)
+              THEN COALESCE(aux_fee_received, 0)::numeric ELSE 0 END
+          ), 0)
+          FROM fee_records
         ) AS fees_collected_mtd,
         (
           SELECT COUNT(*)


### PR DESCRIPTION
## Summary
- "Fees Collected (MTD)" only summed the `fee_payments` ledger, which is exclusively written by the "Add Payment" button on the case detail page
- Fees recorded via MyCase sync, Sheets sync, or a CSV import write straight to `fee_records`' t16/t2/aux_fee_received columns and never touch that ledger, so a month with real money collected through those paths still showed $0
- Now sums each benefit type's own received amount, gated by that benefit type's own received-date falling in the current month — matching how the rest of the dashboard already computes "collected"

## Test plan
- [x] `npm run lint` / `npm test` (62/62) / `npm run build` all pass
- [x] Verified live against an independent DB query: $77,232 for the current month, matching exactly (was $0 before)