### PR TITLE
feat: make Fee Requested/Fees Received editable in Fee Petitions

### DIFF
--- a/src/app/api/fee-petitions/route.ts
+++ b/src/app/api/fee-petitions/route.ts
@@ -6,6 +6,31 @@ import { eq, ilike, sql } from "drizzle-orm";
 const SORT_KEYS = ["claimant", "approvalDate", "updatedAt", "progress"] as const;
 type SortKey = (typeof SORT_KEYS)[number];
 
+// Fee Requested/Received are sums across t16/t2/aux fee_records columns, but
+// the Fee Petitions table edits them as a single inline value — resolve to
+// whichever one benefit type the case is actually using. Cases labeled
+// "concurrent" almost always still have only one type with real numbers
+// (T16 and T2 are rarely both filled in at once); prefer whichever type
+// already has data, and only fall back to the registered claim label when
+// nothing has been entered yet.
+const resolveActiveFeeType = (
+  claimTypeLabel: string | null,
+  t16Retro: number,
+  t2Retro: number,
+  auxRetro: number,
+): "t16" | "t2" | "aux" => {
+  if (t16Retro > 0 && t2Retro <= 0 && auxRetro <= 0) return "t16";
+  if (t2Retro > 0 && t16Retro <= 0 && auxRetro <= 0) return "t2";
+  if (auxRetro > 0 && t16Retro <= 0 && t2Retro <= 0) return "aux";
+  // More than one type has data (rare) — T16 is the primary edit target.
+  if (t16Retro > 0) return "t16";
+  if (t2Retro > 0) return "t2";
+  if (auxRetro > 0) return "aux";
+  // Nothing entered yet — default from the case's registered claim type.
+  if (claimTypeLabel === "T2") return "t2";
+  return "t16";
+};
+
 const getMissingClause = (key: string | null) => {
   switch (key) {
     case "noa": return sql`AND COALESCE(${feePetitions.noa}, false) = false`;
@@ -139,8 +164,12 @@ export const GET = async (req: NextRequest) => {
         firstName: cases.firstName,
         lastName: cases.lastName,
         approvalDate: cases.approvalDate,
+        claimTypeLabel: cases.claimTypeLabel,
         totalFeesExpected: feeRecords.totalFeesExpected,
         totalFeesPaid: feeRecords.totalFeesPaid,
+        t16Retro: feeRecords.t16Retro,
+        t2Retro: feeRecords.t2Retro,
+        auxRetro: feeRecords.auxRetro,
         noa: feePetitions.noa,
         timeDelineation: feePetitions.timeDelineation,
         feePetitionDoc: feePetitions.feePetitionDoc,
@@ -166,6 +195,12 @@ export const GET = async (req: NextRequest) => {
       updatedAt: r.updatedAt ? r.updatedAt.toISOString().slice(0, 10) : null,
       feeAmount: r.totalFeesExpected != null ? Number(r.totalFeesExpected) : null,
       feesReceived: r.totalFeesPaid != null ? Number(r.totalFeesPaid) : null,
+      activeFeeType: resolveActiveFeeType(
+        r.claimTypeLabel,
+        Number(r.t16Retro) || 0,
+        Number(r.t2Retro) || 0,
+        Number(r.auxRetro) || 0,
+      ),
       noa: r.noa ?? false,
       timeDelineation: r.timeDelineation ?? false,
       feePetitionDoc: r.feePetitionDoc ?? false,

--- a/src/components/cases/FeeAmountCell.tsx
+++ b/src/components/cases/FeeAmountCell.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { Check, Loader2, Pencil, X } from "lucide-react";
+import { fmtFull } from "@/lib/formatters";
+
+const currency = (v: number) => (v > 0 ? fmtFull(v) : "—");
+
+export interface FeeAmountCellProps {
+  active: boolean;
+  value: number;
+  draft: string;
+  saving: boolean;
+  error: string | null;
+  canEdit: boolean;
+  saveLabel: string;
+  inputBg: string;
+  hoverCls: string;
+  textMuted: string;
+  onEdit: () => void;
+  onDraftChange: (v: string) => void;
+  onSave: () => void;
+  onCancel: () => void;
+  // Class applied to the pencil button's hover-reveal wrapper — defaults to
+  // an unnamed `group`/`group-hover`. Pass e.g. "opacity-0 group-hover/row:opacity-100"
+  // when the ancestor row uses a named group (Tailwind's group/<name> syntax).
+  pencilRevealClass?: string;
+}
+
+export function FeeAmountCell({
+  active, value, draft, saving, error, canEdit,
+  saveLabel, inputBg, hoverCls, textMuted,
+  onEdit, onDraftChange, onSave, onCancel,
+  pencilRevealClass = "opacity-0 group-hover:opacity-100",
+}: FeeAmountCellProps) {
+  if (active) {
+    return (
+      <div className="flex flex-col items-end gap-1 min-w-[110px]">
+        <div className="flex items-center gap-0.5">
+          <input
+            type="number" min="0" step="0.01" value={draft} autoFocus
+            onChange={(e) => onDraftChange(e.target.value)}
+            onKeyDown={(e) => { if (e.key === "Enter") onSave(); if (e.key === "Escape") onCancel(); }}
+            className={`h-6 px-1.5 rounded border text-[11px] outline-none w-24 text-right ${inputBg}`}
+          />
+          {saving ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin ml-0.5" aria-hidden="true" />
+          ) : (
+            <>
+              <button type="button" onClick={onSave} className="p-0.5 rounded text-emerald-500 hover:bg-emerald-500/10 transition-colors" aria-label={`Save ${saveLabel}`}>
+                <Check className="h-3 w-3" aria-hidden="true" />
+              </button>
+              <button type="button" onClick={onCancel} className={`p-0.5 rounded transition-colors ${hoverCls}`} aria-label="Cancel">
+                <X className="h-3 w-3" aria-hidden="true" />
+              </button>
+            </>
+          )}
+        </div>
+        {error && <p role="alert" className="text-[10px] text-red-500">{error}</p>}
+      </div>
+    );
+  }
+  return (
+    <div className="flex items-center justify-end gap-1">
+      <span>{currency(value)}</span>
+      {canEdit && (
+        <button type="button" onClick={onEdit} className={`${pencilRevealClass} transition-colors p-0.5 rounded ${hoverCls}`} aria-label={`Edit ${saveLabel}`}>
+          <Pencil className={`h-3 w-3 ${textMuted}`} aria-hidden="true" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -21,6 +21,7 @@ import {
 
 import { themeClasses } from "@/lib/theme-classes";
 import { FeePaymentPanel } from "@/components/cases/FeePaymentPanel";
+import { FeeAmountCell } from "@/components/cases/FeeAmountCell";
 import {
   fmtFull,
   fmtDate,
@@ -136,66 +137,6 @@ function CaseStatusBadge({ value, dark }: { value: string | null | undefined; da
   );
 }
 
-interface FeeAmountCellProps {
-  active: boolean;
-  value: number;
-  draft: string;
-  saving: boolean;
-  error: string | null;
-  canEdit: boolean;
-  saveLabel: string;
-  inputBg: string;
-  hoverCls: string;
-  textMuted: string;
-  onEdit: () => void;
-  onDraftChange: (v: string) => void;
-  onSave: () => void;
-  onCancel: () => void;
-}
-
-function FeeAmountCell({
-  active, value, draft, saving, error, canEdit,
-  saveLabel, inputBg, hoverCls, textMuted,
-  onEdit, onDraftChange, onSave, onCancel,
-}: FeeAmountCellProps) {
-  if (active) {
-    return (
-      <div className="flex flex-col items-end gap-1 min-w-[110px]">
-        <div className="flex items-center gap-0.5">
-          <input
-            type="number" min="0" step="0.01" value={draft} autoFocus
-            onChange={(e) => onDraftChange(e.target.value)}
-            onKeyDown={(e) => { if (e.key === "Enter") onSave(); if (e.key === "Escape") onCancel(); }}
-            className={`h-6 px-1.5 rounded border text-[11px] outline-none w-24 text-right ${inputBg}`}
-          />
-          {saving ? (
-            <Loader2 className="h-3.5 w-3.5 animate-spin ml-0.5" aria-hidden="true" />
-          ) : (
-            <>
-              <button type="button" onClick={onSave} className="p-0.5 rounded text-emerald-500 hover:bg-emerald-500/10 transition-colors" aria-label={`Save ${saveLabel}`}>
-                <Check className="h-3 w-3" aria-hidden="true" />
-              </button>
-              <button type="button" onClick={onCancel} className={`p-0.5 rounded transition-colors ${hoverCls}`} aria-label="Cancel">
-                <X className="h-3 w-3" aria-hidden="true" />
-              </button>
-            </>
-          )}
-        </div>
-        {error && <p role="alert" className="text-[10px] text-red-500">{error}</p>}
-      </div>
-    );
-  }
-  return (
-    <div className="flex items-center justify-end gap-1">
-      <span>{currency(value)}</span>
-      {canEdit && (
-        <button type="button" onClick={onEdit} className={`opacity-0 group-hover:opacity-100 transition-colors p-0.5 rounded ${hoverCls}`} aria-label={`Edit ${saveLabel}`}>
-          <Pencil className={`h-3 w-3 ${textMuted}`} aria-hidden="true" />
-        </button>
-      )}
-    </div>
-  );
-}
 
 interface FeeRecordsTableProps {
   cases: CaseRow[];

--- a/src/components/fee-petitions/FeePetitions.tsx
+++ b/src/components/fee-petitions/FeePetitions.tsx
@@ -27,6 +27,8 @@ import { CompletedPetitions } from "./CompletedPetitions";
 import CsvImportModal, { type ColumnDef } from "@/components/modals/CsvImportModal";
 import { parseBool } from "@/lib/import/csv-parser";
 import { NoteField } from "@/components/shared/NoteField";
+import { FeeAmountCell } from "@/components/cases/FeeAmountCell";
+import { useCapabilities } from "@/hooks/useCapabilities";
 
 // ---------- types ----------
 interface FeePetitionRow {
@@ -36,6 +38,10 @@ interface FeePetitionRow {
   updatedAt: string | null;
   feeAmount: number | null;
   feesReceived: number | null;
+  // Which fee_records benefit type Fee Requested/Fees Received edit —
+  // resolved server-side to whichever type actually has data (falling back
+  // to the case's registered claim type when nothing's entered yet).
+  activeFeeType: "t16" | "t2" | "aux";
   noa: boolean;
   timeDelineation: boolean;
   feePetitionDoc: boolean;
@@ -145,6 +151,8 @@ export const FeePetitions = () => {
   useEffect(() => setMounted(true), []);
   const dark = mounted ? resolvedTheme === "dark" : false;
   const t = themeClasses(dark);
+  const { can } = useCapabilities();
+  const canEditFees = can("case.update");
 
   const router = useRouter();
   const pathname = usePathname();
@@ -390,6 +398,70 @@ export const FeePetitions = () => {
     fetchPetitions();
     return () => { fetchAbortRef.current?.abort(); };
   }, [fetchPetitions]);
+
+  // Fee Requested/Fees Received have no single editable column of their own
+  // (they're sums of t16/t2/aux Fee Due and Fee Received) — each cell edits
+  // row.activeFeeType's column directly (resolved server-side to whichever
+  // benefit type the case is actually using).
+  type FeeAmountField = "feeAmount" | "feesReceived";
+  const [feeAmountEdit, setFeeAmountEdit] = useState<{
+    rowId: number;
+    field: FeeAmountField;
+    draft: string;
+  } | null>(null);
+  const [feeAmountSaving, setFeeAmountSaving] = useState(false);
+  const [feeAmountError, setFeeAmountError] = useState<string | null>(null);
+  const [feeAmountOverrides, setFeeAmountOverrides] = useState<
+    Record<number, Partial<Pick<FeePetitionRow, "feeAmount" | "feesReceived">>>
+  >({});
+  const feeAmountAbortRef = useRef<AbortController | null>(null);
+
+  const saveFeeAmount = useCallback(async () => {
+    if (!feeAmountEdit || feeAmountSaving) return;
+    const amount = parseFloat(feeAmountEdit.draft);
+    if (isNaN(amount) || amount < 0) {
+      setFeeAmountError("Enter a valid amount (0 or more).");
+      return;
+    }
+    const row = rows.find((r) => r.id === feeAmountEdit.rowId);
+    if (!row) return;
+    const dbField = feeAmountEdit.field === "feeAmount" ? "FeeDue" : "FeeReceived";
+    const patchField = `${row.activeFeeType}${dbField}`;
+    const typeLabel = row.activeFeeType === "t16" ? "T16" : row.activeFeeType === "t2" ? "T2" : "AUX";
+    const label = `${typeLabel} ${feeAmountEdit.field === "feeAmount" ? "Fee Due" : "Received"}`;
+
+    feeAmountAbortRef.current?.abort();
+    const controller = new AbortController();
+    feeAmountAbortRef.current = controller;
+    setFeeAmountSaving(true);
+    setFeeAmountError(null);
+    try {
+      const res = await fetch(`/api/cases/${row.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          feeFields: { [patchField]: amount },
+          logMessage: `${label} updated to ${fmt(amount)}`,
+        }),
+        signal: controller.signal,
+      });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        throw new Error((j as { error?: string }).error ?? `Save failed (${res.status})`);
+      }
+      setFeeAmountOverrides((prev) => ({
+        ...prev,
+        [row.id]: { ...prev[row.id], [feeAmountEdit.field]: amount },
+      }));
+      setFeeAmountEdit(null);
+      fetchAllTotals();
+    } catch (err) {
+      if ((err as Error).name === "AbortError") return;
+      setFeeAmountError((err as Error).message);
+    } finally {
+      if (!controller.signal.aborted) setFeeAmountSaving(false);
+    }
+  }, [feeAmountEdit, feeAmountSaving, fetchAllTotals, rows]);
 
   // Update select-all indeterminate state
   useEffect(() => {
@@ -1065,7 +1137,8 @@ export const FeePetitions = () => {
                   </td>
                 </tr>
               ) : (
-                rows.map((row) => {
+                rows.map((rawRow) => {
+                  const row = { ...rawRow, ...feeAmountOverrides[rawRow.id] };
                   const completedCount = CHECKBOX_COLUMNS.reduce((acc, c) => acc + (row[c.key] ? 1 : 0), 0);
                   const isComplete = completedCount === CHECKBOX_COLUMNS.length;
                   const isSelected = selectedIds.has(row.id);
@@ -1108,11 +1181,47 @@ export const FeePetitions = () => {
                           </p>
                         )}
                       </td>
-                      <td className={`${tdBase} w-24 ${t.text} text-right font-medium tabular-nums sticky left-[200px] z-10 ${stickyBg} ${stickyHover}`}>
-                        {row.feeAmount != null ? fmt(row.feeAmount) : "—"}
+                      <td
+                        className={`${tdBase} w-24 ${t.text} text-right font-medium tabular-nums sticky left-[200px] z-10 ${stickyBg} ${stickyHover}`}
+                      >
+                        <FeeAmountCell
+                          active={canEditFees && feeAmountEdit?.rowId === row.id && feeAmountEdit.field === "feeAmount"}
+                          value={row.feeAmount ?? 0}
+                          draft={feeAmountEdit?.draft ?? ""}
+                          saving={feeAmountSaving}
+                          error={feeAmountError}
+                          canEdit={canEditFees}
+                          saveLabel="Fee Requested"
+                          inputBg={t.inputBg}
+                          hoverCls={t.hover}
+                          textMuted={t.textMuted}
+                          pencilRevealClass="opacity-0 group-hover/row:opacity-100"
+                          onEdit={() => { setFeeAmountEdit({ rowId: row.id, field: "feeAmount", draft: String(row.feeAmount ?? 0) }); setFeeAmountError(null); }}
+                          onDraftChange={(v) => setFeeAmountEdit((p) => p ? { ...p, draft: v } : p)}
+                          onSave={saveFeeAmount}
+                          onCancel={() => { setFeeAmountEdit(null); setFeeAmountError(null); }}
+                        />
                       </td>
-                      <td className={`${tdBase} w-24 text-right font-medium tabular-nums ${row.feesReceived != null && row.feesReceived > 0 ? (dark ? "text-emerald-400" : "text-emerald-600") : t.textMuted}`}>
-                        {row.feesReceived != null && row.feesReceived > 0 ? fmt(row.feesReceived) : "—"}
+                      <td
+                        className={`${tdBase} w-24 text-right font-medium tabular-nums ${row.feesReceived != null && row.feesReceived > 0 ? (dark ? "text-emerald-400" : "text-emerald-600") : t.textMuted}`}
+                      >
+                        <FeeAmountCell
+                          active={canEditFees && feeAmountEdit?.rowId === row.id && feeAmountEdit.field === "feesReceived"}
+                          value={row.feesReceived ?? 0}
+                          draft={feeAmountEdit?.draft ?? ""}
+                          saving={feeAmountSaving}
+                          error={feeAmountError}
+                          canEdit={canEditFees}
+                          saveLabel="Fees Received"
+                          inputBg={t.inputBg}
+                          hoverCls={t.hover}
+                          textMuted={t.textMuted}
+                          pencilRevealClass="opacity-0 group-hover/row:opacity-100"
+                          onEdit={() => { setFeeAmountEdit({ rowId: row.id, field: "feesReceived", draft: String(row.feesReceived ?? 0) }); setFeeAmountError(null); }}
+                          onDraftChange={(v) => setFeeAmountEdit((p) => p ? { ...p, draft: v } : p)}
+                          onSave={saveFeeAmount}
+                          onCancel={() => { setFeeAmountEdit(null); setFeeAmountError(null); }}
+                        />
                       </td>
                       <td className={`${tdBase} ${t.textMuted}`}>
                         <div className="flex items-center gap-1.5">


### PR DESCRIPTION
## Summary
Ms. Jazz reported that Fee Requested / Fees Received weren't editable under Fee Petition cases — this was true (a pre-existing gap, not a regression): both were plain read-only sums of t16/t2/aux Fee Due and Fee Received, with no way to edit them from this page.

- Each cell is now a true inline-editable textbox (pencil on hover, click to edit, matching the existing Master Fees pattern) for every row, including previously-"concurrent" claim-type cases.
- Since "Fee Requested"/"Fees Received" are sums across up to 3 benefit types, each case is resolved server-side to a single "active" benefit type — whichever type currently has real data, falling back to the case's registered claim type (T16/T2) when nothing's entered yet.
- Extracted the click-to-edit cell (`FeeAmountCell`) out of `FeeRecordsTable.tsx` into a shared component so both tables use the same implementation instead of duplicating it.

## Test plan
- [x] `npx tsc --noEmit`, `npm run lint`, `npm test` (62 passing), `npm run build`
- [x] Verified live: pencil-on-hover appears on both zero and non-zero rows, clicking prefills the correct value, editing writes directly to the resolved benefit type's column, no popups open