### PR TITLE
feat: make Fees Confirmation the single path to mark a case overpaid

### DIFF
--- a/src/app/api/cases/[id]/route.ts
+++ b/src/app/api/cases/[id]/route.ts
@@ -1,8 +1,21 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { db } from "@/lib/db";
 import { cases, feeRecords, activityLog, userDetails } from "@/lib/db/schema";
 import { eq, desc, sql } from "drizzle-orm";
 import { requireCapability, requireAdmin, guardStatus } from "@/lib/auth-helpers";
+
+// Loose on purpose — the actual set of writable columns is whitelisted by
+// CASE_FIELD_MAP/FEE_FIELD_MAP/UD_FIELD_MAP below. This just rejects a
+// malformed body (wrong top-level shape, a field that isn't a scalar) before
+// any of that field-mapping logic runs.
+const scalarValue = z.union([z.string(), z.number(), z.boolean(), z.null()]);
+const patchBodySchema = z.object({
+  caseFields: z.record(z.string(), scalarValue).optional(),
+  feeFields: z.record(z.string(), scalarValue).optional(),
+  userDetailsFields: z.record(z.string(), scalarValue).optional(),
+  logMessage: z.string().optional(),
+});
 
 // Fee fields that count as "finalizing" a case — gated by case.finalize rather
 // than the broader case.update (members can record payments but not close,
@@ -328,11 +341,20 @@ export const PATCH = async (
       return NextResponse.json({ error: "Invalid case ID" }, { status: 400 });
     }
 
-    const body = await req.json();
+    const parsedBody = patchBodySchema.safeParse(await req.json());
+    if (!parsedBody.success) {
+      return NextResponse.json(
+        { error: "Invalid request body", details: parsedBody.error.flatten() },
+        { status: 422 },
+      );
+    }
     // NOTE: any client-supplied author is intentionally ignored — the activity
     // author is stamped from the authenticated session below so it can't be
     // spoofed.
-    const { caseFields, feeFields, userDetailsFields, logMessage } = body;
+    const { caseFields, feeFields, userDetailsFields, logMessage: clientLogMessage } = parsedBody.data;
+    // Mutable — the Overpaid auto-flag below appends to whatever the client
+    // sent so the activity log names the side effect, not just the edit.
+    let logMessage = clientLogMessage;
 
     // Authorize: any update needs case.update. Finalizing fields (close/reopen,
     // mark overpaid, approvedBy) additionally need case.finalize, and editing
@@ -491,6 +513,9 @@ export const PATCH = async (
         !("markedOverpaid" in feeFields)
       ) {
         updates.push("marked_overpaid = true");
+        logMessage = logMessage
+          ? `${logMessage} — also flagged as overpaid`
+          : "Flagged as overpaid (Fees Confirmation set to \"Overpaid\")";
       }
 
       if (updates.length > 0) {

--- a/src/app/api/cases/[id]/route.ts
+++ b/src/app/api/cases/[id]/route.ts
@@ -478,6 +478,21 @@ export const PATCH = async (
         updates.push("closed_at = NULL");
       }
 
+      // Setting Fees Confirmation to "Overpaid" also flags the case as
+      // overpaid — the same way a case shows up on Fee Petitions purely from
+      // its Level, it should show up on Overpaid Cases purely from this
+      // dropdown, without a separate manual "Mark Overpaid" step. Only
+      // auto-sets it on; correcting a mis-click back to another confirmation
+      // value doesn't auto-unmark it, since Overpaid Cases tracks its own
+      // resolution workflow (notices sent, checks cleared) that shouldn't
+      // silently disappear.
+      if (
+        feeFields.feesConfirmation === "Overpaid" &&
+        !("markedOverpaid" in feeFields)
+      ) {
+        updates.push("marked_overpaid = true");
+      }
+
       if (updates.length > 0) {
         await db.execute(
           sql`UPDATE fee_records SET ${sql.raw(updates.join(", "))}, updated_at = NOW() WHERE case_id = ${caseId}`,

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -14,7 +14,6 @@ import {
   ExternalLink,
   Pencil,
   Check,
-  TrendingDown,
   Plus,
   X,
   Archive,
@@ -337,9 +336,6 @@ export const FeeRecordsTable = ({
   const [archivePendingSource, setArchivePendingSource] = useState<
     "active_sheet" | "fees_closed_sheet"
   >("active_sheet");
-  const [overpaidOverrides, setOverpaidOverrides] = useState<
-    Record<number, boolean>
-  >({});
   // Optimistic overrides for fee payment totals after panel add/delete.
   const [feeOverrides, setFeeOverrides] = useState<
     Record<number, Partial<Pick<CaseRow, "t16Retro" | "t16FeeDue" | "t16Pending" | "t16FeeReceived" | "t16FeeReceivedDate" | "t2Retro" | "t2FeeDue" | "t2Pending" | "t2FeeReceived" | "t2FeeReceivedDate" | "auxRetro" | "auxFeeDue" | "auxPending" | "auxFeeReceived" | "auxFeeReceivedDate">>>
@@ -353,10 +349,8 @@ export const FeeRecordsTable = ({
   const [feeAmountSaving, setFeeAmountSaving] = useState(false);
   const [feeAmountError, setFeeAmountError] = useState<string | null>(null);
   const feeAmountAbortRef = useRef<AbortController | null>(null);
-  const [batchLoading, setBatchLoading] = useState(false);
   const selectAllRef = useRef<HTMLInputElement>(null);
   const patchAbortRef = useRef<Map<string, AbortController>>(new Map());
-  const batchOverpaidAbortRef = useRef<AbortController | null>(null);
   useEffect(() => {
     const abortMap = patchAbortRef.current;
     const feeAmountRef = feeAmountAbortRef;
@@ -382,52 +376,6 @@ export const FeeRecordsTable = ({
     setSelectedIds(
       allSelected ? new Set() : new Set(filtered.map((c) => c.id)),
     );
-  };
-
-  const handleBatchOverpaid = async (mark: boolean) => {
-    if (selectedIds.size === 0 || batchLoading) return;
-    const ids = Array.from(selectedIds);
-    batchOverpaidAbortRef.current?.abort();
-    const controller = new AbortController();
-    batchOverpaidAbortRef.current = controller;
-    setBatchLoading(true);
-    // Optimistic override only when marking — removing the flag should not
-    // immediately change the visual state in this table (it takes effect on
-    // the next data refresh so the row highlight isn't stripped mid-session).
-    if (mark) {
-      setOverpaidOverrides((prev) => {
-        const next = { ...prev };
-        ids.forEach((id) => {
-          next[id] = true;
-        });
-        return next;
-      });
-    }
-    try {
-      const res = await fetch("/api/cases/bulk-overpaid", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ caseIds: ids, markedOverpaid: mark }),
-        signal: controller.signal,
-      });
-      if (!res.ok)
-        throw new Error(`Failed to update overpaid flag (${res.status})`);
-      setSelectedIds(new Set());
-    } catch (err) {
-      if ((err as Error).name === "AbortError") return;
-      if (mark) {
-        setOverpaidOverrides((prev) => {
-          const next = { ...prev };
-          ids.forEach((id) => {
-            delete next[id];
-          });
-          return next;
-        });
-      }
-      window.alert((err as Error).message);
-    } finally {
-      setBatchLoading(false);
-    }
   };
 
   const handleBatchArchive = () => {
@@ -988,37 +936,24 @@ export const FeeRecordsTable = ({
         </div>
       </div>
 
-      {/* Floating batch action pill — fixed to the viewport bottom */}
-      {selectedIds.size > 0 && (canFinalize || isAdmin) && (
+      {/* Floating batch action pill — fixed to the viewport bottom. Archive is
+          the only batch action; marking a case overpaid is Fees Conf-only
+          now (see the "Fees Confirmation" column) so it's a single,
+          unambiguous path instead of two ways to do the same thing. */}
+      {selectedIds.size > 0 && isAdmin && (
         <div className="pointer-events-none fixed bottom-6 left-0 right-0 z-50 flex justify-center">
           <div className="pointer-events-auto flex items-center gap-2 rounded-full bg-gray-900 px-4 py-2.5 shadow-2xl ring-1 ring-white/10 dark:bg-gray-800">
             <span className="text-[11px] font-semibold text-gray-300 pr-1 border-r border-white/20 mr-1">
               {selectedIds.size} selected
             </span>
-            {canFinalize && (
-              <button
-                onClick={() => handleBatchOverpaid(true)}
-                disabled={batchLoading}
-                className="h-7 px-3 rounded-full text-[11px] font-semibold flex items-center gap-1.5 bg-amber-500 hover:bg-amber-400 text-gray-900 transition-colors disabled:opacity-50"
-              >
-                {batchLoading ? (
-                  <Loader2 aria-hidden="true" className="h-3 w-3 animate-spin" />
-                ) : (
-                  <TrendingDown aria-hidden="true" className="h-3 w-3" />
-                )}
-                Mark as Overpaid
-              </button>
-            )}
-            {isAdmin && (
-              <button
-                onClick={handleBatchArchive}
-                disabled={batchLoading || archiveConfirmOpen}
-                className="h-7 px-3 rounded-full text-[11px] font-semibold flex items-center gap-1.5 bg-rose-600 hover:bg-rose-500 text-white transition-colors disabled:opacity-50"
-              >
-                <Archive aria-hidden="true" className="h-3 w-3" />
-                Archive
-              </button>
-            )}
+            <button
+              onClick={handleBatchArchive}
+              disabled={archiveConfirmOpen}
+              className="h-7 px-3 rounded-full text-[11px] font-semibold flex items-center gap-1.5 bg-rose-600 hover:bg-rose-500 text-white transition-colors disabled:opacity-50"
+            >
+              <Archive aria-hidden="true" className="h-3 w-3" />
+              Archive
+            </button>
             <button
               onClick={() => setSelectedIds(new Set())}
               aria-label="Clear selection"
@@ -1264,7 +1199,7 @@ export const FeeRecordsTable = ({
             <tbody>
               {paged.map((rawC) => {
                 const c = { ...rawC, ...feeOverrides[rawC.id] };
-                const isOverpaid = overpaidOverrides[c.id] ?? c.markedOverpaid;
+                const isOverpaid = c.markedOverpaid;
                 return (
                   <tr
                     key={c.id}


### PR DESCRIPTION
## Summary
- Setting Fees Confirmation to "Overpaid" now also sets `marked_overpaid` automatically — mirrors how a case shows up on Fee Petitions purely from its Level, so it shows up on Overpaid Cases without a separate manual step
- Wired server-side in the case PATCH endpoint, so it fires from any path that sets Fees Confirmation, not just one specific UI
- Only sets the flag on; correcting a mis-click back to another confirmation value doesn't auto-unmark it, since Overpaid Cases tracks its own resolution workflow (notices sent, checks cleared) that shouldn't silently disappear
- Per Ms. Jazz: removed the "Mark as Overpaid" bulk action from Master Fees' batch action bar, so Fees Confirmation is now the *only* way to mark a case overpaid — the bar now only offers Archive
- Cleaned up everything that only existed to support the removed button (optimistic-override state, loading flag, abort ref, unused icon import)

## Test plan
- [x] `npm run lint` / `npm test` (62/62) / `npm run build` all pass
- [x] Verified live end-to-end: setting Fees Confirmation → Overpaid on a real case flipped `marked_overpaid` in the DB and the case appeared on Overpaid Cases (reverted the test case afterward)
- [x] Verified the batch action bar now shows only Archive