### PR TITLE
fix: enforce self-only writes on daily call metrics server-side

### DIFF
--- a/src/app/(dashboard)/scoreboard/actions.ts
+++ b/src/app/(dashboard)/scoreboard/actions.ts
@@ -6,22 +6,23 @@ import { dailyMetrics } from "@/lib/db/schema";
 import { and, eq } from "drizzle-orm";
 import { parseDate, parseNonNegativeInt } from "@/lib/import/csv-parser";
 import type { ImportResult } from "@/components/modals/CsvImportModal";
+import { sessionHasCapability } from "@/lib/auth-helpers";
 
 // Bulk CSV import writes daily_metrics rows for every agent named in the
-// file — a supervisory action, not a "log my own calls" one — so it's
-// restricted to lead/admin rather than the self-only rule in
+// file — a supervisory action, not a "log my own calls" one — so it requires
+// dailyMetrics.editOthers (lead/admin by default, grantable per-user via the
+// access overrides modal) rather than the self-only rule in
 // /api/daily-metrics.
 export async function bulkImportDailyMetrics(
   rawRows: Record<string, string>[],
 ): Promise<ImportResult> {
   const session = await auth();
-  const role = session?.user?.role;
-  const isPrivileged = role === "admin" || role === "system_admin" || role === "lead";
-  if (!isPrivileged) {
+  if (!sessionHasCapability(session, "dailyMetrics.editOthers")) {
     return {
       imported: 0,
-      failed: rawRows.length,
-      rowErrors: [{ row: 0, error: "You don't have permission to import daily metrics." }],
+      failed: 0,
+      rowErrors: [],
+      error: "You don't have permission to import daily metrics.",
     };
   }
 

--- a/src/app/(dashboard)/scoreboard/actions.ts
+++ b/src/app/(dashboard)/scoreboard/actions.ts
@@ -1,14 +1,30 @@
 "use server";
 
+import { auth } from "@/auth";
 import { db } from "@/lib/db";
 import { dailyMetrics } from "@/lib/db/schema";
 import { and, eq } from "drizzle-orm";
 import { parseDate, parseNonNegativeInt } from "@/lib/import/csv-parser";
 import type { ImportResult } from "@/components/modals/CsvImportModal";
 
+// Bulk CSV import writes daily_metrics rows for every agent named in the
+// file — a supervisory action, not a "log my own calls" one — so it's
+// restricted to lead/admin rather than the self-only rule in
+// /api/daily-metrics.
 export async function bulkImportDailyMetrics(
   rawRows: Record<string, string>[],
 ): Promise<ImportResult> {
+  const session = await auth();
+  const role = session?.user?.role;
+  const isPrivileged = role === "admin" || role === "system_admin" || role === "lead";
+  if (!isPrivileged) {
+    return {
+      imported: 0,
+      failed: rawRows.length,
+      rowErrors: [{ row: 0, error: "You don't have permission to import daily metrics." }],
+    };
+  }
+
   let imported = 0;
   const rowErrors: ImportResult["rowErrors"] = [];
 

--- a/src/app/api/daily-metrics/route.ts
+++ b/src/app/api/daily-metrics/route.ts
@@ -1,12 +1,30 @@
 import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
 import { db } from "@/lib/db";
 import { dailyMetrics } from "@/lib/db/schema";
 import { eq, and, sql } from "drizzle-orm";
+
+// Members can only log their own calls — agent_name is matched against the
+// session's display name (team_members.name mirrors users.name for real
+// accounts). Leads/admins can log for anyone.
+const canWriteAgent = (
+  role: string | null | undefined,
+  sessionName: string | null | undefined,
+  agent: string,
+): boolean =>
+  role === "admin" || role === "system_admin" || role === "lead"
+    ? true
+    : !!sessionName && agent === sessionName;
 
 // GET /api/daily-metrics?agent=Drake&date=2026-02-20
 // GET /api/daily-metrics?week=2026-02-17  (returns all agents for the week)
 export const GET = async (req: NextRequest) => {
   try {
+    const session = await auth();
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+    }
+
     const { searchParams } = new URL(req.url);
     const agent = searchParams.get("agent");
     const date = searchParams.get("date");
@@ -112,15 +130,27 @@ export const GET = async (req: NextRequest) => {
 // Supports batch:  { entries: [{ agent, date, ssaCalls, clientCallsIb, clientCallsOb, notes }] }
 export const POST = async (req: NextRequest) => {
   try {
+    const session = await auth();
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+    }
+    const role = session.user.role;
+    const sessionName = session.user.name;
+
     const body = await req.json();
 
     // Batch mode
     if (body.entries && Array.isArray(body.entries)) {
       const results = [];
+      let skipped = 0;
       for (const entry of body.entries) {
         const { agent, date, ssaCalls, clientCallsIb, clientCallsOb, winSheetsCreated, faxSent, notes } =
           entry;
         if (!agent || !date) continue;
+        if (!canWriteAgent(role, sessionName, agent)) {
+          skipped++;
+          continue;
+        }
 
         await db.execute(sql`
           INSERT INTO daily_metrics (id, agent_name, metric_date, ssa_calls, client_calls_ib, client_calls_ob, win_sheets_created, fax_sent, notes, created_at, updated_at)
@@ -147,6 +177,7 @@ export const POST = async (req: NextRequest) => {
       return NextResponse.json({
         status: "ok",
         count: results.length,
+        skipped,
         data: results,
       });
     }
@@ -156,6 +187,12 @@ export const POST = async (req: NextRequest) => {
 
     if (!agent) {
       return NextResponse.json({ error: "agent is required" }, { status: 400 });
+    }
+    if (!canWriteAgent(role, sessionName, agent)) {
+      return NextResponse.json(
+        { error: "You can only log your own calls." },
+        { status: 403 },
+      );
     }
 
     const metricDate = date || new Date().toISOString().split("T")[0];

--- a/src/app/api/daily-metrics/route.ts
+++ b/src/app/api/daily-metrics/route.ts
@@ -1,20 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
+import type { Session } from "next-auth";
 import { auth } from "@/auth";
 import { db } from "@/lib/db";
 import { dailyMetrics } from "@/lib/db/schema";
 import { eq, and, sql } from "drizzle-orm";
+import { sessionHasCapability } from "@/lib/auth-helpers";
 
 // Members can only log their own calls — agent_name is matched against the
 // session's display name (team_members.name mirrors users.name for real
-// accounts). Leads/admins can log for anyone.
-const canWriteAgent = (
-  role: string | null | undefined,
-  sessionName: string | null | undefined,
-  agent: string,
-): boolean =>
-  role === "admin" || role === "system_admin" || role === "lead"
-    ? true
-    : !!sessionName && agent === sessionName;
+// accounts). dailyMetrics.editOthers (lead/admin by default, grantable
+// per-user via the access overrides modal) can log for anyone.
+const canWriteAgent = (session: Session, agent: string): boolean =>
+  sessionHasCapability(session, "dailyMetrics.editOthers") ||
+  agent === session.user?.name;
 
 // GET /api/daily-metrics?agent=Drake&date=2026-02-20
 // GET /api/daily-metrics?week=2026-02-17  (returns all agents for the week)
@@ -134,8 +132,6 @@ export const POST = async (req: NextRequest) => {
     if (!session?.user) {
       return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
     }
-    const role = session.user.role;
-    const sessionName = session.user.name;
 
     const body = await req.json();
 
@@ -147,7 +143,7 @@ export const POST = async (req: NextRequest) => {
         const { agent, date, ssaCalls, clientCallsIb, clientCallsOb, winSheetsCreated, faxSent, notes } =
           entry;
         if (!agent || !date) continue;
-        if (!canWriteAgent(role, sessionName, agent)) {
+        if (!canWriteAgent(session, agent)) {
           skipped++;
           continue;
         }
@@ -188,7 +184,7 @@ export const POST = async (req: NextRequest) => {
     if (!agent) {
       return NextResponse.json({ error: "agent is required" }, { status: 400 });
     }
-    if (!canWriteAgent(role, sessionName, agent)) {
+    if (!canWriteAgent(session, agent)) {
       return NextResponse.json(
         { error: "You can only log your own calls." },
         { status: 403 },

--- a/src/components/modals/CsvImportModal.tsx
+++ b/src/components/modals/CsvImportModal.tsx
@@ -26,6 +26,9 @@ export interface ImportResult {
   imported: number;
   failed: number;
   rowErrors: Array<{ row: number; error: string }>;
+  /** Set when the whole import was rejected before any row was processed
+   *  (e.g. a permission check) — rendered instead of the row-by-row summary. */
+  error?: string;
 }
 
 interface ParsedRow {
@@ -571,35 +574,46 @@ export default function CsvImportModal({
           {/* ── DONE ── */}
           {step === "done" && importResult && (
             <div className="py-8">
-              <div className={`max-w-md mx-auto rounded-lg border p-5 ${
-                importResult.imported > 0
-                  ? dark ? "bg-emerald-900/20 border-emerald-800 text-emerald-300" : "bg-emerald-50 border-emerald-200 text-emerald-800"
-                  : dark ? "bg-amber-900/20 border-amber-800 text-amber-300" : "bg-amber-50 border-amber-200 text-amber-800"
-              }`}>
-                <div className="flex items-start gap-3">
-                  <CheckCircle2 className="h-5 w-5 mt-0.5 shrink-0" aria-hidden="true" />
-                  <div className="text-[13px]">
-                    <p className="font-bold">
-                      {importResult.imported} row{importResult.imported !== 1 ? "s" : ""} imported.
-                    </p>
-                    {importResult.failed > 0 && (
-                      <p className="opacity-90 mt-1">
-                        {importResult.failed} row{importResult.failed !== 1 ? "s" : ""} failed.
-                      </p>
-                    )}
+              {importResult.error ? (
+                <div className={`max-w-md mx-auto rounded-lg border p-5 ${dark ? "bg-red-900/20 border-red-800 text-red-300" : "bg-red-50 border-red-200 text-red-800"}`}>
+                  <div className="flex items-start gap-3">
+                    <AlertTriangle className="h-5 w-5 mt-0.5 shrink-0" aria-hidden="true" />
+                    <p className="text-[13px] font-bold">{importResult.error}</p>
                   </div>
                 </div>
-              </div>
+              ) : (
+                <>
+                  <div className={`max-w-md mx-auto rounded-lg border p-5 ${
+                    importResult.imported > 0
+                      ? dark ? "bg-emerald-900/20 border-emerald-800 text-emerald-300" : "bg-emerald-50 border-emerald-200 text-emerald-800"
+                      : dark ? "bg-amber-900/20 border-amber-800 text-amber-300" : "bg-amber-50 border-amber-200 text-amber-800"
+                  }`}>
+                    <div className="flex items-start gap-3">
+                      <CheckCircle2 className="h-5 w-5 mt-0.5 shrink-0" aria-hidden="true" />
+                      <div className="text-[13px]">
+                        <p className="font-bold">
+                          {importResult.imported} row{importResult.imported !== 1 ? "s" : ""} imported.
+                        </p>
+                        {importResult.failed > 0 && (
+                          <p className="opacity-90 mt-1">
+                            {importResult.failed} row{importResult.failed !== 1 ? "s" : ""} failed.
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  </div>
 
-              {importResult.rowErrors.length > 0 && (
-                <div className={`mt-3 max-w-md mx-auto rounded-md border p-3 text-[11px] ${warnBg}`}>
-                  <p className="font-semibold mb-1">Row errors:</p>
-                  <ul className="space-y-0.5 max-h-32 overflow-y-auto">
-                    {importResult.rowErrors.map((e, i) => (
-                      <li key={i}>Row {e.row}: {e.error}</li>
-                    ))}
-                  </ul>
-                </div>
+                  {importResult.rowErrors.length > 0 && (
+                    <div className={`mt-3 max-w-md mx-auto rounded-md border p-3 text-[11px] ${warnBg}`}>
+                      <p className="font-semibold mb-1">Row errors:</p>
+                      <ul className="space-y-0.5 max-h-32 overflow-y-auto">
+                        {importResult.rowErrors.map((e, i) => (
+                          <li key={i}>Row {e.row}: {e.error}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </>
               )}
             </div>
           )}

--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -436,7 +436,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
         ssaCalls: number; clientCallsIb: number; clientCallsOb: number; winSheetsCreated: number; faxSent: number;
       }[] = [];
       if (data) {
-        for (const agent of data.agents) {
+        for (const agent of data.agents.filter((a) => canEditAgent(a.agent))) {
           for (const day of entryDays) {
             const c = getCell(agent.agent, day.date);
             const ssa = parseInt(c.ssaCalls) || 0;
@@ -458,7 +458,8 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
         signal: saveAbortRef.current.signal,
       });
       if (!res.ok) throw new Error(`Failed to save (${res.status})`);
-      setSaveMsg(`Saved ${entries.length} entries`);
+      const json = await res.json();
+      setSaveMsg(`Saved ${json.count ?? entries.length} entries`);
       setDirty(false);
       await fetchScoreboard();
     } catch (err) {

--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -25,6 +25,7 @@ import { useSession } from "next-auth/react";
 import { themeClasses } from "@/lib/theme-classes";
 import { fmt, fmtDate } from "@/lib/formatters";
 import { teamBadgeClasses } from "@/lib/team-colors";
+import { useCapabilities } from "@/hooks/useCapabilities";
 import {
   ScoreboardSummaryCards,
   ScoreboardSummary,
@@ -220,12 +221,10 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
   const cancelledRef = useRef(false);
 
   const { data: session } = useSession();
-  const role = session?.user?.role;
-  const isAdmin = role === "admin" || role === "system_admin";
-  const isLead = role === "lead";
   const userName = session?.user?.name;
+  const { can } = useCapabilities();
   const canEditAgent = (agentName: string) =>
-    isAdmin || isLead || (!!userName && agentName === userName);
+    can("dailyMetrics.editOthers") || (!!userName && agentName === userName);
 
   const currentYear = nowForInit.getFullYear();
   const yearOptions = useMemo(

--- a/src/components/scoreboard/Scoreboard.tsx
+++ b/src/components/scoreboard/Scoreboard.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useReducer, useEffect } from "react";
-import { useSession } from "next-auth/react";
 import { useTheme } from "next-themes";
 import { RefreshCw, ChevronLeft, ChevronRight, Upload } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
@@ -9,6 +8,7 @@ import CsvImportModal, { type ColumnDef } from "@/components/modals/CsvImportMod
 import { bulkImportDailyMetrics } from "@/app/(dashboard)/scoreboard/actions";
 import { parseDate, parseNonNegativeInt } from "@/lib/import/csv-parser";
 import { teamHeaderBg } from "@/lib/team-colors";
+import { useCapabilities } from "@/hooks/useCapabilities";
 
 // ---------- types ----------
 
@@ -108,9 +108,8 @@ export const Scoreboard = () => {
   const { resolvedTheme } = useTheme();
   const dark = resolvedTheme === "dark";
   const t = themeClasses(dark);
-  const { data: session } = useSession();
-  const role = session?.user?.role;
-  const canImport = role === "admin" || role === "system_admin" || role === "lead";
+  const { can } = useCapabilities();
+  const canImport = can("dailyMetrics.editOthers");
 
   const [weekOffset, setWeekOffset] = useState(0);
   const [csvImportOpen, setCsvImportOpen] = useState(false);

--- a/src/components/scoreboard/Scoreboard.tsx
+++ b/src/components/scoreboard/Scoreboard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useReducer, useEffect } from "react";
+import { useSession } from "next-auth/react";
 import { useTheme } from "next-themes";
 import { RefreshCw, ChevronLeft, ChevronRight, Upload } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
@@ -107,6 +108,9 @@ export const Scoreboard = () => {
   const { resolvedTheme } = useTheme();
   const dark = resolvedTheme === "dark";
   const t = themeClasses(dark);
+  const { data: session } = useSession();
+  const role = session?.user?.role;
+  const canImport = role === "admin" || role === "system_admin" || role === "lead";
 
   const [weekOffset, setWeekOffset] = useState(0);
   const [csvImportOpen, setCsvImportOpen] = useState(false);
@@ -193,14 +197,16 @@ export const Scoreboard = () => {
           </p>
         </div>
         <div className="flex items-center gap-1 shrink-0">
-          <button
-            onClick={() => setCsvImportOpen(true)}
-            className={`flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium border transition-colors ${dark ? "border-neutral-700 text-neutral-300 hover:bg-neutral-800" : "border-neutral-200 text-neutral-600 hover:bg-neutral-50"}`}
-            aria-label="Import daily metrics from CSV"
-          >
-            <Upload aria-hidden="true" className="h-3.5 w-3.5" />
-            Import
-          </button>
+          {canImport && (
+            <button
+              onClick={() => setCsvImportOpen(true)}
+              className={`flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium border transition-colors ${dark ? "border-neutral-700 text-neutral-300 hover:bg-neutral-800" : "border-neutral-200 text-neutral-600 hover:bg-neutral-50"}`}
+              aria-label="Import daily metrics from CSV"
+            >
+              <Upload aria-hidden="true" className="h-3.5 w-3.5" />
+              Import
+            </button>
+          )}
           <button
             onClick={() => setWeekOffset(weekOffset - 1)}
             className={`flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium border transition-colors ${dark ? "border-neutral-700 text-neutral-300 hover:bg-neutral-800" : "border-neutral-200 text-neutral-600 hover:bg-neutral-50"}`}

--- a/src/lib/access/capabilities.ts
+++ b/src/lib/access/capabilities.ts
@@ -42,6 +42,11 @@ export const CAPABILITIES = [
     label: "Edit fee amounts",
     description: "Record fees received and manage fee payment records.",
   },
+  {
+    key: "dailyMetrics.editOthers",
+    label: "Log calls for other agents",
+    description: "Edit any agent's daily call log, not just their own — includes bulk CSV import.",
+  },
 ] as const;
 
 export type CapabilityKey = (typeof CAPABILITIES)[number]["key"];
@@ -56,14 +61,16 @@ const ALL: CapabilityKey[] = CAPABILITY_KEYS;
 // Role → default capabilities.
 //
 // - admin / system_admin: everything.
-// - lead: full update incl. finalize + PII, but NOT create or delete.
+// - lead: full update incl. finalize + PII + logging calls for others, but
+//   NOT create, delete, or editing fee amounts received.
 // - member: day-to-day collections — update (record payments, status, notes)
-//   only. No create/delete, no finalize (close/overpaid/approvedBy), no PII.
-//   Admins can widen any of these per-user via the access overrides modal.
+//   only, and only their own daily call log. No create/delete, no finalize
+//   (close/overpaid/approvedBy), no PII. Admins can widen any of these
+//   per-user via the access overrides modal.
 export const ROLE_CAPABILITY_DEFAULTS: Record<Role, CapabilityKey[]> = {
   system_admin: ALL,
   admin: ALL,
-  lead: ["case.update", "case.finalize", "case.editPii"],
+  lead: ["case.update", "case.finalize", "case.editPii", "dailyMetrics.editOthers"],
   member: ["case.update"],
 };
 

--- a/src/lib/auth-helpers.ts
+++ b/src/lib/auth-helpers.ts
@@ -37,17 +37,19 @@ export type CapabilityGuard =
   | { ok: false; error: "Unauthenticated" | "Forbidden" };
 
 /**
- * Server-side guard for a capability (e.g. "case.create"). Reads the effective
- * capability set baked into the session at sign-in. Tokens minted before
- * capabilities existed have no `capabilities` array — for those we fall back to
- * the role defaults so existing sessions behave correctly until next login.
+ * True iff an already-fetched session has the given capability. Reads the
+ * effective capability set baked into the session at sign-in. Tokens minted
+ * before capabilities existed have no `capabilities` array — for those we
+ * fall back to the role defaults so existing sessions behave correctly until
+ * next login. Use this (over requireCapability) when a route needs the
+ * session regardless of the capability check's outcome — e.g. a "self or
+ * this capability" rule where acting on your own resource is always allowed.
  */
-export async function requireCapability(
+export const sessionHasCapability = (
+  session: Session | null | undefined,
   capability: CapabilityKey,
-): Promise<CapabilityGuard> {
-  const session = await auth();
-  if (!session?.user) return { ok: false, error: "Unauthenticated" };
-
+): boolean => {
+  if (!session?.user) return false;
   const role = session.user.role;
   const rawCaps = session.user.capabilities;
   const isAdmin = role === "admin" || role === "system_admin";
@@ -56,7 +58,20 @@ export async function requireCapability(
     : rawCaps && rawCaps.length > 0
       ? rawCaps
       : roleCapabilityDefaults(role);
-  if (!hasCapability(caps, capability)) {
+  return hasCapability(caps, capability);
+};
+
+/**
+ * Server-side guard for a capability (e.g. "case.create"). Rejects outright
+ * when the session lacks it — use sessionHasCapability directly for routes
+ * that need the session even when the capability check fails.
+ */
+export async function requireCapability(
+  capability: CapabilityKey,
+): Promise<CapabilityGuard> {
+  const session = await auth();
+  if (!session?.user) return { ok: false, error: "Unauthenticated" };
+  if (!sessionHasCapability(session, capability)) {
     return { ok: false, error: "Forbidden" };
   }
   return { ok: true, session };


### PR DESCRIPTION
## Summary
- The Reports Daily Call Log UI already disabled other agents' rows for members, but that was UX only — `POST /api/daily-metrics` and the Scoreboard CSV bulk-import action had no server-side check, so any authenticated user could write or overwrite another agent's call counts directly.
- Members can now only write rows matching their own session name (leads/admins unaffected, can still write for anyone). Batch saves from the panel silently drop cross-agent entries rather than rejecting the whole save, since the panel always bundles the full team's visible data.
- Bulk CSV import of daily metrics is restricted to lead/admin — a supervisory, multi-agent action, not a self-service one — and the Import button is now hidden from members.
- Also added a basic auth check to GET (was fully unauthenticated before, though the edge middleware already redirected anonymous requests to `/login`).