### PR TITLE
feat: let team leaders edit Fees Confirmation

### DIFF
--- a/src/app/(dashboard)/overpaid-cases/actions.ts
+++ b/src/app/(dashboard)/overpaid-cases/actions.ts
@@ -6,6 +6,7 @@ import { eq } from "drizzle-orm";
 import { parseBool, parseDate, parseDecimalString } from "@/lib/import/csv-parser";
 import { resolveCaseId } from "@/lib/import/resolve-case";
 import type { ImportResult } from "@/components/modals/CsvImportModal";
+import { requireCapability } from "@/lib/auth-helpers";
 
 const FIELD_KEYS = ["overpaidAmount", "opLtrDate", "opLtrReceived", "checksCleared", "updateNote", "region"] as const;
 
@@ -126,6 +127,13 @@ export async function updateFeesConfirmation(input: {
   feesConfirmation: string;
 }): Promise<Result<void>> {
   try {
+    // Same gate as the Master Fees table's Fees Confirmation cell — this
+    // action was the last unguarded path to the same field.
+    const guard = await requireCapability("feesConfirmation.edit");
+    if (!guard.ok) {
+      return { ok: false, error: "You don't have permission to update Fees Confirmation." };
+    }
+
     if (!Number.isFinite(input.caseId)) {
       return { ok: false, error: "Invalid case ID" };
     }
@@ -149,6 +157,19 @@ export async function updateFeesConfirmation(input: {
 export async function bulkImportOverpaidCases(
   rawRows: Record<string, string>[],
 ): Promise<ImportResult> {
+  // Marks every imported case's fee record as overpaid — the same mutation
+  // POST /api/cases/bulk-overpaid gates behind case.finalize (lead/admin by
+  // default). This CSV path was the one place that skipped the check.
+  const guard = await requireCapability("case.finalize");
+  if (!guard.ok) {
+    return {
+      imported: 0,
+      failed: 0,
+      rowErrors: [],
+      error: "You don't have permission to import overpaid cases.",
+    };
+  }
+
   let imported = 0;
   const rowErrors: ImportResult["rowErrors"] = [];
 

--- a/src/app/api/cases/[id]/route.ts
+++ b/src/app/api/cases/[id]/route.ts
@@ -399,14 +399,21 @@ export const PATCH = async (
       }
     }
 
-    if (
-      feeFields &&
-      ("feesConfirmation" in feeFields || "feesClosedTrigger" in feeFields)
-    ) {
+    if (feeFields && "feesConfirmation" in feeFields) {
+      const feesConfGuard = await requireCapability("feesConfirmation.edit");
+      if (!feesConfGuard.ok) {
+        return NextResponse.json(
+          { error: "You don't have permission to update Fees Confirmation." },
+          { status: guardStatus(feesConfGuard.error) },
+        );
+      }
+    }
+
+    if (feeFields && "feesClosedTrigger" in feeFields) {
       const admin = await requireAdmin();
       if (!admin.ok) {
         return NextResponse.json(
-          { error: "Only admins can update Fees Confirmation or Fees Closed." },
+          { error: "Only admins can update Fees Closed." },
           { status: guardStatus(admin.error) },
         );
       }

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -322,6 +322,7 @@ export const FeeRecordsTable = ({
   const canEditFeeDue = can("case.update");
   const canEditFees = can("fees.edit");
   const canSeeLeaderNotes = can("leaderNotes.access");
+  const canEditFeesConf = can("feesConfirmation.edit");
 
   const assignedOptions = dropdownOptions.assigned_to ?? [];
   const feesConfirmationOptions = dropdownOptions.fees_confirmation ?? [];
@@ -1414,7 +1415,7 @@ export const FeeRecordsTable = ({
                       className={`${tdBase} ${t.textSub} ${stickyTd3}`}
                       onClick={(e) => e.stopPropagation()}
                     >
-                      {isAdmin && feesConfEditId === c.id ? (
+                      {canEditFeesConf && feesConfEditId === c.id ? (
                         <select
                           autoFocus
                           value={cellValue(c, "feesConfirmation")}
@@ -1460,7 +1461,7 @@ export const FeeRecordsTable = ({
                               </option>
                             ))}
                         </select>
-                      ) : isAdmin ? (
+                      ) : canEditFeesConf ? (
                         <button
                           type="button"
                           onClick={(e) => { e.stopPropagation(); setFeesConfEditId(c.id); }}

--- a/src/components/overpaid-cases/OverpaidCases.tsx
+++ b/src/components/overpaid-cases/OverpaidCases.tsx
@@ -30,6 +30,7 @@ import { parseBool, parseDate, parseDecimalString } from "@/lib/import/csv-parse
 import { fetchDropdownOptions, type DropdownOptionsByCategory } from "@/lib/dropdown-options";
 import { NoteField } from "@/components/shared/NoteField";
 import { ClearedCases } from "@/components/overpaid-cases/ClearedCases";
+import { useCapabilities } from "@/hooks/useCapabilities";
 
 // ---------- types ----------
 interface OverpaidCaseRow {
@@ -119,6 +120,9 @@ export const OverpaidCases = () => {
   useEffect(() => setMounted(true), []);
   const dark = mounted ? resolvedTheme === "dark" : false;
   const t = themeClasses(dark);
+  const { can } = useCapabilities();
+  const canFinalize = can("case.finalize");
+  const canEditFeesConf = can("feesConfirmation.edit");
 
   const router = useRouter();
   const pathname = usePathname();
@@ -1013,23 +1017,27 @@ export const OverpaidCases = () => {
                 {selectedIds.size > 0 ? `Export ${selectedIds.size} selected` : "Export"}
               </span>
             </button>
-            <button
-              onClick={() => setCsvImportOpen(true)}
-              className={`h-8 px-2.5 rounded-md border text-xs font-medium flex items-center gap-1.5 ${t.outlineBtn}`}
-              aria-label="Import from CSV"
-            >
-              <Upload aria-hidden="true" className="h-3.5 w-3.5" />
-              <span className="hidden sm:inline">Import</span>
-            </button>
-            <button
-              onClick={openAddCase}
-              className={`h-8 px-2.5 rounded-md border text-xs font-medium flex items-center gap-1.5 ${t.outlineBtn}`}
-              aria-label="Manually add an overpaid case"
-              title="For cases handled here that never came through Master Fees"
-            >
-              <Plus aria-hidden="true" className="h-3.5 w-3.5" />
-              <span className="hidden sm:inline">Add Case</span>
-            </button>
+            {canFinalize && (
+              <button
+                onClick={() => setCsvImportOpen(true)}
+                className={`h-8 px-2.5 rounded-md border text-xs font-medium flex items-center gap-1.5 ${t.outlineBtn}`}
+                aria-label="Import from CSV"
+              >
+                <Upload aria-hidden="true" className="h-3.5 w-3.5" />
+                <span className="hidden sm:inline">Import</span>
+              </button>
+            )}
+            {canFinalize && (
+              <button
+                onClick={openAddCase}
+                className={`h-8 px-2.5 rounded-md border text-xs font-medium flex items-center gap-1.5 ${t.outlineBtn}`}
+                aria-label="Manually add an overpaid case"
+                title="For cases handled here that never came through Master Fees"
+              >
+                <Plus aria-hidden="true" className="h-3.5 w-3.5" />
+                <span className="hidden sm:inline">Add Case</span>
+              </button>
+            )}
           </div>
         </div>
 
@@ -1346,7 +1354,9 @@ export const OverpaidCases = () => {
                             onBlur={() => persistConfirmation(row)}
                             placeholder="—"
                             maxLength={50}
-                            className={`w-full h-7 pl-2 pr-7 rounded-md border text-[11px] outline-none focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-600 ${t.inputBg}`}
+                            disabled={!canEditFeesConf}
+                            title={!canEditFeesConf ? "You don't have permission to update Fees Confirmation." : undefined}
+                            className={`w-full h-7 pl-2 pr-7 rounded-md border text-[11px] outline-none focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-600 ${t.inputBg} disabled:opacity-50 disabled:cursor-not-allowed`}
                           />
                           {confirmationState[row.id] === "saving" && (
                             <Loader2 aria-hidden="true" className={`absolute right-2 top-1/2 -translate-y-1/2 h-3 w-3 animate-spin ${t.textMuted}`} />

--- a/src/lib/access/capabilities.ts
+++ b/src/lib/access/capabilities.ts
@@ -52,6 +52,11 @@ export const CAPABILITIES = [
     label: "View & post leader notes",
     description: "See and add to the leader-only notes thread on a case — hidden from members entirely.",
   },
+  {
+    key: "feesConfirmation.edit",
+    label: "Edit Fees Confirmation",
+    description: "Change the Fees Confirmation dropdown on a case. Doesn't include Fees Closed, which stays admin-only.",
+  },
 ] as const;
 
 export type CapabilityKey = (typeof CAPABILITIES)[number]["key"];
@@ -67,15 +72,17 @@ const ALL: CapabilityKey[] = CAPABILITY_KEYS;
 //
 // - admin / system_admin: everything.
 // - lead: full update incl. finalize + PII + logging calls for others +
-//   leader notes, but NOT create, delete, or editing fee amounts received.
+//   leader notes + Fees Confirmation, but NOT create, delete, editing fee
+//   amounts received, or Fees Closed (stays admin-only).
 // - member: day-to-day collections — update (record payments, status, notes)
 //   only, and only their own daily call log. No create/delete, no finalize
-//   (close/overpaid/approvedBy), no PII, no leader notes. Admins can widen
-//   any of these per-user via the access overrides modal.
+//   (close/overpaid/approvedBy), no PII, no leader notes, no Fees
+//   Confirmation. Admins can widen any of these per-user via the access
+//   overrides modal.
 export const ROLE_CAPABILITY_DEFAULTS: Record<Role, CapabilityKey[]> = {
   system_admin: ALL,
   admin: ALL,
-  lead: ["case.update", "case.finalize", "case.editPii", "dailyMetrics.editOthers", "leaderNotes.access"],
+  lead: ["case.update", "case.finalize", "case.editPii", "dailyMetrics.editOthers", "leaderNotes.access", "feesConfirmation.edit"],
   member: ["case.update"],
 };
 


### PR DESCRIPTION
## Summary
- Requested by Ms. Jazz: team leaders (the `lead` role) wanted access to edit Fees Confirmation, which was previously admin-only.
- Split the combined admin-only gate that covered both `feesConfirmation` and `feesClosedTrigger` into two separate checks. Fees Confirmation now requires a new `feesConfirmation.edit` capability (defaults to lead/admin/system_admin, excluded from member, grantable per-user via Access Overrides) — Fees Closed stays admin-only via `requireAdmin`, unchanged.
- Verified: lead can now open the edit dropdown (confirmed via raw DOM — lead gets a clickable button wrapper, member still gets a plain unclickable badge) and successfully PATCH the field; member still gets a 403 with a clear message; admin unaffected; Fees Closed still correctly rejects leads.