### PR TITLE
fix: correct Master Fees group header colspans

### DIFF
--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -1093,7 +1093,7 @@ export const FeeRecordsTable = ({
                   className={`${thBase} ${t.textSub} text-left ${stickyGroup3}`}
                 />
                 <th
-                  colSpan={6}
+                  colSpan={canSeeLeaderNotes ? 7 : 6}
                   aria-hidden="true"
                   className={`${thBase} ${t.textSub} text-left ${stickyThRow1}`}
                 />
@@ -1123,7 +1123,7 @@ export const FeeRecordsTable = ({
                   Totals
                 </th>
                 <th
-                  colSpan={isClosedMode ? 5 : 6}
+                  colSpan={isClosedMode ? 4 : 5}
                   className={`${thBase} text-center ${groupBorder} ${stickyThRow1} ${t.textSub}`}
                 >
                   Workflow


### PR DESCRIPTION
## Summary
- The "Workflow" group header's `colSpan` still counted the PIF column removed in #160, throwing it (and any header rendered after it) out of alignment with its leaf columns.
- The "Case Info" group's blank spacer never accounted for the conditional "Leader Notes" column, so for any role with leader-notes access every group header from that point on was off by one.

## Test plan
- [x] `npx tsc --noEmit`, `npm run lint`, `npm test` (62 passing), `npm run build`
- [x] Verified live: summed each group row's colspans against the corresponding leaf row's actual column count (accounting for the rowspan checkbox), and confirmed `getBoundingClientRect().left` matches exactly between each group header and its first leaf column (Totals ↔ Retro Due, Workflow ↔ Approved By)