### PR TITLE
fix: stop Approval Date from appearing to change on its own

### DIFF
--- a/src/app/api/mycase/sync/route.ts
+++ b/src/app/api/mycase/sync/route.ts
@@ -370,7 +370,11 @@ export const POST = async (req: NextRequest) => {
               case_link          = v.case_link,
               first_name         = v.first_name,
               last_name          = v.last_name,
-              approval_date      = v.approval_date::date,
+              -- Once set, a sync never overwrites approval_date — it's editable
+              -- in the dashboard and shouldn't get silently clobbered by
+              -- whatever MyCase currently reports (matches how
+              -- fees_confirmation/approved_by are protected below).
+              approval_date      = COALESCE(cases.approval_date, v.approval_date::date),
               level_won          = v.level_won,
               claim_type         = v.claim_type::text[],
               claim_type_label   = v.claim_type_label,

--- a/src/app/api/sheets/sync/route.ts
+++ b/src/app/api/sheets/sync/route.ts
@@ -553,7 +553,9 @@ export const POST = async (req: NextRequest) => {
               case_link          = v.case_link,
               first_name         = v.first_name,
               last_name          = v.last_name,
-              approval_date      = v.approval_date::date,
+              -- Once set, a sync never overwrites approval_date — see the
+              -- matching comment in the MyCase sync route.
+              approval_date      = COALESCE(cases.approval_date, v.approval_date::date),
               level_won          = v.level_won,
               claim_type         = v.claim_type::text[],
               claim_type_label   = v.claim_type_label,

--- a/src/components/cases/CaseDetailSheet.tsx
+++ b/src/components/cases/CaseDetailSheet.tsx
@@ -672,7 +672,7 @@ export default function CaseDetailSheet({
                     />
                   ) : (
                     <p className={`${val} flex items-center gap-1`}>
-                      <CalendarDays aria-hidden="true" className="h-3 w-3 text-indigo-500" /> {dateStr(myCaseData?.approvalDate ?? data.approvalDate)}
+                      <CalendarDays aria-hidden="true" className="h-3 w-3 text-indigo-500" /> {dateStr(data.approvalDate)}
                     </p>
                   )}
                 </div>


### PR DESCRIPTION
## Summary
- Ms. Jazz reported Approval Date changing on some cases and asked if we fetch it directly from MyCase. Investigated every write path — no automatic/scheduled sync exists anywhere (both MyCase and Sheets sync are manual button clicks).
- Found the actual bug: `CaseDetailSheet.tsx`'s "Identity & Verification" panel displayed MyCase's *live* Approval Date instead of the saved app value (`myCaseData?.approvalDate ?? data.approvalDate`), even though a separate, clearly-labeled "Live from MyCase" section already exists for that exact comparison further down. Opening a case could show a different date than what's actually saved, with zero syncing involved, whenever MyCase's own value changed. Fixed to show the saved value only.
- Also found and fixed a real gap: MyCase sync and Sheets sync both unconditionally overwrote `cases.approval_date` on every run, unlike sibling fields in the same queries (`fees_confirmation`, `date_assigned_to_agent`) which are already protected against clobbering. Added the same `COALESCE`-based protection — once set, a sync no longer touches it.
- Verified: the display fix live in the browser (shows the saved DB value, matches Master Fees), and the sync protection directly against the database (an already-set date survives a simulated conflicting sync; a null date still gets populated on first sync) — using a rolled-back transaction so no data was actually changed.