### PR TITLE
fix: correct Open Cases Fees Status card and no-fees aging counts

### DIFF
--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -126,35 +126,6 @@ export const GET = async (req: NextRequest) => {
       GROUP BY specialist_assigned
     `);
 
-    const [feesStatus] = await db.execute(sql`
-      SELECT
-        COUNT(*) FILTER (
-          WHERE fr.pif_ready_to_close = true
-        )::int AS pif_count,
-        COUNT(*) FILTER (
-          WHERE fr.pif_ready_to_close IS NOT TRUE
-            AND COALESCE(fr.t16_fee_due, 0)::numeric = 0
-            AND COALESCE(fr.t2_fee_due, 0)::numeric = 0
-            AND COALESCE(fr.aux_fee_due, 0)::numeric = 0
-            AND COALESCE(fr.t16_fee_received, 0)::numeric = 0
-            AND COALESCE(fr.t2_fee_received, 0)::numeric = 0
-            AND COALESCE(fr.aux_fee_received, 0)::numeric = 0
-        )::int AS no_fees_count,
-        COUNT(*) FILTER (
-          WHERE fr.pif_ready_to_close IS NOT TRUE
-            AND NOT (
-              COALESCE(fr.t16_fee_due, 0)::numeric = 0
-              AND COALESCE(fr.t2_fee_due, 0)::numeric = 0
-              AND COALESCE(fr.aux_fee_due, 0)::numeric = 0
-              AND COALESCE(fr.t16_fee_received, 0)::numeric = 0
-              AND COALESCE(fr.t2_fee_received, 0)::numeric = 0
-              AND COALESCE(fr.aux_fee_received, 0)::numeric = 0
-            )
-        )::int AS partial_count
-      FROM fee_records fr
-      WHERE fr.is_closed = false
-    `) as unknown as [{ pif_count: number; no_fees_count: number; partial_count: number }];
-
     // 9. Recent activity entries (for the feed)
     const recentActivity = await db.execute(sql`
       SELECT
@@ -294,11 +265,6 @@ export const GET = async (req: NextRequest) => {
         to,
         agents,
         totals,
-        openCasesFeesStatus: {
-          noFees: Number(feesStatus?.no_fees_count) || 0,
-          partial: Number(feesStatus?.partial_count) || 0,
-          pif: Number(feesStatus?.pif_count) || 0,
-        },
         dailyBreakdown: (
           dailyBreakdown as unknown as {
             date: string;

--- a/src/app/api/scoreboard/route.ts
+++ b/src/app/api/scoreboard/route.ts
@@ -179,30 +179,25 @@ export const GET = async (req: NextRequest) => {
          AND dm.metric_date >= ${startDate}::date
          AND dm.metric_date < ${endExclusive}::date), 0) AS week_fax_sent,
 
-        -- Open cases fees status per agent (current snapshot)
+        -- Open cases fees status per agent (current snapshot), bucketed by
+        -- fees_confirmation alone so the three counts are mutually exclusive
+        -- and always sum to that agent's total open cases.
         (SELECT COUNT(*) FROM fee_records fr
          WHERE fr.assigned_to = tm.name
          AND fr.is_closed = FALSE
-         AND fr.pif_ready_to_close IS NOT TRUE
-         AND COALESCE(fr.t16_fee_due, 0)::numeric = 0
-         AND COALESCE(fr.t2_fee_due, 0)::numeric = 0
-         AND COALESCE(fr.aux_fee_due, 0)::numeric = 0
-         AND COALESCE(fr.t16_fee_received, 0)::numeric = 0
-         AND COALESCE(fr.t2_fee_received, 0)::numeric = 0
-         AND COALESCE(fr.aux_fee_received, 0)::numeric = 0
+         AND (fr.fees_confirmation IS NULL OR fr.fees_confirmation = '')
         )::int AS open_no_fees,
 
         (SELECT COUNT(*) FROM fee_records fr
          WHERE fr.assigned_to = tm.name
          AND fr.is_closed = FALSE
-         AND fr.pif_ready_to_close IS NOT TRUE
          AND fr.fees_confirmation IN ('Partial Payment', 'Pending (full/partial)')
         )::int AS open_partial,
 
         (SELECT COUNT(*) FROM fee_records fr
          WHERE fr.assigned_to = tm.name
          AND fr.is_closed = FALSE
-         AND fr.pif_ready_to_close = TRUE
+         AND fr.fees_confirmation = 'Paid In Full'
         )::int AS open_pif
 
       FROM team_members tm
@@ -318,37 +313,24 @@ export const GET = async (req: NextRequest) => {
       }),
     );
 
+    // Bucketed by fees_confirmation alone so this always matches the same
+    // definition used by the No Fees Cases aging query below.
     const [feesStatus] = await db.execute(sql`
-      SELECT
-        COUNT(*) FILTER (WHERE pif_ready_to_close = true)::int AS pif_count,
-        COUNT(*) FILTER (
-          WHERE pif_ready_to_close IS NOT TRUE
-            AND COALESCE(t16_fee_due, 0)::numeric = 0
-            AND COALESCE(t2_fee_due, 0)::numeric = 0
-            AND COALESCE(aux_fee_due, 0)::numeric = 0
-            AND COALESCE(t16_fee_received, 0)::numeric = 0
-            AND COALESCE(t2_fee_received, 0)::numeric = 0
-            AND COALESCE(aux_fee_received, 0)::numeric = 0
-        )::int AS no_fees_count,
-        COUNT(*) FILTER (
-          WHERE pif_ready_to_close IS NOT TRUE
-            AND fees_confirmation IN ('Partial Payment', 'Pending (full/partial)')
-        )::int AS partial_count
+      SELECT COUNT(*) FILTER (WHERE fees_confirmation IS NULL OR fees_confirmation = '')::int AS no_fees_count
       FROM fee_records
       WHERE is_closed = false
-    `) as unknown as [{ pif_count: number; no_fees_count: number; partial_count: number }];
+    `) as unknown as [{ no_fees_count: number }];
 
     const openCasesFeesStatus = {
-      noFees:  Number(feesStatus?.no_fees_count)  || 0,
-      partial: Number(feesStatus?.partial_count)   || 0,
-      pif:     Number(feesStatus?.pif_count)        || 0,
+      noFees: Number(feesStatus?.no_fees_count) || 0,
     };
 
-    // No Fees Cases — open cases with zero fees due/received (same predicate
-    // as openCasesFeesStatus.noFees above), aged over 60 days by approval_date.
-    // Returns the actual case rows (not just a count) so the Reports page can
-    // list them for reporting; over60/over90 counts are derived from this
-    // same list below so the card and the table can never disagree.
+    // No Fees Cases — open cases with no fees_confirmation set (same
+    // predicate as openCasesFeesStatus.noFees above), aged over 60 days by
+    // approval_date. Returns the actual case rows (not just a count) so the
+    // Reports page can list them for reporting; over60/over90 counts are
+    // derived from this same list below so the card and the table can never
+    // disagree.
     const noFeesCaseRows = await db.execute(sql`
       SELECT
         c.client_id AS id,
@@ -362,13 +344,7 @@ export const GET = async (req: NextRequest) => {
       FROM fee_records fr
       JOIN cases c ON c.client_id = fr.case_id
       WHERE fr.is_closed = FALSE
-        AND fr.pif_ready_to_close IS NOT TRUE
-        AND COALESCE(fr.t16_fee_due, 0)::numeric = 0
-        AND COALESCE(fr.t2_fee_due, 0)::numeric = 0
-        AND COALESCE(fr.aux_fee_due, 0)::numeric = 0
-        AND COALESCE(fr.t16_fee_received, 0)::numeric = 0
-        AND COALESCE(fr.t2_fee_received, 0)::numeric = 0
-        AND COALESCE(fr.aux_fee_received, 0)::numeric = 0
+        AND (fr.fees_confirmation IS NULL OR fr.fees_confirmation = '')
         AND c.approval_date IS NOT NULL
         AND c.approval_date < CURRENT_DATE - INTERVAL '60 days'
       ORDER BY c.approval_date ASC

--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -84,7 +84,7 @@ interface TrackerData {
   daily: DailyEntry[];
   summary: ScoreboardSummary | null;
   teams: ScoreboardTeam[];
-  openCasesFeesStatus: { noFees: number; partial: number; pif: number };
+  openCasesFeesStatus: { noFees: number };
   noFeesAging: { over60: number; over90: number };
   noFeesCases: NoFeesCaseRow[];
 }
@@ -320,7 +320,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
         daily: json.daily ?? [],
         summary: json.summary ?? null,
         teams: json.teams ?? [],
-        openCasesFeesStatus: json.openCasesFeesStatus ?? { noFees: 0, partial: 0, pif: 0 },
+        openCasesFeesStatus: json.openCasesFeesStatus ?? { noFees: 0 },
         noFeesAging: json.noFeesAging ?? { over60: 0, over90: 0 },
         noFeesCases: json.noFeesCases ?? [],
       });
@@ -505,9 +505,9 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
           </div>
           <div className={`grid grid-cols-3 divide-x divide-dashed ${dark ? "divide-neutral-700" : "divide-neutral-200"}`}>
             {[
-              { label: "No Fees",           value: data.openCasesFeesStatus.noFees,  tone: dark ? "text-amber-400"   : "text-amber-600"   },
-              { label: "Partial / Pending",  value: data.openCasesFeesStatus.partial, tone: dark ? "text-blue-400"    : "text-blue-600"    },
-              { label: "Paid in Full",       value: data.openCasesFeesStatus.pif,     tone: dark ? "text-emerald-400" : "text-emerald-600" },
+              { label: "No Fees",              value: data.openCasesFeesStatus.noFees, tone: dark ? "text-amber-400" : "text-amber-600" },
+              { label: "No Fees Over 60 Days",  value: data.noFeesAging.over60,         tone: dark ? "text-orange-400" : "text-orange-600" },
+              { label: "No Fees Over 90 Days",  value: data.noFeesAging.over90,         tone: dark ? "text-red-400"   : "text-red-600"   },
             ].map(({ label, value, tone }) => (
               <div key={label} className="py-3 text-center">
                 <div className={`text-[10px] font-semibold uppercase tracking-wider ${t.textMuted} mb-1`}>{label}</div>


### PR DESCRIPTION
## Summary
- The Open Cases (Fees Status) card and the No Fees Cases aging counts were keyed off `pif_ready_to_close`/raw fee-amount columns instead of `fees_confirmation`, so ~200 open cases matched none of the buckets and the 60/90-day aging counts undercounted against the sheet.
- Rebucketed both by `fees_confirmation` alone — mutually exclusive, always sums to total open cases (685 verified live: 510 No Fees / 173 Partial-Pending / 14 Paid in Full, and 240/166 for 60/90-day aging).
- Per Jazz's request, swapped the card's Partial/Pending and Paid in Full columns for No Fees Over 60 Days / No Fees Over 90 Days.
- Removed a dead, differently-defined duplicate of this stat in `/api/reports` that had no consumers.