### PR TITLE
fix: sync Pending amount in the UI after Fee Due/Received edits

### DIFF
--- a/src/app/api/cases/[id]/route.ts
+++ b/src/app/api/cases/[id]/route.ts
@@ -356,6 +356,10 @@ export const PATCH = async (
     // Mutable — the Overpaid auto-flag below appends to whatever the client
     // sent so the activity log names the side effect, not just the edit.
     let logMessage = clientLogMessage;
+    // Populated by the Pending auto-calc below and returned to the client so
+    // optimistic UI updates (which only know the field they explicitly sent)
+    // can pick up the server-computed sibling value without a refetch.
+    const computedFields: Record<string, number> = {};
 
     // Authorize: any update needs case.update. Finalizing fields (close/reopen,
     // mark overpaid, approvedBy) additionally need case.finalize, and editing
@@ -520,9 +524,24 @@ export const PATCH = async (
       }
 
       if (updates.length > 0) {
-        await db.execute(
-          sql`UPDATE fee_records SET ${sql.raw(updates.join(", "))}, updated_at = NOW() WHERE case_id = ${caseId}`,
-        );
+        // t16/t2/aux_pending are auto-recomputed as Due − Received (floored
+        // at 0) by the trg_fee_records_compute_totals DB trigger on every
+        // write — it always wins, an explicit Pending in `updates` above is
+        // silently overwritten. RETURNING reads its result back so
+        // optimistic client updates (which only know the field they
+        // explicitly sent) can sync without a refetch.
+        const [updated] = (await db.execute(sql`
+          UPDATE fee_records SET ${sql.raw(updates.join(", "))}, updated_at = NOW()
+          WHERE case_id = ${caseId}
+          RETURNING t16_pending, t2_pending, aux_pending
+        `)) as unknown as [
+          { t16_pending: string; t2_pending: string; aux_pending: string } | undefined,
+        ];
+        if (updated) {
+          computedFields.t16Pending = Number(updated.t16_pending);
+          computedFields.t2Pending = Number(updated.t2_pending);
+          computedFields.auxPending = Number(updated.aux_pending);
+        }
       }
     }
 
@@ -568,7 +587,7 @@ export const PATCH = async (
       });
     }
 
-    return NextResponse.json({ status: "ok", updated: caseId });
+    return NextResponse.json({ status: "ok", updated: caseId, computed: computedFields });
   } catch (error) {
     console.error("PATCH /api/cases/[id] error:", error);
     return NextResponse.json(

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -737,9 +737,14 @@ export const FeeRecordsTable = ({
         const j = await res.json().catch(() => ({}));
         throw new Error((j as { error?: string }).error ?? `Save failed (${res.status})`);
       }
+      const j = await res.json().catch(() => ({}));
+      // The server also auto-recalculates the sibling Pending amount when
+      // Fee Due/Received changes — merge it in so the row reflects it
+      // immediately instead of waiting for the next full refetch.
+      const computed = (j as { computed?: Record<string, number> }).computed ?? {};
       setFeeOverrides((prev) => ({
         ...prev,
-        [caseId]: { ...prev[caseId], [field]: amount },
+        [caseId]: { ...prev[caseId], [field]: amount, ...computed },
       }));
       setFeeAmountEdit(null);
     } catch (err) {


### PR DESCRIPTION
## Summary
- Pending has always been auto-recalculated as Due minus Received by an existing DB trigger (`trg_fee_records_compute_totals`) on every write — the automation itself was never broken.
- The bug was purely client-side: the inline Master Fees table editor only optimistically applied the one field the user edited, so Pending stayed visually stale until a full refetch. The team had been manually retyping Pending to force it to look right.
- `PATCH /api/cases/[id]` now reads the trigger's authoritative Pending values back via `RETURNING` and includes them in the response; the table merges them into the row immediately.
- Verified live: editing Fee Due now updates the Pending cell on-screen instantly, no reload needed.

Also fixed as a data-only correction (no code change): a test case ("Vidal, Rachel") was stuck flagged as overpaid from earlier testing — cleared directly in the database.