### PR TITLE
feat: bump text sizes app-wide for readability

### DIFF
--- a/src/app/(dashboard)/archive/ArchivePageClient.tsx
+++ b/src/app/(dashboard)/archive/ArchivePageClient.tsx
@@ -80,13 +80,13 @@ export function ArchivePageClient() {
           </div>
           <div className="flex-1">
             <h3 className={`text-sm font-bold ${t.text}`}>Archive</h3>
-            <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
+            <p className={`text-[13px] ${t.textMuted} mt-0.5`}>
               Cases removed from reconciliation — not found in the Master List or Fees Closed sheet
             </p>
           </div>
           {rows.length > 0 && (
             <span
-              className={`text-[11px] font-semibold px-2 py-0.5 rounded-full ${dark ? "bg-neutral-700 text-neutral-300" : "bg-neutral-100 text-neutral-600"}`}
+              className={`text-[13px] font-semibold px-2 py-0.5 rounded-full ${dark ? "bg-neutral-700 text-neutral-300" : "bg-neutral-100 text-neutral-600"}`}
             >
               {rows.length}
             </span>

--- a/src/app/(dashboard)/fees-closed/page.tsx
+++ b/src/app/(dashboard)/fees-closed/page.tsx
@@ -148,7 +148,7 @@ export default function FeesClosedPage() {
             </div>
             <div>
               <h3 className={`text-sm font-bold ${t.text}`}>Fees Closed</h3>
-              <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
+              <p className={`text-[13px] ${t.textMuted} mt-0.5`}>
                 Cases acknowledged and marked closed from the dashboard
               </p>
             </div>
@@ -159,7 +159,7 @@ export default function FeesClosedPage() {
                 key={f}
                 onClick={() => setLevelFilter(f)}
                 aria-pressed={levelFilter === f}
-                className={`px-3 py-1 rounded-full text-[11px] font-medium border transition-colors ${
+                className={`px-3 py-1 rounded-full text-[13px] font-medium border transition-colors ${
                   levelFilter === f
                     ? dark
                       ? "bg-emerald-700 border-emerald-600 text-white"
@@ -172,26 +172,26 @@ export default function FeesClosedPage() {
                 {f === "all" ? "All" : "Fee Petitions"}
               </button>
             ))}
-            <span className={`text-[11px] ${t.textMuted} ml-1`}>Closed:</span>
+            <span className={`text-[13px] ${t.textMuted} ml-1`}>Closed:</span>
             <input
               type="date"
               value={closedFrom}
               onChange={(e) => setClosedFrom(e.target.value)}
               aria-label="Closed from date"
-              className={`rounded-md border px-2 py-1 text-[11px] ${dark ? "bg-neutral-800 border-neutral-700 text-neutral-200" : "bg-white border-neutral-200 text-neutral-900"}`}
+              className={`rounded-md border px-2 py-1 text-[13px] ${dark ? "bg-neutral-800 border-neutral-700 text-neutral-200" : "bg-white border-neutral-200 text-neutral-900"}`}
             />
-            <span className={`text-[11px] ${t.textMuted}`}>–</span>
+            <span className={`text-[13px] ${t.textMuted}`}>–</span>
             <input
               type="date"
               value={closedTo}
               onChange={(e) => setClosedTo(e.target.value)}
               aria-label="Closed to date"
-              className={`rounded-md border px-2 py-1 text-[11px] ${dark ? "bg-neutral-800 border-neutral-700 text-neutral-200" : "bg-white border-neutral-200 text-neutral-900"}`}
+              className={`rounded-md border px-2 py-1 text-[13px] ${dark ? "bg-neutral-800 border-neutral-700 text-neutral-200" : "bg-white border-neutral-200 text-neutral-900"}`}
             />
             {(closedFrom || closedTo) && (
               <button
                 onClick={() => { setClosedFrom(""); setClosedTo(""); }}
-                className={`text-[11px] ${t.textMuted} hover:text-red-500 transition-colors`}
+                className={`text-[13px] ${t.textMuted} hover:text-red-500 transition-colors`}
                 aria-label="Clear date filter"
               >
                 Clear

--- a/src/app/(dashboard)/master-fees/page.tsx
+++ b/src/app/(dashboard)/master-fees/page.tsx
@@ -88,7 +88,7 @@ export default function MasterFeesPage() {
           c.approvedBy?.toLowerCase().includes(approverFilter),
         );
 
-  const presetBase = `px-3 py-1 rounded-full text-[11px] font-medium border transition-colors`;
+  const presetBase = `px-3 py-1 rounded-full text-[13px] font-medium border transition-colors`;
   const presetActive = dark
     ? "bg-amber-700 border-amber-600 text-white"
     : "bg-amber-100 border-amber-400 text-amber-800";
@@ -99,7 +99,7 @@ export default function MasterFeesPage() {
   return (
     <div className="space-y-3">
       <div className={`rounded-xl border ${t.card} px-4 py-2.5 flex items-center gap-2 flex-wrap`}>
-        <span className={`text-[10px] font-semibold uppercase tracking-wider ${t.textMuted} shrink-0`}>
+        <span className={`text-[12px] font-semibold uppercase tracking-wider ${t.textMuted} shrink-0`}>
           Aging:
         </span>
         {AGING_OPTIONS.map(({ value, label }) => (
@@ -113,7 +113,7 @@ export default function MasterFeesPage() {
           </button>
         ))}
         {agingFilter !== "all" && (
-          <span className={`ml-auto text-[11px] ${t.textMuted}`}>
+          <span className={`ml-auto text-[13px] ${t.textMuted}`}>
             {displayCases.length} case{displayCases.length !== 1 ? "s" : ""}
           </span>
         )}

--- a/src/app/(dashboard)/notifications/page.tsx
+++ b/src/app/(dashboard)/notifications/page.tsx
@@ -263,7 +263,7 @@ export default function NotificationsPage() {
             <Icon className="h-3.5 w-3.5" aria-hidden="true" />
             {label}
             {key === "notifications" && unreadCount > 0 && (
-              <span className="min-w-4 h-4 px-1 rounded-full bg-red-500 text-white text-[9px] font-bold flex items-center justify-center">
+              <span className="min-w-4 h-4 px-1 rounded-full bg-red-500 text-white text-[11px] font-bold flex items-center justify-center">
                 {unreadCount > 99 ? "99+" : unreadCount}
               </span>
             )}
@@ -291,14 +291,14 @@ export default function NotificationsPage() {
                 className={`h-5 w-5 ${dark ? "text-indigo-400" : "text-indigo-500"}`}
               />
               {unreadCount > 0 && (
-                <span className="absolute -top-1.5 -right-1.5 min-w-4 h-4 px-1 rounded-full bg-red-500 text-white text-[9px] font-bold flex items-center justify-center">
+                <span className="absolute -top-1.5 -right-1.5 min-w-4 h-4 px-1 rounded-full bg-red-500 text-white text-[11px] font-bold flex items-center justify-center">
                   {unreadCount > 99 ? "99+" : unreadCount}
                 </span>
               )}
             </div>
             <div>
               <h3 className={`text-sm font-bold ${t.text}`}>Notifications</h3>
-              <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
+              <p className={`text-[13px] ${t.textMuted} mt-0.5`}>
                 {all.length} total · {unread.length} unread
               </p>
             </div>
@@ -337,7 +337,7 @@ export default function NotificationsPage() {
               <button
                 key={key}
                 onClick={() => setFilter(key)}
-                className={`h-7 px-3 rounded-md text-[11px] font-medium flex items-center gap-1.5 whitespace-nowrap transition-colors ${
+                className={`h-7 px-3 rounded-md text-[13px] font-medium flex items-center gap-1.5 whitespace-nowrap transition-colors ${
                   active
                     ? dark
                       ? "bg-neutral-800 text-neutral-100"
@@ -350,7 +350,7 @@ export default function NotificationsPage() {
                 {label}
                 {count > 0 && (
                   <span
-                    className={`text-[9px] font-semibold px-1.5 py-0.5 rounded-full ${
+                    className={`text-[11px] font-semibold px-1.5 py-0.5 rounded-full ${
                       active
                         ? dark
                           ? "bg-neutral-700 text-neutral-300"
@@ -452,7 +452,7 @@ export default function NotificationsPage() {
                         />
                       )}
                       <h4
-                        className={`text-[13px] font-semibold truncate ${t.text}`}
+                        className={`text-[15px] font-semibold truncate ${t.text}`}
                       >
                         {n.title}
                       </h4>
@@ -460,7 +460,7 @@ export default function NotificationsPage() {
                     <div className="flex items-center gap-1.5 shrink-0">
                       {isLive && (
                         <span
-                          className={`text-[9px] font-semibold px-1.5 py-0.5 rounded-full ${
+                          className={`text-[11px] font-semibold px-1.5 py-0.5 rounded-full ${
                             dark
                               ? "bg-indigo-900/40 text-indigo-300 border border-indigo-700/50"
                               : "bg-indigo-50 text-indigo-600 border border-indigo-200"
@@ -470,26 +470,26 @@ export default function NotificationsPage() {
                         </span>
                       )}
                       <span
-                        className={`text-[10px] ${t.textMuted} whitespace-nowrap`}
+                        className={`text-[12px] ${t.textMuted} whitespace-nowrap`}
                       >
                         {timeAgo(n.createdAt)}
                       </span>
                     </div>
                   </div>
                   <p
-                    className={`text-[12px] ${t.textSub} mt-0.5 leading-relaxed`}
+                    className={`text-[14px] ${t.textSub} mt-0.5 leading-relaxed`}
                   >
                     {n.message}
                   </p>
                   <div className="flex items-center gap-3 mt-2">
                     <span
-                      className={`text-[10px] font-medium px-2 py-0.5 rounded-full border ${colorClass}`}
+                      className={`text-[12px] font-medium px-2 py-0.5 rounded-full border ${colorClass}`}
                     >
                       {meta.label}
                     </span>
                     {n.agentName && (
                       <span
-                        className={`text-[10px] font-medium ${t.textMuted}`}
+                        className={`text-[12px] font-medium ${t.textMuted}`}
                       >
                         {n.agentName}
                       </span>
@@ -497,7 +497,7 @@ export default function NotificationsPage() {
                     {n.caseId && (
                       <Link
                         href={`/cases/${n.caseId}`}
-                        className={`text-[10px] font-medium flex items-center gap-0.5 ${dark ? "text-indigo-400 hover:text-indigo-300" : "text-indigo-600 hover:text-indigo-700"}`}
+                        className={`text-[12px] font-medium flex items-center gap-0.5 ${dark ? "text-indigo-400 hover:text-indigo-300" : "text-indigo-600 hover:text-indigo-700"}`}
                       >
                         View case <ChevronRight className="h-3 w-3" />
                       </Link>
@@ -505,7 +505,7 @@ export default function NotificationsPage() {
                     {!n.isRead && !isLive && (
                       <button
                         onClick={() => markRead(n.id)}
-                        className={`text-[10px] font-medium flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity ${
+                        className={`text-[12px] font-medium flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity ${
                           dark
                             ? "text-neutral-400 hover:text-neutral-200"
                             : "text-neutral-500 hover:text-neutral-700"

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -325,7 +325,7 @@ export default function SettingsPage() {
             />
             <div>
               <h3 className={`text-sm font-bold ${t.text}`}>Settings</h3>
-              <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
+              <p className={`text-[13px] ${t.textMuted} mt-0.5`}>
                 Configure fee caps, integrations, targets, and preferences
               </p>
             </div>
@@ -358,7 +358,7 @@ export default function SettingsPage() {
                   setActiveTab(tab);
                   setSaveMsg(null);
                 }}
-                className={`h-8 px-3 rounded-md text-[11px] font-medium flex items-center gap-1.5 whitespace-nowrap transition-colors ${
+                className={`h-8 px-3 rounded-md text-[13px] font-medium flex items-center gap-1.5 whitespace-nowrap transition-colors ${
                   active
                     ? dark
                       ? "bg-neutral-800 text-neutral-100"
@@ -488,7 +488,7 @@ export default function SettingsPage() {
                   >
                     <Calendar className="h-3.5 w-3.5" /> SSA Fee Cap History
                   </h4>
-                  <span className={`text-[10px] ${t.textMuted}`}>
+                  <span className={`text-[12px] ${t.textMuted}`}>
                     {feeCaps.length} entries
                   </span>
                 </div>
@@ -497,13 +497,13 @@ export default function SettingsPage() {
                 <div
                   className={`p-4 border-b ${t.borderLight} ${dark ? "bg-neutral-800/30" : "bg-neutral-50/50"}`}
                 >
-                  <p className={`text-[11px] font-semibold ${t.textSub} mb-2`}>
+                  <p className={`text-[13px] font-semibold ${t.textSub} mb-2`}>
                     Add Fee Cap
                   </p>
                   <div className="flex flex-col sm:flex-row items-start sm:items-end gap-2">
                     <div className="flex-1 min-w-0">
                       <label
-                        className={`text-[10px] ${t.textMuted} block mb-0.5`}
+                        className={`text-[12px] ${t.textMuted} block mb-0.5`}
                       >
                         Effective Date
                       </label>
@@ -516,7 +516,7 @@ export default function SettingsPage() {
                     </div>
                     <div className="flex-1 min-w-0">
                       <label
-                        className={`text-[10px] ${t.textMuted} block mb-0.5`}
+                        className={`text-[12px] ${t.textMuted} block mb-0.5`}
                       >
                         Cap Amount ($)
                       </label>
@@ -531,7 +531,7 @@ export default function SettingsPage() {
                     </div>
                     <div className="flex-2 min-w-0">
                       <label
-                        className={`text-[10px] ${t.textMuted} block mb-0.5`}
+                        className={`text-[12px] ${t.textMuted} block mb-0.5`}
                       >
                         Notes (optional)
                       </label>
@@ -587,7 +587,7 @@ export default function SettingsPage() {
                             })}
                           </div>
                           {fc.notes && (
-                            <span className={`text-[11px] ${t.textMuted}`}>
+                            <span className={`text-[13px] ${t.textMuted}`}>
                               {fc.notes}
                             </span>
                           )}
@@ -625,7 +625,7 @@ export default function SettingsPage() {
                   >
                     <Shield className="h-3.5 w-3.5" /> Service Connections
                   </h4>
-                  <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
+                  <p className={`text-[13px] ${t.textMuted} mt-0.5`}>
                     API keys and URLs are managed via environment variables in
                     Vercel
                   </p>
@@ -655,11 +655,11 @@ export default function SettingsPage() {
                   return (
                     <div key={conn.service} className="p-4">
                       <div className="flex items-center gap-2 mb-1">
-                        <h5 className={`text-[13px] font-semibold ${t.text}`}>
+                        <h5 className={`text-[15px] font-semibold ${t.text}`}>
                           {conn.label}
                         </h5>
                         <span
-                          className={`text-[9px] font-semibold px-2 py-0.5 rounded-full border flex items-center gap-1 ${colorClass}`}
+                          className={`text-[11px] font-semibold px-2 py-0.5 rounded-full border flex items-center gap-1 ${colorClass}`}
                         >
                           <StatusIcon className="h-2.5 w-2.5" />
                           {conn.status === "connected"
@@ -671,14 +671,14 @@ export default function SettingsPage() {
                                 : "Untested"}
                         </span>
                       </div>
-                      <p className={`text-[11px] ${t.textSub}`}>
+                      <p className={`text-[13px] ${t.textSub}`}>
                         {conn.message}
                       </p>
 
                       <div className={`mt-2 flex flex-wrap items-center gap-3`}>
                         <div className="flex items-center gap-1.5">
                           <Key className={`h-3 w-3 ${t.textMuted}`} />
-                          <span className={`text-[10px] ${t.textMuted}`}>
+                          <span className={`text-[12px] ${t.textMuted}`}>
                             <code
                               className={`px-1 py-0.5 rounded ${dark ? "bg-neutral-800" : "bg-neutral-100"}`}
                             >
@@ -687,13 +687,13 @@ export default function SettingsPage() {
                           </span>
                           {conn.keyConfigured ? (
                             <span
-                              className={`text-[9px] font-semibold px-1.5 py-0.5 rounded-full ${dark ? "bg-emerald-900/30 text-emerald-400" : "bg-emerald-50 text-emerald-700"}`}
+                              className={`text-[11px] font-semibold px-1.5 py-0.5 rounded-full ${dark ? "bg-emerald-900/30 text-emerald-400" : "bg-emerald-50 text-emerald-700"}`}
                             >
                               SET
                             </span>
                           ) : (
                             <span
-                              className={`text-[9px] font-semibold px-1.5 py-0.5 rounded-full ${dark ? "bg-neutral-800 text-neutral-500" : "bg-neutral-100 text-neutral-400"}`}
+                              className={`text-[11px] font-semibold px-1.5 py-0.5 rounded-full ${dark ? "bg-neutral-800 text-neutral-500" : "bg-neutral-100 text-neutral-400"}`}
                             >
                               NOT SET
                             </span>
@@ -702,7 +702,7 @@ export default function SettingsPage() {
                         {conn.baseUrl && (
                           <div className="flex items-center gap-1.5">
                             <Link2 className={`h-3 w-3 ${t.textMuted}`} />
-                            <span className={`text-[10px] ${t.textMuted}`}>
+                            <span className={`text-[12px] ${t.textMuted}`}>
                               {conn.baseUrl}
                             </span>
                           </div>
@@ -715,7 +715,7 @@ export default function SettingsPage() {
 
               {/* Help note */}
               <div className={`p-4 border-t ${t.borderLight}`}>
-                <p className={`text-[11px] ${t.textMuted}`}>
+                <p className={`text-[13px] ${t.textMuted}`}>
                   To update API keys or URLs, go to{" "}
                   <span className={`font-semibold ${t.text}`}>
                     Vercel Dashboard → Project Settings → Environment Variables
@@ -736,7 +736,7 @@ export default function SettingsPage() {
                 >
                   <Target className="h-3.5 w-3.5" /> Daily Call Targets
                 </h4>
-                <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
+                <p className={`text-[13px] ${t.textMuted} mt-0.5`}>
                   Agents below these thresholds trigger &qout;Missed Calls&qout;
                   notifications.
                 </p>
@@ -759,7 +759,7 @@ export default function SettingsPage() {
                       onChange={(e) => editValue(s.key, e.target.value)}
                       className={`${inputClass} sm:w-32`}
                     />
-                    <span className={`text-[11px] ${t.textMuted}`}>
+                    <span className={`text-[13px] ${t.textMuted}`}>
                       calls/day
                     </span>
                   </div>
@@ -796,7 +796,7 @@ export default function SettingsPage() {
                       onChange={(e) => editValue(s.key, e.target.value)}
                       className={`${inputClass} sm:w-32`}
                     />
-                    <span className={`text-[11px] ${t.textMuted}`}>
+                    <span className={`text-[13px] ${t.textMuted}`}>
                       seconds
                     </span>
                   </div>

--- a/src/app/cases/[id]/page.tsx
+++ b/src/app/cases/[id]/page.tsx
@@ -186,9 +186,9 @@ const FeeSection = memo(
     onSaved,
   }: FeeSectionProps) => {
     const t = themeClasses(dark);
-    const lbl = `text-[10px] font-semibold uppercase tracking-wider ${t.textMuted}`;
-    const valCls = `text-[13px] font-semibold ${t.text} mt-0.5`;
-    const inpCls = `mt-1 h-7 px-2 rounded border text-[12px] outline-none w-full ${t.inputBg}`;
+    const lbl = `text-[12px] font-semibold uppercase tracking-wider ${t.textMuted}`;
+    const valCls = `text-[15px] font-semibold ${t.text} mt-0.5`;
+    const inpCls = `mt-1 h-7 px-2 rounded border text-[14px] outline-none w-full ${t.inputBg}`;
     const sectionCard = `rounded-xl border ${t.card} p-4 md:p-5`;
 
     const [inlineEdit, setInlineEdit] = useState(false);
@@ -276,7 +276,7 @@ const FeeSection = memo(
           {!inlineEdit ? (
             <button
               onClick={startEdit}
-              className={`text-[10px] font-medium ${t.textMuted} flex items-center gap-1`}
+              className={`text-[12px] font-medium ${t.textMuted} flex items-center gap-1`}
             >
               <Pencil className="h-2.5 w-2.5" /> Edit
             </button>
@@ -284,14 +284,14 @@ const FeeSection = memo(
             <div className="flex gap-1.5">
               <button
                 onClick={cancelInlineEdit}
-                className={`text-[10px] font-medium ${t.textMuted} flex items-center gap-0.5`}
+                className={`text-[12px] font-medium ${t.textMuted} flex items-center gap-0.5`}
               >
                 <X className="h-2.5 w-2.5" /> Cancel
               </button>
               <button
                 onClick={saveInline}
                 disabled={localSaving}
-                className="text-[10px] font-semibold text-emerald-500 flex items-center gap-0.5 disabled:opacity-50"
+                className="text-[12px] font-semibold text-emerald-500 flex items-center gap-0.5 disabled:opacity-50"
               >
                 {localSaving ? (
                   <RefreshCw className="h-2.5 w-2.5 animate-spin" />
@@ -319,7 +319,7 @@ const FeeSection = memo(
               <div>
                 <p className={lbl}>
                   Fee Due{" "}
-                  <span className="text-[8px] normal-case font-normal">
+                  <span className="text-[10px] normal-case font-normal">
                     (auto)
                   </span>
                 </p>
@@ -373,7 +373,7 @@ const FeeSection = memo(
               <div>
                 <p className={lbl}>Fee Received</p>
                 <p
-                  className={`text-[13px] font-semibold mt-0.5 ${received > 0 ? "text-emerald-500" : t.textMuted}`}
+                  className={`text-[15px] font-semibold mt-0.5 ${received > 0 ? "text-emerald-500" : t.textMuted}`}
                 >
                   {currency(received)}
                 </p>
@@ -381,7 +381,7 @@ const FeeSection = memo(
               <div>
                 <p className={lbl}>Pending</p>
                 <p
-                  className={`text-[13px] font-semibold mt-0.5 ${pending > 0 ? (dark ? "text-amber-400" : "text-amber-600") : t.textMuted}`}
+                  className={`text-[15px] font-semibold mt-0.5 ${pending > 0 ? (dark ? "text-amber-400" : "text-amber-600") : t.textMuted}`}
                 >
                   {currency(pending)}
                 </p>
@@ -693,9 +693,9 @@ const CaseDetailPage = () => {
   // ---- Style helpers ----
 
   const sectionCard = `rounded-xl border ${t.card} p-4 md:p-5`;
-  const lbl = `text-[10px] font-semibold uppercase tracking-wider ${t.textMuted}`;
-  const val = `text-[13px] font-semibold ${t.text} mt-0.5`;
-  const inp = `mt-1 h-7 px-2 rounded border text-[12px] w-full outline-none ${t.inputBg}`;
+  const lbl = `text-[12px] font-semibold uppercase tracking-wider ${t.textMuted}`;
+  const val = `text-[15px] font-semibold ${t.text} mt-0.5`;
+  const inp = `mt-1 h-7 px-2 rounded border text-[14px] w-full outline-none ${t.inputBg}`;
 
   // ---- Render ----
 
@@ -751,7 +751,7 @@ const CaseDetailPage = () => {
               </div>
               <div>
                 <h3 className={`text-sm font-bold ${t.text}`}>Delete Case</h3>
-                <p className={`text-[11px] ${t.textMuted}`}>
+                <p className={`text-[13px] ${t.textMuted}`}>
                   This action cannot be undone
                 </p>
               </div>
@@ -801,17 +801,17 @@ const CaseDetailPage = () => {
                 {caseData.name}
               </h1>
               <span
-                className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${t.pillBg}`}
+                className={`text-[12px] font-medium px-1.5 py-0.5 rounded ${t.pillBg}`}
               >
                 {fmtClaim(caseData.claim)}
               </span>
               <span
-                className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${t.pillBg}`}
+                className={`text-[12px] font-medium px-1.5 py-0.5 rounded ${t.pillBg}`}
               >
                 {caseData.level}
               </span>
               <span
-                className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold ${getStatusColor(caseData.status as WinSheetStatus, dark)}`}
+                className={`inline-flex items-center px-2 py-0.5 rounded-full text-[12px] font-semibold ${getStatusColor(caseData.status as WinSheetStatus, dark)}`}
               >
                 {STATUS_LABELS_DETAIL[caseData.status] || caseData.status}
               </span>
@@ -1180,7 +1180,7 @@ const CaseDetailPage = () => {
                   className={`text-xs font-bold ${t.text} mb-3 flex items-center gap-2`}
                 >
                   <DollarSign className="h-3.5 w-3.5" /> Financial Summary
-                  <span className={`text-[9px] font-normal ${t.textMuted}`}>
+                  <span className={`text-[11px] font-normal ${t.textMuted}`}>
                     (computed)
                   </span>
                 </h4>
@@ -1196,7 +1196,7 @@ const CaseDetailPage = () => {
                   <div>
                     <p className={lbl}>Paid</p>
                     <p
-                      className={`text-[13px] font-semibold mt-0.5 ${caseData.paid > 0 ? "text-emerald-500" : t.textMuted}`}
+                      className={`text-[15px] font-semibold mt-0.5 ${caseData.paid > 0 ? "text-emerald-500" : t.textMuted}`}
                     >
                       {fmtFull(caseData.paid)}
                     </p>
@@ -1204,7 +1204,7 @@ const CaseDetailPage = () => {
                   <div>
                     <p className={lbl}>Outstanding</p>
                     <p
-                      className={`text-[13px] font-semibold mt-0.5 ${caseData.outstanding > 0 ? (dark ? "text-red-400" : "text-red-600") : "text-emerald-500"}`}
+                      className={`text-[15px] font-semibold mt-0.5 ${caseData.outstanding > 0 ? (dark ? "text-red-400" : "text-red-600") : "text-emerald-500"}`}
                     >
                       {fmtFull(caseData.outstanding)}
                     </p>
@@ -1221,7 +1221,7 @@ const CaseDetailPage = () => {
                           }}
                         />
                       </div>
-                      <p className={`text-[10px] ${t.textMuted} mt-1`}>
+                      <p className={`text-[12px] ${t.textMuted} mt-1`}>
                         {Math.round((caseData.paid / caseData.expected) * 100)}%
                         collected
                       </p>
@@ -1230,7 +1230,7 @@ const CaseDetailPage = () => {
                   <div className="flex items-center gap-2 pt-1">
                     <p className={lbl}>PIF</p>
                     <span
-                      className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold ${
+                      className={`inline-flex items-center px-2 py-0.5 rounded-full text-[12px] font-semibold ${
                         caseData.pif === "YES"
                           ? dark
                             ? "bg-emerald-900/40 text-emerald-400"
@@ -1254,7 +1254,7 @@ const CaseDetailPage = () => {
                     <div className="flex items-center gap-2">
                       <p className={lbl}>Aging</p>
                       <span
-                        className={`text-[12px] font-semibold ${caseData.approvalCategory === ">60" ? (dark ? "text-red-400" : "text-red-600") : dark ? "text-emerald-400" : "text-emerald-600"}`}
+                        className={`text-[14px] font-semibold ${caseData.approvalCategory === ">60" ? (dark ? "text-red-400" : "text-red-600") : dark ? "text-emerald-400" : "text-emerald-600"}`}
                       >
                         <Clock className="h-3 w-3 inline mr-1" />
                         {caseData.daysAfterApproval}d (
@@ -1280,7 +1280,7 @@ const CaseDetailPage = () => {
                   className={`text-xs font-bold ${t.text} mb-3 flex items-center gap-2`}
                 >
                   <Shield className="h-3.5 w-3.5" /> PDF-Extracted Data
-                  <span className={`text-[9px] font-normal ${t.textMuted}`}>
+                  <span className={`text-[11px] font-normal ${t.textMuted}`}>
                     (from Chronicle file)
                   </span>
                 </h4>
@@ -1370,7 +1370,7 @@ const CaseDetailPage = () => {
                   <div className="mt-3">
                     <p className={lbl}>Allegations</p>
                     <p
-                      className={`text-[12px] ${t.textSub} mt-1 leading-relaxed`}
+                      className={`text-[14px] ${t.textSub} mt-1 leading-relaxed`}
                     >
                       {caseData.allegations}
                     </p>
@@ -1385,7 +1385,7 @@ const CaseDetailPage = () => {
                         {caseData.representatives.map((rep, i) => (
                           <span
                             key={i}
-                            className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-lg text-[11px] font-medium ${dark ? "bg-neutral-800/60 text-neutral-300" : "bg-neutral-100 text-neutral-700"}`}
+                            className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-lg text-[13px] font-medium ${dark ? "bg-neutral-800/60 text-neutral-300" : "bg-neutral-100 text-neutral-700"}`}
                           >
                             <User className="h-3 w-3" /> {rep.name}
                             {rep.repId ? ` (${rep.repId})` : ""}
@@ -1408,7 +1408,7 @@ const CaseDetailPage = () => {
                           return (
                             <span
                               key={i}
-                              className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-lg text-[11px] font-medium ${
+                              className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-lg text-[13px] font-medium ${
                                 denied
                                   ? dark
                                     ? "bg-red-900/30 text-red-400"
@@ -1486,7 +1486,7 @@ const CaseDetailPage = () => {
                 className={`text-xs font-bold ${t.text} mb-4 flex items-center gap-2`}
               >
                 <MessageSquare className="h-3.5 w-3.5" /> Activity Log
-                <span className={`ml-1 text-[10px] font-normal ${t.textMuted}`}>
+                <span className={`ml-1 text-[12px] font-normal ${t.textMuted}`}>
                   ({caseData.activities?.length ?? 0}{" "}
                   {caseData.activities?.length === 1 ? "entry" : "entries"})
                 </span>
@@ -1494,7 +1494,7 @@ const CaseDetailPage = () => {
               <div
                 className={`mb-4 rounded-lg border p-3 ${dark ? "bg-neutral-800/40 border-neutral-700" : "bg-neutral-50 border-neutral-200"}`}
               >
-                <p className={`text-[10px] ${t.textMuted} mb-2`}>
+                <p className={`text-[12px] ${t.textMuted} mb-2`}>
                   Posting as{" "}
                   <span className={`font-semibold ${t.textSub}`}>
                     {currentUser}
@@ -1506,7 +1506,7 @@ const CaseDetailPage = () => {
                     onChange={(e) => setNewNote(e.target.value)}
                     onKeyDown={(e) => e.key === "Enter" && handlePostNote()}
                     placeholder="Add a note or status update..."
-                    className={`flex-1 h-8 px-3 rounded-md border text-[12px] outline-none ${t.inputBg}`}
+                    className={`flex-1 h-8 px-3 rounded-md border text-[14px] outline-none ${t.inputBg}`}
                   />
                   <button
                     onClick={handlePostNote}
@@ -1544,11 +1544,11 @@ const CaseDetailPage = () => {
                         <div className="flex-1 min-w-0 pb-1">
                           <div className="flex items-center gap-2">
                             <span
-                              className={`text-[11px] font-semibold ${t.text}`}
+                              className={`text-[13px] font-semibold ${t.text}`}
                             >
                               {a.createdBy}
                             </span>
-                            <span className={`text-[10px] ${t.textMuted}`}>
+                            <span className={`text-[12px] ${t.textMuted}`}>
                               {new Date(a.createdAt).toLocaleDateString(
                                 "en-US",
                                 {
@@ -1562,7 +1562,7 @@ const CaseDetailPage = () => {
                             </span>
                           </div>
                           <p
-                            className={`text-[12px] ${t.textSub} mt-0.5 leading-relaxed break-words`}
+                            className={`text-[14px] ${t.textSub} mt-0.5 leading-relaxed break-words`}
                           >
                             {a.message}
                           </p>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,6 +4,13 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
+  /* Bumped one tier up from Tailwind's defaults (xs 0.75rem->0.875rem,
+     sm 0.875rem->1rem) so dense UI text stays readable for older users —
+     text-base and above are left alone since headings weren't the complaint. */
+  --text-xs: 0.875rem;
+  --text-xs--line-height: 1.25rem;
+  --text-sm: 1rem;
+  --text-sm--line-height: 1.5rem;
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-outfit);

--- a/src/app/login/test-accounts-hint.tsx
+++ b/src/app/login/test-accounts-hint.tsx
@@ -34,7 +34,7 @@ export function TestAccountsHint() {
 
       {open && (
         <div className="rounded-md border border-neutral-200 bg-white px-3 py-2 shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
-          <table className="cursor-text text-[11px] select-text">
+          <table className="cursor-text text-[13px] select-text">
             <tbody>
               {TEST_ACCOUNTS.map((a) => (
                 <tr key={a.email}>

--- a/src/components/admin/AccessOverridesDialog.tsx
+++ b/src/components/admin/AccessOverridesDialog.tsx
@@ -147,14 +147,14 @@ export function AccessOverridesDialog({
                 size="sm"
                 variant="outline"
                 onClick={applyDefaults}
-                className="h-7 text-[11px]"
+                className="h-7 text-[13px]"
               >
                 <RotateCcw className="h-3 w-3" aria-hidden="true" /> Apply Role
                 Defaults
               </Button>
             </div>
             <div>
-              <p className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+              <p className="mb-2 text-[13px] font-semibold uppercase tracking-wider text-muted-foreground">
                 Pages
               </p>
               <div className="grid grid-cols-1 gap-x-6 gap-y-2 sm:grid-cols-2">
@@ -181,7 +181,7 @@ export function AccessOverridesDialog({
             </div>
 
             <div>
-              <p className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+              <p className="mb-2 text-[13px] font-semibold uppercase tracking-wider text-muted-foreground">
                 Case actions
               </p>
               <div className="grid grid-cols-1 gap-x-6 gap-y-2">
@@ -206,7 +206,7 @@ export function AccessOverridesDialog({
                           />
                         )}
                       </span>
-                      <span className="text-[11px] text-muted-foreground">
+                      <span className="text-[13px] text-muted-foreground">
                         {c.description}
                       </span>
                     </span>
@@ -224,7 +224,7 @@ export function AccessOverridesDialog({
         )}
 
         <DialogFooter className="items-center">
-          <span className="mr-auto text-[11px] text-muted-foreground">
+          <span className="mr-auto text-[13px] text-muted-foreground">
             {dirty ? "Unsaved changes" : "No unsaved changes"}
           </span>
           <Button variant="outline" onClick={onClose} disabled={saving}>

--- a/src/components/admin/AdminActivityLog.tsx
+++ b/src/components/admin/AdminActivityLog.tsx
@@ -102,7 +102,7 @@ export function AdminActivityLog({ entries }: { entries: AdminActivityEntry[] })
         <h3 className={`text-sm font-semibold mt-3 ${t.text}`}>
           No admin activity yet
         </h3>
-        <p className={`text-[11px] ${t.textMuted} mt-1 max-w-md mx-auto`}>
+        <p className={`text-[13px] ${t.textMuted} mt-1 max-w-md mx-auto`}>
           User creates, role changes, password resets, and access edits will
           appear here as they happen.
         </p>
@@ -147,15 +147,15 @@ export function AdminActivityLog({ entries }: { entries: AdminActivityEntry[] })
                 className={`flex items-start gap-3 px-4 py-2.5 ${dark ? "hover:bg-neutral-800/30" : "hover:bg-neutral-50"}`}
               >
                 <span
-                  className={`mt-0.5 shrink-0 text-[10px] font-semibold px-1.5 py-0.5 rounded ${toneClasses(meta.tone, dark)}`}
+                  className={`mt-0.5 shrink-0 text-[12px] font-semibold px-1.5 py-0.5 rounded ${toneClasses(meta.tone, dark)}`}
                 >
                   {meta.label}
                 </span>
                 <div className="flex-1 min-w-0 select-text">
-                  <p className={`text-[12px] ${t.text} break-words`}>
+                  <p className={`text-[14px] ${t.text} break-words`}>
                     {e.summary}
                   </p>
-                  <p className={`text-[10px] ${t.textMuted} mt-0.5`}>
+                  <p className={`text-[12px] ${t.textMuted} mt-0.5`}>
                     {e.actorEmail ?? "Unknown"} · {fmtDateTime(e.createdAt)}
                   </p>
                 </div>

--- a/src/components/admin/AdminPage.tsx
+++ b/src/components/admin/AdminPage.tsx
@@ -53,7 +53,7 @@ export function AdminPage({
           </div>
           <div>
             <h3 className={`text-sm font-bold ${t.text}`}>Admin</h3>
-            <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
+            <p className={`text-[13px] ${t.textMuted} mt-0.5`}>
               Manage user accounts and review activity
             </p>
           </div>

--- a/src/components/admin/CaseActivityFeed.tsx
+++ b/src/components/admin/CaseActivityFeed.tsx
@@ -76,7 +76,7 @@ export function CaseActivityFeed({
         <h3 className={`text-sm font-semibold mt-3 ${t.text}`}>
           No case activity yet
         </h3>
-        <p className={`text-[11px] ${t.textMuted} mt-1 max-w-md mx-auto`}>
+        <p className={`text-[13px] ${t.textMuted} mt-1 max-w-md mx-auto`}>
           Edits to cases (fees, status, notes, assignments) will appear here.
         </p>
       </div>
@@ -117,17 +117,17 @@ export function CaseActivityFeed({
               <div className="flex items-center gap-2">
                 <Link
                   href={`/cases/${e.caseId}`}
-                  className={`inline-flex items-center gap-1 text-[11px] font-semibold hover:underline ${dark ? "text-blue-400" : "text-blue-600"}`}
+                  className={`inline-flex items-center gap-1 text-[13px] font-semibold hover:underline ${dark ? "text-blue-400" : "text-blue-600"}`}
                 >
                   {e.caseName}
                   <ExternalLink className="h-2.5 w-2.5" aria-hidden="true" />
                 </Link>
               </div>
               <div className="select-text">
-                <p className={`text-[12px] ${t.text} mt-0.5 break-words`}>
+                <p className={`text-[14px] ${t.text} mt-0.5 break-words`}>
                   {e.message}
                 </p>
-                <p className={`text-[10px] ${t.textMuted} mt-0.5`}>
+                <p className={`text-[12px] ${t.textMuted} mt-0.5`}>
                   {e.createdBy ?? "System"} · {fmtDateTime(e.createdAt)}
                 </p>
               </div>

--- a/src/components/admin/EditUserDialog.tsx
+++ b/src/components/admin/EditUserDialog.tsx
@@ -97,7 +97,7 @@ export function EditUserDialog({
               </SelectContent>
             </Select>
             {isSelf && (
-              <p className="text-[11px] text-muted-foreground">
+              <p className="text-[13px] text-muted-foreground">
                 You can&apos;t change your own role or active status.
               </p>
             )}

--- a/src/components/admin/UsersTable.tsx
+++ b/src/components/admin/UsersTable.tsx
@@ -156,8 +156,8 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
   };
 
   const sectionCard = `rounded-xl border ${t.card}`;
-  const thBase = `py-2 px-3 text-[10px] font-semibold uppercase tracking-wider whitespace-nowrap ${t.textSub}`;
-  const tdBase = `py-2 px-3 text-[12px] whitespace-nowrap`;
+  const thBase = `py-2 px-3 text-[12px] font-semibold uppercase tracking-wider whitespace-nowrap ${t.textSub}`;
+  const tdBase = `py-2 px-3 text-[14px] whitespace-nowrap`;
   const rowBorder = dark ? "border-neutral-800/50" : "border-neutral-100";
 
   return (
@@ -168,7 +168,7 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
       >
         <div>
           <h3 className={`text-sm font-bold ${t.text}`}>Users</h3>
-          <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
+          <p className={`text-[13px] ${t.textMuted} mt-0.5`}>
             {users.length === 1 ? "1 account" : `${users.length} accounts`}
           </p>
         </div>
@@ -243,7 +243,7 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
                     <td className={tdBase}>
                       <div className="flex items-center gap-2.5">
                         <div
-                          className={`w-7 h-7 rounded-full flex items-center justify-center text-[11px] font-bold ${t.avatarBg}`}
+                          className={`w-7 h-7 rounded-full flex items-center justify-center text-[13px] font-bold ${t.avatarBg}`}
                         >
                           {initial}
                         </div>
@@ -252,7 +252,7 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
                             {user.name || user.email}
                             {isSelf && (
                               <span
-                                className={`ml-2 text-[10px] font-normal ${t.textMuted}`}
+                                className={`ml-2 text-[12px] font-normal ${t.textMuted}`}
                               >
                                 (you)
                               </span>
@@ -261,7 +261,7 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
                           {user.name && (
                             <a
                               href={`mailto:${user.email}`}
-                              className={`text-[10px] ${t.textMuted} truncate hover:underline`}
+                              className={`text-[12px] ${t.textMuted} truncate hover:underline`}
                             >
                               {user.email}
                             </a>
@@ -299,7 +299,7 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
                             variant="outline"
                             onClick={() => setEditTarget(user)}
                             disabled={rowBusy}
-                            className="h-7 text-[11px]"
+                            className="h-7 text-[13px]"
                           >
                             <Pencil className="h-3 w-3" aria-hidden="true" />
                             Edit
@@ -310,7 +310,7 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
                           variant="outline"
                           onClick={() => setResetTarget(user)}
                           disabled={rowBusy}
-                          className="h-7 text-[11px]"
+                          className="h-7 text-[13px]"
                         >
                           <KeyRound className="h-3 w-3" aria-hidden="true" />
                           Reset password
@@ -320,7 +320,7 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
                           variant="outline"
                           onClick={() => setAccessTarget(user)}
                           disabled={rowBusy}
-                          className="h-7 text-[11px]"
+                          className="h-7 text-[13px]"
                         >
                           <ShieldCheck className="h-3 w-3" aria-hidden="true" />
                           Access

--- a/src/components/admin/activity-filters.tsx
+++ b/src/components/admin/activity-filters.tsx
@@ -189,7 +189,7 @@ export function ActivityFilterBar({
             className={`${ctl} cursor-pointer`}
             aria-label="From date"
           />
-          <span className={`text-[11px] ${t.textMuted}`}>to</span>
+          <span className={`text-[13px] ${t.textMuted}`}>to</span>
           <input
             type="date"
             value={state.to}

--- a/src/components/cases/ArchiveTable.tsx
+++ b/src/components/cases/ArchiveTable.tsx
@@ -34,7 +34,7 @@ const SourceBadge = ({ source, dark }: { source: ArchiveRow["archivedSource"]; d
         ? "bg-emerald-900/40 text-emerald-300"
         : "bg-emerald-50 text-emerald-700";
   return (
-    <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${cls}`}>
+    <span className={`text-[12px] font-semibold px-1.5 py-0.5 rounded ${cls}`}>
       {label}
     </span>
   );
@@ -107,12 +107,12 @@ export const ArchiveTable = ({ rows, dark, t, onReopened }: ArchiveTableProps) =
         <table className="w-full text-sm">
           <thead>
             <tr className={`border-b ${t.border} ${dark ? "bg-neutral-800/60" : "bg-neutral-50"}`}>
-              <th className={`px-4 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider ${t.textMuted}`}>Case</th>
-              <th className={`px-4 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider ${t.textMuted}`}>Approval Date</th>
-              <th className={`px-4 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider ${t.textMuted}`}>Archived From</th>
-              <th className={`px-4 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider ${t.textMuted}`}>Archived By</th>
-              <th className={`px-4 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider ${t.textMuted}`}>Archived At</th>
-              <th className={`px-4 py-2.5 text-right text-[11px] font-semibold uppercase tracking-wider ${t.textMuted}`}>Action</th>
+              <th className={`px-4 py-2.5 text-left text-[13px] font-semibold uppercase tracking-wider ${t.textMuted}`}>Case</th>
+              <th className={`px-4 py-2.5 text-left text-[13px] font-semibold uppercase tracking-wider ${t.textMuted}`}>Approval Date</th>
+              <th className={`px-4 py-2.5 text-left text-[13px] font-semibold uppercase tracking-wider ${t.textMuted}`}>Archived From</th>
+              <th className={`px-4 py-2.5 text-left text-[13px] font-semibold uppercase tracking-wider ${t.textMuted}`}>Archived By</th>
+              <th className={`px-4 py-2.5 text-left text-[13px] font-semibold uppercase tracking-wider ${t.textMuted}`}>Archived At</th>
+              <th className={`px-4 py-2.5 text-right text-[13px] font-semibold uppercase tracking-wider ${t.textMuted}`}>Action</th>
             </tr>
           </thead>
           <tbody className={`divide-y ${t.border}`}>
@@ -121,7 +121,7 @@ export const ArchiveTable = ({ rows, dark, t, onReopened }: ArchiveTableProps) =
                 <tr className={`transition-colors ${t.hover}`}>
                   <td className={`px-4 py-3 ${t.text}`}>
                     <div className="font-medium">{row.caseName ?? "—"}</div>
-                    <div className={`text-[11px] ${t.textMuted}`}>#{row.originalClientId}</div>
+                    <div className={`text-[13px] ${t.textMuted}`}>#{row.originalClientId}</div>
                   </td>
                   <td className={`px-4 py-3 ${t.textSub} text-sm`}>{fmtDate(row.approvalDate)}</td>
                   <td className="px-4 py-3">
@@ -133,7 +133,7 @@ export const ArchiveTable = ({ rows, dark, t, onReopened }: ArchiveTableProps) =
                     {reopenId === row.id ? (
                       <button
                         onClick={() => { setReopenId(null); setError(null); }}
-                        className={`text-[11px] font-medium px-2 py-1 rounded ${t.textMuted} ${t.hover}`}
+                        className={`text-[13px] font-medium px-2 py-1 rounded ${t.textMuted} ${t.hover}`}
                       >
                         Cancel
                       </button>
@@ -141,7 +141,7 @@ export const ArchiveTable = ({ rows, dark, t, onReopened }: ArchiveTableProps) =
                       <button
                         onClick={() => { setReopenId(row.id); setError(null); }}
                         disabled={reopenId !== null}
-                        className={`flex items-center gap-1.5 text-[11px] font-semibold px-2.5 py-1 rounded transition-colors ${dark ? "text-amber-300 hover:bg-amber-900/30 disabled:opacity-40" : "text-amber-700 hover:bg-amber-50 disabled:opacity-40"}`}
+                        className={`flex items-center gap-1.5 text-[13px] font-semibold px-2.5 py-1 rounded transition-colors ${dark ? "text-amber-300 hover:bg-amber-900/30 disabled:opacity-40" : "text-amber-700 hover:bg-amber-50 disabled:opacity-40"}`}
                       >
                         <RotateCcw aria-hidden="true" className="h-3 w-3" />
                         Reopen
@@ -153,20 +153,20 @@ export const ArchiveTable = ({ rows, dark, t, onReopened }: ArchiveTableProps) =
                   <tr className={`${dark ? "bg-neutral-800/40" : "bg-neutral-50"}`}>
                     <td colSpan={6} className="px-4 py-3">
                       <div className="flex items-center gap-3">
-                        <span className={`text-[12px] font-medium ${t.textSub}`}>
+                        <span className={`text-[14px] font-medium ${t.textSub}`}>
                           Restore this case to:
                         </span>
                         <button
                           onClick={() => handleReopen(row.id, "master_list")}
                           disabled={reopening !== null}
-                          className={`text-[12px] font-semibold px-3 py-1 rounded border transition-colors disabled:opacity-50 ${dark ? "border-blue-700 text-blue-300 hover:bg-blue-900/30" : "border-blue-300 text-blue-700 hover:bg-blue-50"}`}
+                          className={`text-[14px] font-semibold px-3 py-1 rounded border transition-colors disabled:opacity-50 ${dark ? "border-blue-700 text-blue-300 hover:bg-blue-900/30" : "border-blue-300 text-blue-700 hover:bg-blue-50"}`}
                         >
                           {reopening === "master_list" ? "Restoring…" : "Master List"}
                         </button>
                         <button
                           onClick={() => handleReopen(row.id, "fees_closed")}
                           disabled={reopening !== null}
-                          className={`text-[12px] font-semibold px-3 py-1 rounded border transition-colors disabled:opacity-50 ${dark ? "border-emerald-700 text-emerald-300 hover:bg-emerald-900/30" : "border-emerald-300 text-emerald-700 hover:bg-emerald-50"}`}
+                          className={`text-[14px] font-semibold px-3 py-1 rounded border transition-colors disabled:opacity-50 ${dark ? "border-emerald-700 text-emerald-300 hover:bg-emerald-900/30" : "border-emerald-300 text-emerald-700 hover:bg-emerald-50"}`}
                         >
                           {reopening === "fees_closed" ? "Restoring…" : "Fees Closed"}
                         </button>

--- a/src/components/cases/CaseDetailSheet.tsx
+++ b/src/components/cases/CaseDetailSheet.tsx
@@ -131,7 +131,7 @@ function ClientDetailsSection({
 
   return (
     <div className={sectionCls}>
-      <h4 className={`text-[10px] font-bold uppercase tracking-widest ${textMuted} mb-3 flex items-center gap-1.5`}>
+      <h4 className={`text-[12px] font-bold uppercase tracking-widest ${textMuted} mb-3 flex items-center gap-1.5`}>
         <User aria-hidden="true" className="h-3 w-3" /> Client Details
       </h4>
       <div className="space-y-3">
@@ -465,9 +465,9 @@ export default function CaseDetailSheet({
     setSaveError(null);
   }, []);
 
-  const lbl = `text-[10px] font-semibold uppercase tracking-wider ${t.textMuted}`;
-  const val = `text-[13px] font-semibold ${t.text} mt-0.5`;
-  const inp = `mt-1 h-7 px-2 rounded border text-[12px] w-full outline-none ${t.inputBg}`;
+  const lbl = `text-[12px] font-semibold uppercase tracking-wider ${t.textMuted}`;
+  const val = `text-[15px] font-semibold ${t.text} mt-0.5`;
+  const inp = `mt-1 h-7 px-2 rounded border text-[14px] w-full outline-none ${t.inputBg}`;
   const sectionCls = `p-4 border-b ${t.borderLight}`;
 
   const chronicleLink = data
@@ -517,7 +517,7 @@ export default function CaseDetailSheet({
                     onClick={handleSave}
                     disabled={isSaving}
                     aria-label="Save changes"
-                    className={`h-7 px-2 rounded-md flex items-center gap-1 text-[11px] font-semibold ${dark ? "bg-indigo-600 hover:bg-indigo-500 text-white" : "bg-indigo-600 hover:bg-indigo-700 text-white"} disabled:opacity-50`}
+                    className={`h-7 px-2 rounded-md flex items-center gap-1 text-[13px] font-semibold ${dark ? "bg-indigo-600 hover:bg-indigo-500 text-white" : "bg-indigo-600 hover:bg-indigo-700 text-white"} disabled:opacity-50`}
                   >
                     <Check aria-hidden="true" className="h-3 w-3" />
                     {isSaving ? "Saving…" : "Save"}
@@ -542,11 +542,11 @@ export default function CaseDetailSheet({
               )}
             </div>
           </div>
-          <SheetDescription className={`text-[11px] ${t.textMuted}`}>
+          <SheetDescription className={`text-[13px] ${t.textMuted}`}>
             {isEditing ? "Edit local DB fields — changes write to the app database." : "Details needed for processing the win sheet for this case."}
           </SheetDescription>
           {saveError && (
-            <p role="alert" className="text-[11px] text-red-500 mt-1">{saveError}</p>
+            <p role="alert" className="text-[13px] text-red-500 mt-1">{saveError}</p>
           )}
         </SheetHeader>
 
@@ -579,14 +579,14 @@ export default function CaseDetailSheet({
                     {data.name}
                   </h3>
                   <div className="flex items-center gap-2 mt-1.5 flex-wrap">
-                    <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${t.pillBg}`}>
+                    <span className={`text-[12px] font-medium px-1.5 py-0.5 rounded ${t.pillBg}`}>
                       {fmtClaim(data.claim)}
                     </span>
-                    <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${t.pillBg}`}>
+                    <span className={`text-[12px] font-medium px-1.5 py-0.5 rounded ${t.pillBg}`}>
                       {data.level}
                     </span>
                     <span
-                      className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold ${getStatusColor(data.status as WinSheetStatus, dark)}`}
+                      className={`inline-flex items-center px-2 py-0.5 rounded-full text-[12px] font-semibold ${getStatusColor(data.status as WinSheetStatus, dark)}`}
                     >
                       {STATUS_LABELS_DETAIL[data.status] || data.status}
                     </span>
@@ -634,14 +634,14 @@ export default function CaseDetailSheet({
                     href={data.externalId || `https://rgdr.mycase.com/court_cases/${data.id}`}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-[10px] font-bold uppercase transition-colors ${dark ? "bg-indigo-900/30 text-indigo-400 hover:bg-indigo-900/50" : "bg-indigo-50 text-indigo-600 hover:bg-indigo-100"}`}
+                    className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-[12px] font-bold uppercase transition-colors ${dark ? "bg-indigo-900/30 text-indigo-400 hover:bg-indigo-900/50" : "bg-indigo-50 text-indigo-600 hover:bg-indigo-100"}`}
                   >
                     MyCase <ExternalLink aria-hidden="true" className="h-3 w-3" />
                   </a>
                   <button
                     type="button"
                     onClick={() => setDocsOpen(true)}
-                    className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-[10px] font-bold uppercase transition-colors ${dark ? "bg-emerald-900/30 text-emerald-400 hover:bg-emerald-900/50" : "bg-emerald-50 text-emerald-600 hover:bg-emerald-100"}`}
+                    className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-[12px] font-bold uppercase transition-colors ${dark ? "bg-emerald-900/30 text-emerald-400 hover:bg-emerald-900/50" : "bg-emerald-50 text-emerald-600 hover:bg-emerald-100"}`}
                   >
                     Documents <FileText aria-hidden="true" className="h-3 w-3" />
                   </button>
@@ -650,7 +650,7 @@ export default function CaseDetailSheet({
                       href={chronicleLink}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-[10px] font-bold uppercase transition-colors ${dark ? "bg-sky-900/30 text-sky-400 hover:bg-sky-900/50" : "bg-sky-50 text-sky-600 hover:bg-sky-100"}`}
+                      className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-[12px] font-bold uppercase transition-colors ${dark ? "bg-sky-900/30 text-sky-400 hover:bg-sky-900/50" : "bg-sky-50 text-sky-600 hover:bg-sky-100"}`}
                     >
                       Chronicle <ExternalLink aria-hidden="true" className="h-3 w-3" />
                     </a>
@@ -661,7 +661,7 @@ export default function CaseDetailSheet({
 
             {/* Core Identification */}
             <div className={sectionCls}>
-              <h4 className={`text-[10px] font-bold uppercase tracking-widest ${t.textMuted} mb-3 flex items-center gap-1.5`}>
+              <h4 className={`text-[12px] font-bold uppercase tracking-widest ${t.textMuted} mb-3 flex items-center gap-1.5`}>
                 <Shield aria-hidden="true" className="h-3 w-3" /> Identity & Verification
               </h4>
               <div className="grid grid-cols-2 gap-4">
@@ -719,7 +719,7 @@ export default function CaseDetailSheet({
 
             {/* Decisions */}
             <div className={sectionCls}>
-              <h4 className={`text-[10px] font-bold uppercase tracking-widest ${t.textMuted} mb-3 flex items-center gap-1.5`}>
+              <h4 className={`text-[12px] font-bold uppercase tracking-widest ${t.textMuted} mb-3 flex items-center gap-1.5`}>
                 <FileText aria-hidden="true" className="h-3 w-3" /> Decisions
               </h4>
               <div className="space-y-3">
@@ -819,7 +819,7 @@ export default function CaseDetailSheet({
                       href={data.winSheetLink}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1 text-[12px] font-medium text-blue-500 hover:underline"
+                      className="inline-flex items-center gap-1 text-[14px] font-medium text-blue-500 hover:underline"
                     >
                       <ExternalLink className="h-3 w-3" aria-hidden="true" />
                       {data.winSheetLinkText || "Open"}
@@ -831,7 +831,7 @@ export default function CaseDetailSheet({
 
             {/* Financial Totals */}
             <div className={sectionCls}>
-              <h4 className={`text-[10px] font-bold uppercase tracking-widest ${t.textMuted} mb-3 flex items-center gap-1.5`}>
+              <h4 className={`text-[12px] font-bold uppercase tracking-widest ${t.textMuted} mb-3 flex items-center gap-1.5`}>
                 <DollarSign aria-hidden="true" className="h-3 w-3" /> Financial Summary
               </h4>
               <div className="grid grid-cols-2 gap-4">
@@ -843,7 +843,7 @@ export default function CaseDetailSheet({
                   <p className={lbl}>PIF Status</p>
                   <div className="mt-1">
                     <span
-                      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-[10px] font-bold ${
+                      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-[12px] font-bold ${
                         data.pif === "YES"
                           ? dark ? "bg-emerald-900/40 text-emerald-400" : "bg-emerald-50 text-emerald-700"
                           : data.pif === "PENDING"
@@ -871,7 +871,7 @@ export default function CaseDetailSheet({
 
             {/* Detailed Fee Breakdown */}
             <div className={sectionCls}>
-              <h4 className={`text-[10px] font-bold uppercase tracking-widest ${t.textMuted} mb-3`}>
+              <h4 className={`text-[12px] font-bold uppercase tracking-widest ${t.textMuted} mb-3`}>
                 Fee Breakdown
               </h4>
               <div className="space-y-4">
@@ -883,7 +883,7 @@ export default function CaseDetailSheet({
                   ] as const
                 ).map((b) => (
                   <div key={b.key} className={`p-3 rounded-lg border ${t.borderLight} bg-neutral-50/30 dark:bg-neutral-900/20`}>
-                    <p className={`text-[11px] font-bold uppercase ${b.titleColor} mb-2`}>{b.label}</p>
+                    <p className={`text-[13px] font-bold uppercase ${b.titleColor} mb-2`}>{b.label}</p>
                     {isEditing ? (
                       <div className="grid grid-cols-2 gap-x-3 gap-y-2">
                         <div>
@@ -961,18 +961,18 @@ export default function CaseDetailSheet({
 
             {/* Live from MyCase */}
             <div className={sectionCls}>
-              <h4 className={`text-[10px] font-bold uppercase tracking-widest ${t.textMuted} mb-3 flex items-center gap-1.5`}>
+              <h4 className={`text-[12px] font-bold uppercase tracking-widest ${t.textMuted} mb-3 flex items-center gap-1.5`}>
                 <Database aria-hidden="true" className="h-3 w-3" /> Live from MyCase
               </h4>
               {myCaseLoading ? (
                 <div className="flex items-center gap-2 py-2">
                   <RefreshCw aria-hidden="true" className={`h-3.5 w-3.5 animate-spin ${t.textMuted}`} />
-                  <span className={`text-[11px] ${t.textMuted}`}>Fetching from MyCase…</span>
+                  <span className={`text-[13px] ${t.textMuted}`}>Fetching from MyCase…</span>
                 </div>
               ) : myCaseError ? (
                 <div
                   role="alert"
-                  className={`flex items-start gap-2 rounded-md p-2 text-[11px] ${dark ? "bg-amber-900/20 text-amber-400" : "bg-amber-50 text-amber-700"}`}
+                  className={`flex items-start gap-2 rounded-md p-2 text-[13px] ${dark ? "bg-amber-900/20 text-amber-400" : "bg-amber-50 text-amber-700"}`}
                 >
                   <AlertTriangle aria-hidden="true" className="h-3.5 w-3.5 shrink-0 mt-0.5" />
                   <span className="flex-1">{myCaseError}</span>
@@ -989,7 +989,7 @@ export default function CaseDetailSheet({
                     </div>
                     <div>
                       <p className={lbl}>Case Stage</p>
-                      <p className={`${val} text-[11px] leading-tight`}>{myCaseData.caseStage ?? "—"}</p>
+                      <p className={`${val} text-[13px] leading-tight`}>{myCaseData.caseStage ?? "—"}</p>
                     </div>
                     <div>
                       <p className={lbl}>Assigned To</p>
@@ -1006,7 +1006,7 @@ export default function CaseDetailSheet({
                           href={data.winSheetLink}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="inline-flex items-center gap-1 text-[12px] font-medium text-blue-500 hover:underline"
+                          className="inline-flex items-center gap-1 text-[14px] font-medium text-blue-500 hover:underline"
                         >
                           <ExternalLink className="h-3 w-3" aria-hidden="true" />
                           {data.winSheetLinkText || "Open"}
@@ -1031,7 +1031,7 @@ export default function CaseDetailSheet({
                     { key: "t2", label: "T2 (SSDI)", color: "text-blue-500", retro: myCaseData.t2Retro, due: myCaseData.t2FeeDue, received: myCaseData.t2FeeReceived, pending: myCaseData.t2Pending, receivedDate: myCaseData.t2FeeReceivedDate },
                   ].map((b) => (
                     <div key={b.key} className={`p-3 rounded-lg border ${t.borderLight} bg-neutral-50/30 dark:bg-neutral-900/20`}>
-                      <p className={`text-[11px] font-bold uppercase ${b.color} mb-2`}>{b.label}</p>
+                      <p className={`text-[13px] font-bold uppercase ${b.color} mb-2`}>{b.label}</p>
                       <div className="grid grid-cols-2 gap-2">
                         {[
                           { label: "Retro", val: b.retro },
@@ -1067,13 +1067,13 @@ export default function CaseDetailSheet({
                   {myCaseData.feesConfirmation && (
                     <div>
                       <p className={lbl}>Fees Confirmation</p>
-                      <p className={`${val} text-[11px] leading-snug`}>{myCaseData.feesConfirmation}</p>
+                      <p className={`${val} text-[13px] leading-snug`}>{myCaseData.feesConfirmation}</p>
                     </div>
                   )}
                   {myCaseData.notes && (
                     <div>
                       <p className={lbl}>Collection Notes</p>
-                      <p className={`${val} text-[11px] leading-snug whitespace-pre-wrap`}>{myCaseData.notes}</p>
+                      <p className={`${val} text-[13px] leading-snug whitespace-pre-wrap`}>{myCaseData.notes}</p>
                     </div>
                   )}
                 </div>

--- a/src/components/cases/CollectionsPanel.tsx
+++ b/src/components/cases/CollectionsPanel.tsx
@@ -22,18 +22,18 @@ export const CollectionsPanel = ({ data }: CollectionsPanelProps) => {
           <h3 className={`text-sm font-bold ${t.text}`}>
             Collections Activity — Monthly
           </h3>
-          <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
+          <p className={`text-[13px] ${t.textMuted} mt-0.5`}>
             Showing fee activity for the last 6 months
           </p>
         </div>
         <div className="flex items-center gap-4">
           <span
-            className={`flex items-center gap-1.5 text-[11px] ${t.textSub}`}
+            className={`flex items-center gap-1.5 text-[13px] ${t.textSub}`}
           >
             <span className="w-2 h-2 rounded-full bg-indigo-500" /> Expected
           </span>
           <span
-            className={`flex items-center gap-1.5 text-[11px] ${t.textSub}`}
+            className={`flex items-center gap-1.5 text-[13px] ${t.textSub}`}
           >
             <span className="w-2 h-2 rounded-full bg-emerald-500" /> Collected
           </span>

--- a/src/components/cases/FeeAmountCell.tsx
+++ b/src/components/cases/FeeAmountCell.tsx
@@ -40,7 +40,7 @@ export function FeeAmountCell({
             type="number" min="0" step="0.01" value={draft} autoFocus
             onChange={(e) => onDraftChange(e.target.value)}
             onKeyDown={(e) => { if (e.key === "Enter") onSave(); if (e.key === "Escape") onCancel(); }}
-            className={`h-6 px-1.5 rounded border text-[11px] outline-none w-24 text-right ${inputBg}`}
+            className={`h-6 px-1.5 rounded border text-[13px] outline-none w-24 text-right ${inputBg}`}
           />
           {saving ? (
             <Loader2 className="h-3.5 w-3.5 animate-spin ml-0.5" aria-hidden="true" />
@@ -55,7 +55,7 @@ export function FeeAmountCell({
             </>
           )}
         </div>
-        {error && <p role="alert" className="text-[10px] text-red-500">{error}</p>}
+        {error && <p role="alert" className="text-[12px] text-red-500">{error}</p>}
       </div>
     );
   }

--- a/src/components/cases/FeeEditModal.tsx
+++ b/src/components/cases/FeeEditModal.tsx
@@ -205,8 +205,8 @@ export default function FeeEditModal({
   };
 
   // Styles
-  const lbl = `text-[10px] font-semibold uppercase tracking-wider ${t.textMuted}`;
-  const inpCls = `mt-1 h-7 px-2 rounded border text-[12px] outline-none w-full ${t.inputBg}`;
+  const lbl = `text-[12px] font-semibold uppercase tracking-wider ${t.textMuted}`;
+  const inpCls = `mt-1 h-7 px-2 rounded border text-[14px] outline-none w-full ${t.inputBg}`;
   const amber = dark ? "text-amber-400" : "text-amber-600";
 
   // Fee Due/Pending default to the formula but stay editable — typing into
@@ -222,12 +222,12 @@ export default function FeeEditModal({
       <p className={lbl}>
         {label}{" "}
         {overrideVal == null ? (
-          <span className="text-[8px] normal-case font-normal">(auto)</span>
+          <span className="text-[10px] normal-case font-normal">(auto)</span>
         ) : (
           <button
             type="button"
             onClick={resetOverride(overrideKey)}
-            className={`text-[8px] normal-case font-normal underline ${amber}`}
+            className={`text-[10px] normal-case font-normal underline ${amber}`}
           >
             reset to auto
           </button>
@@ -256,7 +256,7 @@ export default function FeeEditModal({
         <div className="flex items-center justify-between mb-5">
           <div>
             <h3 className={`text-sm font-bold ${t.text}`}>Edit Fee Amounts</h3>
-            <p className={`text-[10px] ${t.textMuted} mt-0.5`}>
+            <p className={`text-[12px] ${t.textMuted} mt-0.5`}>
               Fee Due = MIN(Retro × 25%, {fmtFull(feeCap)}) · Pending = Fee Due
               − Received — both editable; edits stick until reset to auto
             </p>

--- a/src/components/cases/FeePaymentPanel.tsx
+++ b/src/components/cases/FeePaymentPanel.tsx
@@ -151,26 +151,26 @@ export function FeePaymentPanel({
       className={`fixed rounded-xl border shadow-xl ${t.card} p-4 space-y-3`}
     >
       <div className="flex items-center justify-between">
-        <span className={`text-[11px] font-semibold uppercase tracking-wide ${t.textMuted}`}>
+        <span className={`text-[13px] font-semibold uppercase tracking-wide ${t.textMuted}`}>
           {feeType.toUpperCase()} Payment History
         </span>
-        <span className={`text-[11px] font-medium ${t.textSub}`}>
+        <span className={`text-[13px] font-medium ${t.textSub}`}>
           Total: {currentTotal > 0 ? fmtFull(currentTotal) : "—"}
         </span>
       </div>
 
       {/* Payment list */}
       {!payments && !loadError && (
-        <div className={`flex items-center gap-2 text-[12px] ${t.textMuted}`}>
+        <div className={`flex items-center gap-2 text-[14px] ${t.textMuted}`}>
           <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
           Loading…
         </div>
       )}
       {loadError && (
-        <p className="text-[12px] text-red-500" role="alert">{loadError}</p>
+        <p className="text-[14px] text-red-500" role="alert">{loadError}</p>
       )}
       {payments && payments.length === 0 && (
-        <p className={`text-[12px] ${t.textMuted}`}>No payment records yet.</p>
+        <p className={`text-[14px] ${t.textMuted}`}>No payment records yet.</p>
       )}
       {payments && payments.length > 0 && (
         <div className="space-y-1 max-h-52 overflow-y-auto">
@@ -180,10 +180,10 @@ export function FeePaymentPanel({
               className={`flex items-center justify-between gap-2 rounded-lg px-3 py-2 ${dark ? "bg-neutral-800/60" : "bg-neutral-50"}`}
             >
               <div className="min-w-0">
-                <div className={`text-[12px] font-semibold tabular-nums ${dark ? "text-emerald-400" : "text-emerald-600"}`}>
+                <div className={`text-[14px] font-semibold tabular-nums ${dark ? "text-emerald-400" : "text-emerald-600"}`}>
                   {fmtFull(p.amount)}
                 </div>
-                <div className={`text-[11px] ${t.textMuted}`}>
+                <div className={`text-[13px] ${t.textMuted}`}>
                   {fmtDate(p.receivedDate)}
                   {p.note && <span className="ml-1 italic">· {p.note}</span>}
                 </div>
@@ -208,7 +208,7 @@ export function FeePaymentPanel({
       {/* Add payment form */}
       {canEdit && (
         <div className={`border-t pt-3 ${t.borderLight}`}>
-          <p className={`text-[11px] font-semibold uppercase tracking-wide ${t.textMuted} mb-2`}>
+          <p className={`text-[13px] font-semibold uppercase tracking-wide ${t.textMuted} mb-2`}>
             Add payment
           </p>
           <div className="space-y-2">
@@ -217,7 +217,7 @@ export function FeePaymentPanel({
                 type="date"
                 value={newDate}
                 onChange={(e) => setNewDate(e.target.value)}
-                className={`rounded-md border px-2 py-1.5 text-[12px] w-full ${t.inputBg}`}
+                className={`rounded-md border px-2 py-1.5 text-[14px] w-full ${t.inputBg}`}
                 aria-label="Payment date"
               />
               <input
@@ -227,7 +227,7 @@ export function FeePaymentPanel({
                 value={newAmount}
                 onChange={(e) => setNewAmount(e.target.value)}
                 placeholder="Amount"
-                className={`rounded-md border px-2 py-1.5 text-[12px] w-full ${t.inputBg}`}
+                className={`rounded-md border px-2 py-1.5 text-[14px] w-full ${t.inputBg}`}
                 aria-label="Payment amount"
               />
             </div>
@@ -237,16 +237,16 @@ export function FeePaymentPanel({
               onChange={(e) => setNewNote(e.target.value)}
               placeholder="Note (optional)"
               maxLength={200}
-              className={`rounded-md border px-2 py-1.5 text-[12px] w-full ${t.inputBg}`}
+              className={`rounded-md border px-2 py-1.5 text-[14px] w-full ${t.inputBg}`}
               aria-label="Payment note"
             />
             {addError && (
-              <p className="text-[11px] text-red-500" role="alert">{addError}</p>
+              <p className="text-[13px] text-red-500" role="alert">{addError}</p>
             )}
             <button
               onClick={handleAdd}
               disabled={adding}
-              className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-[12px] font-medium transition-colors w-full justify-center ${dark ? "bg-emerald-700 hover:bg-emerald-600 text-white" : "bg-emerald-600 hover:bg-emerald-700 text-white"} disabled:opacity-50`}
+              className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-[14px] font-medium transition-colors w-full justify-center ${dark ? "bg-emerald-700 hover:bg-emerald-600 text-white" : "bg-emerald-600 hover:bg-emerald-700 text-white"} disabled:opacity-50`}
             >
               {adding
                 ? <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
@@ -264,7 +264,7 @@ export function FeePaymentPanel({
       <button
         ref={triggerRef}
         onClick={handleOpen}
-        className={`flex items-center gap-1 text-[12px] rounded px-1 py-0.5 transition-colors ${t.hover} ${t.textSub}`}
+        className={`flex items-center gap-1 text-[14px] rounded px-1 py-0.5 transition-colors ${t.hover} ${t.textSub}`}
         aria-label={`${feeType.toUpperCase()} payment history`}
         aria-expanded={open}
       >

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -69,7 +69,7 @@ function ClaimTypeBadge({ value, dark }: { value: string | null | undefined; dar
   if (!value) return <span className="text-neutral-400">—</span>;
   const colors = CLAIM_TYPE_COLORS[value] ?? CLAIM_TYPE_FALLBACK;
   return (
-    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium border whitespace-nowrap ${dark ? colors.badgeDark : colors.badge}`}>
+    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-[12px] font-medium border whitespace-nowrap ${dark ? colors.badgeDark : colors.badge}`}>
       {value}
     </span>
   );
@@ -79,7 +79,7 @@ function FeesConfBadge({ value, dark }: { value: string | null | undefined; dark
   if (!value) return <span className="text-neutral-400">—</span>;
   const colors = FEES_CONF_COLORS[value] ?? FEES_CONF_FALLBACK;
   return (
-    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium border whitespace-nowrap ${dark ? colors.badgeDark : colors.badge}`}>
+    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-[12px] font-medium border whitespace-nowrap ${dark ? colors.badgeDark : colors.badge}`}>
       {value}
     </span>
   );
@@ -102,7 +102,7 @@ function WinSheetStatusBadge({ value, dark }: { value: string | null | undefined
   if (!value) return <span className="text-neutral-400">—</span>;
   const colors = WIN_SHEET_STATUS_COLORS[value] ?? WIN_SHEET_STATUS_FALLBACK;
   return (
-    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium border whitespace-nowrap ${dark ? colors.badgeDark : colors.badge}`}>
+    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-[12px] font-medium border whitespace-nowrap ${dark ? colors.badgeDark : colors.badge}`}>
       {value}
     </span>
   );
@@ -131,7 +131,7 @@ function CaseStatusBadge({ value, dark }: { value: string | null | undefined; da
   if (!value) return <span className="text-neutral-400">—</span>;
   const colors = CASE_STATUS_COLORS[value] ?? CASE_STATUS_FALLBACK;
   return (
-    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium border whitespace-nowrap ${dark ? colors.badgeDark : colors.badge}`}>
+    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-[12px] font-medium border whitespace-nowrap ${dark ? colors.badgeDark : colors.badge}`}>
       {value}
     </span>
   );
@@ -756,8 +756,8 @@ export const FeeRecordsTable = ({
   // (row 1) overrides to the very top with `top-0!`.
   // `h-8` forces each header row to exactly 32px so row 2's `top-8` sits
   // flush against row 1's bottom — no gap for body rows to peek through.
-  const thBase = `h-8 px-3 text-[10px] font-semibold uppercase tracking-wider whitespace-nowrap sticky top-8 z-20 ${stickyBg}`;
-  const tdBase = `py-2 px-3 text-[12px] whitespace-nowrap`;
+  const thBase = `h-8 px-3 text-[12px] font-semibold uppercase tracking-wider whitespace-nowrap sticky top-8 z-20 ${stickyBg}`;
+  const tdBase = `py-2 px-3 text-[14px] whitespace-nowrap`;
   const groupBorder = dark
     ? "border-l border-neutral-700/50"
     : "border-l border-neutral-200";
@@ -835,7 +835,7 @@ export const FeeRecordsTable = ({
       >
         <div>
           <h3 className={`text-sm font-bold ${t.text}`}>Master Fee Records</h3>
-          <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
+          <p className={`text-[13px] ${t.textMuted} mt-0.5`}>
             {filtered.length} of {cases.length} cases
           </p>
         </div>
@@ -964,13 +964,13 @@ export const FeeRecordsTable = ({
       {selectedIds.size > 0 && isAdmin && (
         <div className="pointer-events-none fixed bottom-6 left-0 right-0 z-50 flex justify-center">
           <div className="pointer-events-auto flex items-center gap-2 rounded-full bg-gray-900 px-4 py-2.5 shadow-2xl ring-1 ring-white/10 dark:bg-gray-800">
-            <span className="text-[11px] font-semibold text-gray-300 pr-1 border-r border-white/20 mr-1">
+            <span className="text-[13px] font-semibold text-gray-300 pr-1 border-r border-white/20 mr-1">
               {selectedIds.size} selected
             </span>
             <button
               onClick={handleBatchArchive}
               disabled={archiveConfirmOpen}
-              className="h-7 px-3 rounded-full text-[11px] font-semibold flex items-center gap-1.5 bg-rose-600 hover:bg-rose-500 text-white transition-colors disabled:opacity-50"
+              className="h-7 px-3 rounded-full text-[13px] font-semibold flex items-center gap-1.5 bg-rose-600 hover:bg-rose-500 text-white transition-colors disabled:opacity-50"
             >
               <Archive aria-hidden="true" className="h-3 w-3" />
               Archive
@@ -1271,7 +1271,7 @@ export const FeeRecordsTable = ({
                             {c.name}
                           </span>
                         )}
-                        <div className="flex items-center gap-2 text-[11px] leading-none min-w-0">
+                        <div className="flex items-center gap-2 text-[13px] leading-none min-w-0">
                           {(() => {
                             // Mirror the Claim column's optimistic value so the
                             // sub-line updates the instant the dropdown changes.
@@ -1355,7 +1355,7 @@ export const FeeRecordsTable = ({
                             );
                             setFeesConfEditId(null);
                           }}
-                          className={`w-full h-7 px-2 rounded-md border text-[11px] outline-none cursor-pointer ${t.inputBg}`}
+                          className={`w-full h-7 px-2 rounded-md border text-[13px] outline-none cursor-pointer ${t.inputBg}`}
                           title={
                             feesConfirmationOptions.length === 0
                               ? "No options configured — add them in Settings"
@@ -1481,7 +1481,7 @@ export const FeeRecordsTable = ({
                             );
                             setClaimEditId(null);
                           }}
-                          className={`h-7 px-2 rounded-md border text-[11px] outline-none cursor-pointer ${t.inputBg}`}
+                          className={`h-7 px-2 rounded-md border text-[13px] outline-none cursor-pointer ${t.inputBg}`}
                           title={
                             claimTypeOptions.length === 0
                               ? "No options configured — add them in Settings"
@@ -1544,7 +1544,7 @@ export const FeeRecordsTable = ({
                             );
                             setWinSheetStatusEditId(null);
                           }}
-                          className={`h-7 px-2 rounded-md border text-[11px] outline-none cursor-pointer ${t.inputBg}`}
+                          className={`h-7 px-2 rounded-md border text-[13px] outline-none cursor-pointer ${t.inputBg}`}
                           title={
                             winSheetStatusOptions.length === 0
                               ? "No options configured — add them in Settings"
@@ -1605,7 +1605,7 @@ export const FeeRecordsTable = ({
                               if (e.key === "Enter") handleWinSheetSave(c);
                               if (e.key === "Escape") setWinSheetEditing(null);
                             }}
-                            className={`h-6 px-2 rounded border text-[11px] outline-none w-full ${t.inputBg}`}
+                            className={`h-6 px-2 rounded border text-[13px] outline-none w-full ${t.inputBg}`}
                           />
                           <input
                             type="text"
@@ -1618,10 +1618,10 @@ export const FeeRecordsTable = ({
                               if (e.key === "Enter") handleWinSheetSave(c);
                               if (e.key === "Escape") setWinSheetEditing(null);
                             }}
-                            className={`h-6 px-2 rounded border text-[11px] outline-none w-full ${t.inputBg}`}
+                            className={`h-6 px-2 rounded border text-[13px] outline-none w-full ${t.inputBg}`}
                           />
                           {winSheetError && (
-                            <p role="alert" className={`text-[10px] text-red-500`}>
+                            <p role="alert" className={`text-[12px] text-red-500`}>
                               {winSheetError}
                             </p>
                           )}
@@ -1633,7 +1633,7 @@ export const FeeRecordsTable = ({
                                 <button
                                   type="button"
                                   onClick={() => handleWinSheetSave(c)}
-                                  className="inline-flex items-center gap-0.5 h-5 px-1.5 rounded text-[10px] font-semibold bg-blue-500 text-white hover:bg-blue-600"
+                                  className="inline-flex items-center gap-0.5 h-5 px-1.5 rounded text-[12px] font-semibold bg-blue-500 text-white hover:bg-blue-600"
                                 >
                                   <Check className="h-3 w-3" aria-hidden="true" />
                                   Save
@@ -1641,7 +1641,7 @@ export const FeeRecordsTable = ({
                                 <button
                                   type="button"
                                   onClick={() => { setWinSheetEditing(null); setWinSheetError(null); }}
-                                  className={`inline-flex items-center gap-0.5 h-5 px-1.5 rounded text-[10px] font-semibold border ${t.outlineBtn}`}
+                                  className={`inline-flex items-center gap-0.5 h-5 px-1.5 rounded text-[12px] font-semibold border ${t.outlineBtn}`}
                                 >
                                   <X className="h-3 w-3" aria-hidden="true" />
                                   Cancel
@@ -1660,7 +1660,7 @@ export const FeeRecordsTable = ({
                                   target="_blank"
                                   rel="noopener noreferrer"
                                   onClick={(e) => e.stopPropagation()}
-                                  className="inline-flex items-center gap-1 text-[11px] font-medium text-blue-500 hover:underline"
+                                  className="inline-flex items-center gap-1 text-[13px] font-medium text-blue-500 hover:underline"
                                 >
                                   <ExternalLink className="h-3 w-3" aria-hidden="true" />
                                   {c.winSheetLinkText || "Open"}
@@ -1669,7 +1669,7 @@ export const FeeRecordsTable = ({
                               <HoverCardContent
                                 align="start"
                                 collisionPadding={12}
-                                className="w-72 p-3 space-y-2 text-[11px]"
+                                className="w-72 p-3 space-y-2 text-[13px]"
                               >
                                 <p>
                                   <span className="font-semibold">Display text: </span>
@@ -1682,7 +1682,7 @@ export const FeeRecordsTable = ({
                               </HoverCardContent>
                             </HoverCard>
                           ) : (
-                            <span className={`text-[11px] ${t.textMuted}`}>—</span>
+                            <span className={`text-[13px] ${t.textMuted}`}>—</span>
                           )}
                           <button
                             type="button"
@@ -1717,7 +1717,7 @@ export const FeeRecordsTable = ({
                             e.stopPropagation();
                             setLeaderNotesFor({ id: c.id, name: c.name });
                           }}
-                          className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-semibold ${
+                          className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[12px] font-semibold ${
                             c.leaderNotesCount > 0
                               ? dark
                                 ? "bg-violet-900/40 text-violet-400 hover:bg-violet-900/60"
@@ -2006,7 +2006,7 @@ export const FeeRecordsTable = ({
                             );
                             setCaseStatusEditId(null);
                           }}
-                          className={`h-7 px-2 rounded-md border text-[11px] outline-none cursor-pointer ${t.inputBg}`}
+                          className={`h-7 px-2 rounded-md border text-[13px] outline-none cursor-pointer ${t.inputBg}`}
                           title={
                             caseStatusOptions.length === 0
                               ? "No options configured — add them in Settings"
@@ -2057,7 +2057,7 @@ export const FeeRecordsTable = ({
                           <HoverCardContent
                             align="start"
                             collisionPadding={12}
-                            className="w-auto max-w-[min(28rem,90vw)] p-3 text-[12px] leading-relaxed whitespace-pre-wrap wrap-break-word"
+                            className="w-auto max-w-[min(28rem,90vw)] p-3 text-[14px] leading-relaxed whitespace-pre-wrap wrap-break-word"
                           >
                             {c.update}
                           </HoverCardContent>
@@ -2072,7 +2072,7 @@ export const FeeRecordsTable = ({
                           e.stopPropagation();
                           setNotesFor({ id: c.id, name: c.name });
                         }}
-                        className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-semibold ${
+                        className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[12px] font-semibold ${
                           c.notesCount > 0
                             ? dark
                               ? "bg-blue-900/40 text-blue-400 hover:bg-blue-900/60"
@@ -2100,7 +2100,7 @@ export const FeeRecordsTable = ({
                         {c.daysAfterApproval !== null ? (
                           <span>
                             {c.daysAfterApproval}d{" "}
-                            <span className="text-[9px] opacity-70">
+                            <span className="text-[11px] opacity-70">
                               {c.approvalCategory}
                             </span>
                           </span>
@@ -2129,12 +2129,12 @@ export const FeeRecordsTable = ({
         <div
           className={`flex flex-col sm:flex-row sm:items-center justify-between gap-3 px-4 py-3 border-t ${t.borderLight}`}
         >
-          <p className={`text-[11px] ${t.textMuted}`}>
+          <p className={`text-[13px] ${t.textMuted}`}>
             Showing {pageStart + 1}–{pageEnd} of {filtered.length}
           </p>
           <div className="flex items-center gap-2">
             <label
-              className={`text-[11px] font-medium ${t.textSub} flex items-center gap-1.5`}
+              className={`text-[13px] font-medium ${t.textSub} flex items-center gap-1.5`}
             >
               Rows per page
               <select
@@ -2165,7 +2165,7 @@ export const FeeRecordsTable = ({
                   Prev
                 </button>
                 <span
-                  className={`text-[11px] ${t.textSub} px-1 whitespace-nowrap`}
+                  className={`text-[13px] ${t.textSub} px-1 whitespace-nowrap`}
                 >
                   Page {currentPage + 1} of {pageCount}
                 </span>

--- a/src/components/cases/MyCaseDocumentsDialog.tsx
+++ b/src/components/cases/MyCaseDocumentsDialog.tsx
@@ -172,14 +172,14 @@ export function MyCaseDocumentsDialog({
                     />
                     <div className="flex-1 min-w-0">
                       <p
-                        className={`text-[13px] font-medium ${t.text} truncate`}
+                        className={`text-[15px] font-medium ${t.text} truncate`}
                         title={d.filename || d.name}
                       >
                         {d.filename || d.name}
                       </p>
                       {d.path && (
                         <p
-                          className={`text-[10px] ${t.textMuted} truncate`}
+                          className={`text-[12px] ${t.textMuted} truncate`}
                           title={d.path}
                         >
                           {d.path}
@@ -187,14 +187,14 @@ export function MyCaseDocumentsDialog({
                       )}
                     </div>
                     <div className="flex items-center gap-3 shrink-0">
-                      <span className={`text-[10px] ${t.textMuted}`}>
+                      <span className={`text-[12px] ${t.textMuted}`}>
                         {fmtDate(d.assigned_date || d.created_at)}
                       </span>
                       <a
                         href={`/api/mycase/documents/${d.id}/file`}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className={`inline-flex items-center gap-1 text-[11px] font-medium ${dark ? "text-indigo-400" : "text-indigo-600"} hover:underline`}
+                        className={`inline-flex items-center gap-1 text-[13px] font-medium ${dark ? "text-indigo-400" : "text-indigo-600"} hover:underline`}
                       >
                         View
                         <ExternalLink aria-hidden="true" className="h-3 w-3" />
@@ -202,7 +202,7 @@ export function MyCaseDocumentsDialog({
                     </div>
                   </div>
                   {d.description && (
-                    <p className={`mt-1 ml-7 text-[11px] ${t.textSub}`}>
+                    <p className={`mt-1 ml-7 text-[13px] ${t.textSub}`}>
                       {d.description}
                     </p>
                   )}

--- a/src/components/cases/RevenuePanel.tsx
+++ b/src/components/cases/RevenuePanel.tsx
@@ -38,7 +38,7 @@ export const RevenuePanel = ({ stats, cases }: RevenuePanelProps) => {
       <div className={`text-2xl font-extrabold ${t.text} mt-1`}>
         {fmtFull(stats.paid)}
       </div>
-      <div className={`text-[11px] font-medium mt-0.5 ${rateTone}`}>
+      <div className={`text-[13px] font-medium mt-0.5 ${rateTone}`}>
         {hasExpected
           ? `${rate.toFixed(1)}% collection rate`
           : "No fees expected yet"}
@@ -48,11 +48,11 @@ export const RevenuePanel = ({ stats, cases }: RevenuePanelProps) => {
         <ClaimTypeBarChart cases={cases} />
       </div>
       <div className="mt-3 flex items-center gap-4 justify-center">
-        <span className={`flex items-center gap-1.5 text-[10px] ${t.textSub}`}>
+        <span className={`flex items-center gap-1.5 text-[12px] ${t.textSub}`}>
           <span className="w-2.5 h-2.5 rounded-sm bg-indigo-400 opacity-30" />{" "}
           Expected
         </span>
-        <span className={`flex items-center gap-1.5 text-[10px] ${t.textSub}`}>
+        <span className={`flex items-center gap-1.5 text-[12px] ${t.textSub}`}>
           <span className="w-2.5 h-2.5 rounded-sm bg-emerald-500" /> Collected
         </span>
       </div>

--- a/src/components/cases/StatCards.tsx
+++ b/src/components/cases/StatCards.tsx
@@ -107,7 +107,7 @@ export const StatCards = ({ stats }: StatCardsProps) => {
                 {s.value}
               </div>
               {s.sub && (
-                <div className={`text-[11px] ${t.textMuted} mt-0.5`}>
+                <div className={`text-[13px] ${t.textMuted} mt-0.5`}>
                   {s.sub}
                 </div>
               )}
@@ -116,11 +116,11 @@ export const StatCards = ({ stats }: StatCardsProps) => {
           <div
             className={`mt-3 pt-2 border-t ${t.borderLight} flex items-center justify-between`}
           >
-            <span className={`text-[11px] ${t.textSub} font-medium`}>
+            <span className={`text-[13px] ${t.textSub} font-medium`}>
               Details
             </span>
             <span
-              className={`text-[11px] font-semibold flex items-center gap-0.5 ${toneClass(
+              className={`text-[13px] font-semibold flex items-center gap-0.5 ${toneClass(
                 s.detailTone,
               )}`}
             >

--- a/src/components/charts/ClaimTypeBarChart.tsx
+++ b/src/components/charts/ClaimTypeBarChart.tsx
@@ -38,7 +38,7 @@ export const ClaimTypeBarChart = ({ cases }: ClaimTypeBarChartProps) => {
 
   if (bars.length === 0) {
     return (
-      <div className="flex items-center justify-center h-36 text-[11px] text-neutral-400 dark:text-neutral-500">
+      <div className="flex items-center justify-center h-36 text-[13px] text-neutral-400 dark:text-neutral-500">
         No claim-type data yet
       </div>
     );
@@ -50,7 +50,7 @@ export const ClaimTypeBarChart = ({ cases }: ClaimTypeBarChartProps) => {
     <div className="flex items-end gap-6 justify-center h-36 px-4 overflow-x-auto">
       {bars.map((b) => (
         <div key={b.label} className="flex flex-col items-center gap-1 shrink-0">
-          <span className="text-[10px] text-neutral-400 dark:text-neutral-500 font-medium">
+          <span className="text-[12px] text-neutral-400 dark:text-neutral-500 font-medium">
             {fmt(b.expected)}
           </span>
           <div className="flex items-end gap-1">
@@ -70,7 +70,7 @@ export const ClaimTypeBarChart = ({ cases }: ClaimTypeBarChartProps) => {
               }}
             />
           </div>
-          <span className="text-[11px] text-neutral-500 dark:text-neutral-400 font-medium">
+          <span className="text-[13px] text-neutral-500 dark:text-neutral-400 font-medium">
             {b.label}
           </span>
         </div>

--- a/src/components/chronicle/ChroniclePull.tsx
+++ b/src/components/chronicle/ChroniclePull.tsx
@@ -546,10 +546,10 @@ export const ChroniclePull = () => {
   ) => (
     <div className="flex items-center gap-2">
       <Icon className={`h-3.5 w-3.5 ${t.textMuted} shrink-0`} />
-      <span className={`text-[11px] ${t.textMuted} w-28 shrink-0`}>
+      <span className={`text-[13px] ${t.textMuted} w-28 shrink-0`}>
         {label}
       </span>
-      <span className={`text-[12px] ${t.text}`}>{value || "\u2014"}</span>
+      <span className={`text-[14px] ${t.text}`}>{value || "\u2014"}</span>
     </div>
   );
 
@@ -570,7 +570,7 @@ export const ChroniclePull = () => {
               <h3 className={`text-sm font-bold ${t.text}`}>
                 Chronicle Legal Lookup
               </h3>
-              <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
+              <p className={`text-[13px] ${t.textMuted} mt-0.5`}>
                 Enter a Chronicle Client ID to pull case data
               </p>
             </div>
@@ -620,7 +620,7 @@ export const ChroniclePull = () => {
               <h3 className={`text-sm font-bold ${t.text}`}>
                 Search Clients
               </h3>
-              <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
+              <p className={`text-[13px] ${t.textMuted} mt-0.5`}>
                 Find a Chronicle client by name, last-4 SSN, or external ID
                 (fields are combined). Useful for cases where you don&apos;t
                 know the Chronicle ID.
@@ -688,7 +688,7 @@ export const ChroniclePull = () => {
               {searching ? "Searching..." : "Search"}
             </button>
             {searchResults && (
-              <span className={`text-[11px] ${t.textMuted}`}>
+              <span className={`text-[13px] ${t.textMuted}`}>
                 {searchResults.length} result
                 {searchResults.length === 1 ? "" : "s"}
               </span>
@@ -700,13 +700,13 @@ export const ChroniclePull = () => {
               className={`mt-3 rounded-lg border p-2.5 flex items-center gap-2 ${dark ? "bg-red-900/20 border-red-800 text-red-400" : "bg-red-50 border-red-200 text-red-700"}`}
             >
               <AlertCircle className="h-3.5 w-3.5 shrink-0" />
-              <span className="text-[12px]">{searchError}</span>
+              <span className="text-[14px]">{searchError}</span>
             </div>
           )}
 
           {searchResults && searchResults.length > 0 && (
             <div className="mt-3 overflow-x-auto">
-              <table className="w-full text-[12px]">
+              <table className="w-full text-[14px]">
                 <thead>
                   <tr className={`text-left ${t.textMuted}`}>
                     <th className="py-1.5 pr-3 font-medium">Chronicle ID</th>
@@ -749,7 +749,7 @@ export const ChroniclePull = () => {
                       <td className="py-1.5 pr-3">
                         <button
                           onClick={() => handlePull(String(r.clientId))}
-                          className={`inline-flex items-center gap-1 h-7 px-2 rounded-md text-[11px] font-semibold border ${t.outlineBtn}`}
+                          className={`inline-flex items-center gap-1 h-7 px-2 rounded-md text-[13px] font-semibold border ${t.outlineBtn}`}
                           title="Pull this client into the lookup above"
                         >
                           <ArrowRight className="h-3 w-3" /> Pull
@@ -763,7 +763,7 @@ export const ChroniclePull = () => {
           )}
 
           {searchResults && searchResults.length === 0 && !searchError && (
-            <p className={`mt-3 text-[12px] ${t.textMuted}`}>
+            <p className={`mt-3 text-[14px] ${t.textMuted}`}>
               No clients matched.
             </p>
           )}
@@ -792,7 +792,7 @@ export const ChroniclePull = () => {
           className={`rounded-xl border p-3 flex items-center gap-2.5 ${dark ? "bg-amber-900/20 border-amber-800 text-amber-400" : "bg-amber-50 border-amber-200 text-amber-700"}`}
         >
           <AlertCircle className="h-3.5 w-3.5 shrink-0" />
-          <span className="text-[11px]">
+          <span className="text-[13px]">
             Using mock data \u2014 set CHRONICLE_API_URL and CHRONICLE_API_KEY
             in .env.local
           </span>
@@ -862,7 +862,7 @@ export const ChroniclePull = () => {
             <div className="flex items-center gap-2">
               {result.existsInDb ? (
                 <span
-                  className={`text-[10px] font-semibold px-2 py-1 rounded ${dark ? "bg-blue-900/40 text-blue-400" : "bg-blue-100 text-blue-700"}`}
+                  className={`text-[12px] font-semibold px-2 py-1 rounded ${dark ? "bg-blue-900/40 text-blue-400" : "bg-blue-100 text-blue-700"}`}
                 >
                   Already in DB #{result.matchedClientId}
                 </span>
@@ -887,7 +887,7 @@ export const ChroniclePull = () => {
           <div className="p-4 grid grid-cols-1 lg:grid-cols-2 gap-6">
             <div className="space-y-3">
               <p
-                className={`text-[10px] font-semibold uppercase tracking-wider ${t.textMuted}`}
+                className={`text-[12px] font-semibold uppercase tracking-wider ${t.textMuted}`}
               >
                 Client Information
               </p>
@@ -911,7 +911,7 @@ export const ChroniclePull = () => {
               {infoRow(MapPin, "Office", result.parsed.officeWithJurisdiction)}
               <div className="pt-2">
                 <p
-                  className={`text-[10px] font-semibold uppercase tracking-wider ${t.textMuted} mb-2`}
+                  className={`text-[12px] font-semibold uppercase tracking-wider ${t.textMuted} mb-2`}
                 >
                   Claim Details
                 </p>
@@ -935,7 +935,7 @@ export const ChroniclePull = () => {
 
             <div className="space-y-3">
               <p
-                className={`text-[10px] font-semibold uppercase tracking-wider ${t.textMuted}`}
+                className={`text-[12px] font-semibold uppercase tracking-wider ${t.textMuted}`}
               >
                 Decisions
               </p>
@@ -945,7 +945,7 @@ export const ChroniclePull = () => {
               </div>
               <div className="pt-2">
                 <p
-                  className={`text-[10px] font-semibold uppercase tracking-wider ${t.textMuted} mb-2`}
+                  className={`text-[12px] font-semibold uppercase tracking-wider ${t.textMuted} mb-2`}
                 >
                   Key Dates
                 </p>
@@ -995,7 +995,7 @@ export const ChroniclePull = () => {
               {result.parsed.aljName && (
                 <div className="pt-2">
                   <p
-                    className={`text-[10px] font-semibold uppercase tracking-wider ${t.textMuted} mb-2`}
+                    className={`text-[12px] font-semibold uppercase tracking-wider ${t.textMuted} mb-2`}
                   >
                     Hearing Info
                   </p>
@@ -1021,7 +1021,7 @@ export const ChroniclePull = () => {
                 <span className={`text-xs font-bold ${t.text}`}>
                   PDF Data Extraction
                 </span>
-                <span className={`ml-2 text-[10px] ${t.textMuted}`}>
+                <span className={`ml-2 text-[12px] ${t.textMuted}`}>
                   Fields not available from API
                 </span>
               </div>
@@ -1046,7 +1046,7 @@ export const ChroniclePull = () => {
             )}
             {pdfData && (
               <span
-                className={`text-[10px] font-medium px-2 py-1 rounded ${dark ? "bg-emerald-900/30 text-emerald-400" : "bg-emerald-50 text-emerald-700"}`}
+                className={`text-[12px] font-medium px-2 py-1 rounded ${dark ? "bg-emerald-900/30 text-emerald-400" : "bg-emerald-50 text-emerald-700"}`}
               >
                 ✓ {pdfData.totalPages} pages parsed
               </span>
@@ -1080,21 +1080,21 @@ export const ChroniclePull = () => {
               <div
                 className={`flex items-center justify-between py-2 mb-2 border-b ${t.borderLight}`}
               >
-                <span className={`text-[11px] ${t.textMuted}`}>
+                <span className={`text-[13px] ${t.textMuted}`}>
                   {selectedPdfFields.size} of {availablePdfFieldCount} fields
                   selected for import
                 </span>
                 <div className="flex items-center gap-2">
                   <button
                     onClick={selectAllPdfFields}
-                    className={`text-[10px] font-medium ${dark ? "text-violet-400 hover:text-violet-300" : "text-violet-600 hover:text-violet-700"}`}
+                    className={`text-[12px] font-medium ${dark ? "text-violet-400 hover:text-violet-300" : "text-violet-600 hover:text-violet-700"}`}
                   >
                     Select All
                   </button>
-                  <span className={`text-[10px] ${t.textMuted}`}>|</span>
+                  <span className={`text-[12px] ${t.textMuted}`}>|</span>
                   <button
                     onClick={deselectAllPdfFields}
-                    className={`text-[10px] font-medium ${dark ? "text-neutral-400 hover:text-neutral-300" : "text-neutral-500 hover:text-neutral-600"}`}
+                    className={`text-[12px] font-medium ${dark ? "text-neutral-400 hover:text-neutral-300" : "text-neutral-500 hover:text-neutral-600"}`}
                   >
                     None
                   </button>
@@ -1119,7 +1119,7 @@ export const ChroniclePull = () => {
                           className={`h-3.5 w-3.5 ${dark ? "text-violet-400" : "text-violet-600"}`}
                         />
                         <span
-                          className={`text-[10px] font-semibold uppercase tracking-wider ${t.textMuted}`}
+                          className={`text-[12px] font-semibold uppercase tracking-wider ${t.textMuted}`}
                         >
                           {group.label}
                         </span>
@@ -1149,13 +1149,13 @@ export const ChroniclePull = () => {
                               />
                               <div className="min-w-0 flex-1">
                                 <span
-                                  className={`text-[11px] font-medium ${t.text}`}
+                                  className={`text-[13px] font-medium ${t.text}`}
                                 >
                                   {field.label}
                                 </span>
                                 {displayVal && (
                                   <p
-                                    className={`text-[10px] ${t.textMuted} truncate`}
+                                    className={`text-[12px] ${t.textMuted} truncate`}
                                   >
                                     {displayVal}
                                   </p>
@@ -1175,7 +1175,7 @@ export const ChroniclePull = () => {
                 <div
                   className={`mt-4 pt-3 border-t ${t.borderLight} flex items-center justify-between`}
                 >
-                  <span className={`text-[11px] ${t.textMuted}`}>
+                  <span className={`text-[13px] ${t.textMuted}`}>
                     {selectedPdfFields.size > 0
                       ? `${selectedPdfFields.size} PDF fields will be saved with import`
                       : "No PDF fields selected — only Chronicle API data will be imported"}
@@ -1201,7 +1201,7 @@ export const ChroniclePull = () => {
 
           {/* Not yet parsed hint */}
           {!pdfData && !parsingPdf && !pdfError && (
-            <div className={`px-4 py-3 text-[11px] ${t.textMuted}`}>
+            <div className={`px-4 py-3 text-[13px] ${t.textMuted}`}>
               Click &quot;Parse PDF&quot; to extract diagnoses, fee info, DLI,
               representative details, and more from the Chronicle file.
             </div>
@@ -1243,30 +1243,30 @@ export const ChroniclePull = () => {
                   />
                 )}
                 <div className="flex-1 min-w-0">
-                  <span className={`text-[12px] font-semibold ${t.text}`}>
+                  <span className={`text-[14px] font-semibold ${t.text}`}>
                     {pr.parsed.lastName}, {pr.parsed.firstName}
                   </span>
-                  <span className={`ml-2 text-[10px] ${t.textMuted}`}>
+                  <span className={`ml-2 text-[12px] ${t.textMuted}`}>
                     #{pr.parsed.chronicleClientId}
                   </span>
                 </div>
                 <span
-                  className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${t.pillBg}`}
+                  className={`text-[12px] font-medium px-1.5 py-0.5 rounded ${t.pillBg}`}
                 >
                   {fmtClaim(pr.parsed.claimType)}
                 </span>
-                <span className={`text-[10px] ${t.textMuted}`}>
+                <span className={`text-[12px] ${t.textMuted}`}>
                   {pr.parsed.caseLevel}
                 </span>
                 {pr.existsInDb ? (
                   <span
-                    className={`text-[10px] px-1.5 py-0.5 rounded ${dark ? "bg-blue-900/30 text-blue-400" : "bg-blue-50 text-blue-600"}`}
+                    className={`text-[12px] px-1.5 py-0.5 rounded ${dark ? "bg-blue-900/30 text-blue-400" : "bg-blue-50 text-blue-600"}`}
                   >
                     In DB
                   </span>
                 ) : (
                   <span
-                    className={`text-[10px] px-1.5 py-0.5 rounded ${dark ? "bg-emerald-900/30 text-emerald-400" : "bg-emerald-50 text-emerald-600"}`}
+                    className={`text-[12px] px-1.5 py-0.5 rounded ${dark ? "bg-emerald-900/30 text-emerald-400" : "bg-emerald-50 text-emerald-600"}`}
                   >
                     New
                   </span>
@@ -1288,7 +1288,7 @@ export const ChroniclePull = () => {
             Enter a Chronicle Client ID above to pull case data. Favorable
             decisions can be imported directly into the dashboard.
           </p>
-          <p className={`text-[10px] ${t.textMuted} mt-3`}>
+          <p className={`text-[12px] ${t.textMuted} mt-3`}>
             Mock IDs for testing: 112221, 112222, 112223, 112224
           </p>
         </div>

--- a/src/components/fee-petitions/CompletedPetitions.tsx
+++ b/src/components/fee-petitions/CompletedPetitions.tsx
@@ -225,8 +225,8 @@ export const CompletedPetitions = ({ dark }: Props) => {
   const isInitialLoad = loading && rows.length === 0;
   const isRefreshing = loading && rows.length > 0;
 
-  const thBase = `py-2 px-3 text-[10px] font-semibold uppercase tracking-wider whitespace-nowrap`;
-  const tdBase = `py-2 px-3 text-[12px] whitespace-nowrap`;
+  const thBase = `py-2 px-3 text-[12px] font-semibold uppercase tracking-wider whitespace-nowrap`;
+  const tdBase = `py-2 px-3 text-[14px] whitespace-nowrap`;
   const rowBorder = dark ? "border-neutral-800/50" : "border-neutral-100";
   const rowHover = dark ? "hover:bg-neutral-800/40" : "hover:bg-neutral-50/80";
   const stickyHeaderBg = dark ? "bg-neutral-900" : "bg-white";
@@ -256,7 +256,7 @@ export const CompletedPetitions = ({ dark }: Props) => {
           <span className={`text-sm font-bold ${t.text}`}>Completed Petitions</span>
           {total != null && total > 0 && (
             <span
-              className={`inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold ${
+              className={`inline-flex items-center px-2 py-0.5 rounded-full text-[13px] font-semibold ${
                 dark ? "bg-emerald-900/40 text-emerald-300" : "bg-emerald-100 text-emerald-700"
               }`}
             >
@@ -280,13 +280,13 @@ export const CompletedPetitions = ({ dark }: Props) => {
                   <Loader2 aria-hidden="true" className={`h-3 w-3 animate-spin ${t.textMuted}`} />
                 )}
               </p>
-              <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
+              <p className={`text-[13px] ${t.textMuted} mt-0.5`}>
                 {safeTotal === 0
                   ? "0 petitions"
                   : `Showing ${rangeStart}–${rangeEnd} of ${safeTotal} petitions`}
               </p>
               {safeTotal > 0 && (
-                <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
+                <p className={`text-[13px] ${t.textMuted} mt-0.5`}>
                   Fees Requested {fmt(totals.feeRequested)} · Fees Received {fmt(totals.feesReceived)}
                 </p>
               )}
@@ -453,7 +453,7 @@ export const CompletedPetitions = ({ dark }: Props) => {
                             {row.claimant}
                           </Link>
                           {row.updatedAt && (
-                            <p className={`text-[10px] ${t.textMuted} mt-0.5 font-normal`}>
+                            <p className={`text-[12px] ${t.textMuted} mt-0.5 font-normal`}>
                               Completed {formatRelativeDate(row.updatedAt)}
                             </p>
                           )}
@@ -497,7 +497,7 @@ export const CompletedPetitions = ({ dark }: Props) => {
           {/* Pagination */}
           {safeTotal > pageSize && (
             <div className={`px-4 py-3 flex items-center justify-between border-t ${t.borderLight}`}>
-              <p className={`text-[11px] ${t.textMuted}`}>Page {page} of {totalPages}</p>
+              <p className={`text-[13px] ${t.textMuted}`}>Page {page} of {totalPages}</p>
               <div className="flex items-center gap-1">
                 <button
                   onClick={() => setPage((p) => Math.max(1, p - 1))}
@@ -506,7 +506,7 @@ export const CompletedPetitions = ({ dark }: Props) => {
                 >
                   <ChevronLeft aria-hidden="true" className="h-3.5 w-3.5" /> Prev
                 </button>
-                <span className={`text-[11px] px-2 ${t.textMuted}`}>{page} / {totalPages}</span>
+                <span className={`text-[13px] px-2 ${t.textMuted}`}>{page} / {totalPages}</span>
                 <button
                   onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
                   disabled={page >= totalPages || loading}

--- a/src/components/fee-petitions/FeePetitions.tsx
+++ b/src/components/fee-petitions/FeePetitions.tsx
@@ -737,16 +737,16 @@ export const FeePetitions = () => {
   const isRefreshing = loading && rows.length > 0;
 
   const sectionCard = `rounded-xl border ${t.card}`;
-  const thBase = `py-2 px-3 text-[10px] font-semibold uppercase tracking-wider whitespace-nowrap`;
-  const tdBase = `py-2 px-3 text-[12px] whitespace-nowrap`;
+  const thBase = `py-2 px-3 text-[12px] font-semibold uppercase tracking-wider whitespace-nowrap`;
+  const tdBase = `py-2 px-3 text-[14px] whitespace-nowrap`;
   const rowBorder = dark ? "border-neutral-800/50" : "border-neutral-100";
   const rowHover = dark ? "hover:bg-neutral-800/40" : "hover:bg-neutral-50/80";
   const stickyHeaderBg = dark ? "bg-neutral-900" : "bg-white";
-  const chipBase = `inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium ${dark ? "bg-neutral-700 text-neutral-200" : "bg-neutral-100 text-neutral-700"}`;
+  const chipBase = `inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[13px] font-medium ${dark ? "bg-neutral-700 text-neutral-200" : "bg-neutral-100 text-neutral-700"}`;
   const presetActive = dark
     ? "bg-indigo-700 border-indigo-600 text-white"
     : "bg-indigo-100 border-indigo-400 text-indigo-800";
-  const presetBase = `shrink-0 px-2.5 py-1 rounded-full text-[11px] font-medium border transition-colors`;
+  const presetBase = `shrink-0 px-2.5 py-1 rounded-full text-[13px] font-medium border transition-colors`;
   const colSpan = CHECKBOX_COLUMNS.length + 8;
 
   return (
@@ -776,7 +776,7 @@ export const FeePetitions = () => {
           </div>
           <div>
             <h3 className={`text-sm font-bold ${t.text}`}>Fee Petitions</h3>
-            <p className={`text-[11px] ${t.textMuted} mt-0.5`}>Track and manage fee petition filings</p>
+            <p className={`text-[13px] ${t.textMuted} mt-0.5`}>Track and manage fee petition filings</p>
           </div>
         </div>
       </div>
@@ -790,9 +790,9 @@ export const FeePetitions = () => {
           { label: "Fees Received", value: allTotals == null ? "—" : fmt(allTotals.feesReceived), sub: "pending + completed petitions" },
         ].map((s) => (
           <div key={s.label} className={`${sectionCard} p-4`}>
-            <p className={`text-[10px] font-semibold uppercase tracking-wider ${t.textMuted}`}>{s.label}</p>
+            <p className={`text-[12px] font-semibold uppercase tracking-wider ${t.textMuted}`}>{s.label}</p>
             <p className={`text-xl font-bold mt-1 ${t.text}`}>{s.value}</p>
-            <p className={`text-[10px] ${t.textMuted} mt-0.5`}>{s.sub}</p>
+            <p className={`text-[12px] ${t.textMuted} mt-0.5`}>{s.sub}</p>
           </div>
         ))}
       </div>
@@ -901,7 +901,7 @@ export const FeePetitions = () => {
                     <Loader2 aria-label="Refreshing" className={`h-3 w-3 animate-spin ${t.textMuted}`} />
                   )}
                 </h3>
-                <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
+                <p className={`text-[13px] ${t.textMuted} mt-0.5`}>
                   {total === 0 ? "0 petitions" : `Showing ${rangeStart}–${rangeEnd} of ${total} petitions`}
                 </p>
               </>
@@ -969,7 +969,7 @@ export const FeePetitions = () => {
 
         {/* Quick filter presets */}
         <div className={`px-4 py-2 flex items-center gap-2 flex-wrap border-b ${t.borderLight}`}>
-          <span className={`text-[10px] font-semibold uppercase tracking-wider ${t.textMuted} shrink-0`}>Quick:</span>
+          <span className={`text-[12px] font-semibold uppercase tracking-wider ${t.textMuted} shrink-0`}>Quick:</span>
           <button
             onClick={() => { urlMethodRef.current = "push"; setTouchedFilter((v) => (v === "none" ? "" : "none")); setPage(1); }}
             className={`${presetBase} ${touchedFilter === "none" ? presetActive : t.outlineBtn}`}
@@ -1027,7 +1027,7 @@ export const FeePetitions = () => {
                 </button>
               </span>
             )}
-            <button onClick={clearAllFilters} className={`text-[11px] font-medium underline ${t.textMuted} hover:opacity-70`}>
+            <button onClick={clearAllFilters} className={`text-[13px] font-medium underline ${t.textMuted} hover:opacity-70`}>
               Clear all
             </button>
           </div>
@@ -1176,7 +1176,7 @@ export const FeePetitions = () => {
                           {row.claimant}
                         </Link>
                         {row.updatedAt && (
-                          <p className={`text-[10px] ${t.textMuted} mt-0.5 font-normal`}>
+                          <p className={`text-[12px] ${t.textMuted} mt-0.5 font-normal`}>
                             Updated {formatRelativeDate(row.updatedAt)}
                           </p>
                         )}
@@ -1227,7 +1227,7 @@ export const FeePetitions = () => {
                         <div className="flex items-center gap-1.5">
                           <span>{fmtDate(row.approvalDate)}</span>
                           {daysSince(row.approvalDate) != null && (
-                            <span className={`text-[10px] font-semibold px-1 rounded ${dark ? "bg-neutral-700 text-neutral-300" : "bg-neutral-100 text-neutral-500"}`}>
+                            <span className={`text-[12px] font-semibold px-1 rounded ${dark ? "bg-neutral-700 text-neutral-300" : "bg-neutral-100 text-neutral-500"}`}>
                               {daysSince(row.approvalDate)}d
                             </span>
                           )}
@@ -1242,7 +1242,7 @@ export const FeePetitions = () => {
                               style={{ width: `${(completedCount / CHECKBOX_COLUMNS.length) * 100}%` }}
                             />
                           </div>
-                          <span className={`text-[11px] font-semibold ${isComplete ? (dark ? "text-emerald-400" : "text-emerald-600") : t.textMuted}`}>
+                          <span className={`text-[13px] font-semibold ${isComplete ? (dark ? "text-emerald-400" : "text-emerald-600") : t.textMuted}`}>
                             {completedCount}/{CHECKBOX_COLUMNS.length}
                           </span>
                         </div>
@@ -1277,7 +1277,7 @@ export const FeePetitions = () => {
 
         {/* Pagination footer */}
         <div className={`px-4 py-3 flex items-center justify-between border-t ${t.borderLight}`}>
-          <p className={`text-[11px] ${t.textMuted}`}>Page {page} of {totalPages}</p>
+          <p className={`text-[13px] ${t.textMuted}`}>Page {page} of {totalPages}</p>
           <div className="flex items-center gap-1">
             <button
               onClick={() => { urlMethodRef.current = "push"; setPage((p) => Math.max(1, p - 1)); }}
@@ -1308,7 +1308,7 @@ export const FeePetitions = () => {
                 onBlur={(e) => { e.target.value = String(page); }}
                 className={`h-8 w-12 px-1 rounded-md border text-xs text-center outline-none focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-600 disabled:opacity-40 ${t.inputBg}`}
               />
-              <span className={`text-[11px] ${t.textMuted}`}>/ {totalPages}</span>
+              <span className={`text-[13px] ${t.textMuted}`}>/ {totalPages}</span>
             </div>
             <button
               onClick={() => { urlMethodRef.current = "push"; setPage((p) => Math.min(totalPages, p + 1)); }}

--- a/src/components/inbound-calls/InboundCallsClient.tsx
+++ b/src/components/inbound-calls/InboundCallsClient.tsx
@@ -357,7 +357,7 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
 
   const card = `rounded-xl border ${t.card}`;
   const inputCls = `w-full text-xs bg-transparent border-0 outline-none focus:ring-1 focus:ring-blue-500 rounded px-1.5 py-1 ${t.text} placeholder:${t.textMuted}`;
-  const thCls = `px-3 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider ${t.textMuted} whitespace-nowrap`;
+  const thCls = `px-3 py-2.5 text-left text-[13px] font-semibold uppercase tracking-wider ${t.textMuted} whitespace-nowrap`;
   const tdCls = `px-2 py-1.5 align-top`;
 
   // ── render ─────────────────────────────────────────────────────────────────
@@ -387,7 +387,7 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
           </div>
           <div>
             <h2 className={`text-sm font-bold ${t.text}`}>Inbound Call History</h2>
-            <p className={`text-[11px] ${t.textMuted}`}>POC schedule and call log by week</p>
+            <p className={`text-[13px] ${t.textMuted}`}>POC schedule and call log by week</p>
           </div>
         </div>
 
@@ -399,7 +399,7 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
           >
             {weekLabel(selectedWeek)}
             {isCurrentWeek(selectedWeek) && (
-              <span className={`text-[10px] px-1.5 py-0.5 rounded-full ${dark ? "bg-blue-900/50 text-blue-300" : "bg-blue-100 text-blue-600"}`}>
+              <span className={`text-[12px] px-1.5 py-0.5 rounded-full ${dark ? "bg-blue-900/50 text-blue-300" : "bg-blue-100 text-blue-600"}`}>
                 This week
               </span>
             )}
@@ -418,7 +418,7 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
                   }`}
                 >
                   <span>{weekLabel(w)}</span>
-                  {isCurrentWeek(w) && <span className={`text-[10px] ${dark ? "text-blue-400" : "text-blue-500"}`}>Now</span>}
+                  {isCurrentWeek(w) && <span className={`text-[12px] ${dark ? "text-blue-400" : "text-blue-500"}`}>Now</span>}
                 </button>
               ))}
             </div>
@@ -433,7 +433,7 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
           {isAdmin && !pocEditMode && (
             <button
               onClick={() => { setPocDraft({ ...pocAssignments }); setPocEditMode(true); }}
-              className={`text-[11px] px-2.5 py-1 rounded-lg border transition-colors ${dark ? "border-neutral-600 text-neutral-300 hover:border-neutral-400" : "border-neutral-200 text-neutral-600 hover:border-neutral-400"}`}
+              className={`text-[13px] px-2.5 py-1 rounded-lg border transition-colors ${dark ? "border-neutral-600 text-neutral-300 hover:border-neutral-400" : "border-neutral-200 text-neutral-600 hover:border-neutral-400"}`}
             >
               Edit schedule
             </button>
@@ -442,14 +442,14 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
             <div className="flex items-center gap-2">
               <button
                 onClick={() => setPocEditMode(false)}
-                className={`text-[11px] px-2.5 py-1 rounded-lg border transition-colors ${dark ? "border-neutral-600 text-neutral-400 hover:border-neutral-400" : "border-neutral-200 text-neutral-500 hover:border-neutral-400"}`}
+                className={`text-[13px] px-2.5 py-1 rounded-lg border transition-colors ${dark ? "border-neutral-600 text-neutral-400 hover:border-neutral-400" : "border-neutral-200 text-neutral-500 hover:border-neutral-400"}`}
               >
                 Cancel
               </button>
               <button
                 onClick={savePoc}
                 disabled={pocSaving}
-                className="text-[11px] px-2.5 py-1 rounded-lg bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 transition-colors flex items-center gap-1.5"
+                className="text-[13px] px-2.5 py-1 rounded-lg bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 transition-colors flex items-center gap-1.5"
               >
                 {pocSaving && <RefreshCw aria-hidden="true" className="h-3 w-3 animate-spin" />}
                 <Save aria-hidden="true" className="h-3 w-3" />
@@ -476,7 +476,7 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
                 key={num}
                 className={`rounded-lg border p-3 min-h-[90px] ${dark ? "border-neutral-700 bg-neutral-800/40" : "border-neutral-200 bg-neutral-50/60"}`}
               >
-                <p className={`text-[11px] font-semibold mb-2 ${t.textMuted}`}>{label}</p>
+                <p className={`text-[13px] font-semibold mb-2 ${t.textMuted}`}>{label}</p>
                 {pocEditMode && isAdmin ? (
                   <div className="space-y-1.5">
                     {teamMembers.map((name) => {
@@ -496,7 +496,7 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
                             }}
                             className="h-3 w-3 rounded accent-blue-500"
                           />
-                          <span className={`text-[11px] ${t.text} truncate`}>{name}</span>
+                          <span className={`text-[13px] ${t.text} truncate`}>{name}</span>
                         </label>
                       );
                     })}
@@ -506,14 +506,14 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
                     {assigned.map((name) => (
                       <span
                         key={name}
-                        className={`text-[10px] px-2 py-0.5 rounded-full font-medium ${dark ? "bg-blue-900/40 text-blue-300" : "bg-blue-100 text-blue-700"}`}
+                        className={`text-[12px] px-2 py-0.5 rounded-full font-medium ${dark ? "bg-blue-900/40 text-blue-300" : "bg-blue-100 text-blue-700"}`}
                       >
                         {name}
                       </span>
                     ))}
                   </div>
                 ) : (
-                  <span className={`text-[11px] italic ${t.textMuted}`}>No POC assigned</span>
+                  <span className={`text-[13px] italic ${t.textMuted}`}>No POC assigned</span>
                 )}
               </div>
             );
@@ -527,13 +527,13 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
           <span className={`text-xs font-semibold ${t.text}`}>
             Call Log
             {records.length > 0 && (
-              <span className={`ml-2 text-[11px] font-normal ${t.textMuted}`}>{records.length} record{records.length !== 1 ? "s" : ""}</span>
+              <span className={`ml-2 text-[13px] font-normal ${t.textMuted}`}>{records.length} record{records.length !== 1 ? "s" : ""}</span>
             )}
           </span>
           <div className="flex items-center gap-2">
             <button
               onClick={() => setCsvImportOpen(true)}
-              className={`flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg border transition-colors ${dark ? "border-neutral-600 text-neutral-300 hover:border-neutral-400" : "border-neutral-200 text-neutral-600 hover:border-neutral-400"}`}
+              className={`flex items-center gap-1.5 text-[13px] px-2.5 py-1 rounded-lg border transition-colors ${dark ? "border-neutral-600 text-neutral-300 hover:border-neutral-400" : "border-neutral-200 text-neutral-600 hover:border-neutral-400"}`}
               aria-label="Import call records from CSV"
             >
               <Upload aria-hidden="true" className="h-3 w-3" />
@@ -542,7 +542,7 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
             <button
               onClick={addRow}
               disabled={addingRow}
-              className="flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
+              className="flex items-center gap-1.5 text-[13px] px-2.5 py-1 rounded-lg bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
             >
               {addingRow
                 ? <RefreshCw aria-hidden="true" className="h-3 w-3 animate-spin" />
@@ -672,13 +672,13 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
                         <div className="flex items-center gap-1">
                           <button
                             onClick={() => confirmDelete(row.id)}
-                            className="text-[10px] px-1.5 py-0.5 rounded bg-red-500 text-white hover:bg-red-600 transition-colors"
+                            className="text-[12px] px-1.5 py-0.5 rounded bg-red-500 text-white hover:bg-red-600 transition-colors"
                           >
                             Delete
                           </button>
                           <button
                             onClick={() => setPendingDelete(null)}
-                            className={`text-[10px] px-1.5 py-0.5 rounded border transition-colors ${dark ? "border-neutral-600 text-neutral-400 hover:border-neutral-400" : "border-neutral-200 text-neutral-500 hover:border-neutral-400"}`}
+                            className={`text-[12px] px-1.5 py-0.5 rounded border transition-colors ${dark ? "border-neutral-600 text-neutral-400 hover:border-neutral-400" : "border-neutral-200 text-neutral-500 hover:border-neutral-400"}`}
                           >
                             Cancel
                           </button>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -134,7 +134,7 @@ export const Header = ({ dateRange, onDateRangeChange }: HeaderProps) => {
             >
               <div className="p-2">
                 <p
-                  className={`px-2 py-1 text-[10px] font-semibold uppercase ${t.textMuted}`}
+                  className={`px-2 py-1 text-[12px] font-semibold uppercase ${t.textMuted}`}
                 >
                   Quick Select
                 </p>
@@ -152,27 +152,27 @@ export const Header = ({ dateRange, onDateRangeChange }: HeaderProps) => {
               </div>
               <div className={`border-t ${t.borderLight} p-2`}>
                 <p
-                  className={`px-2 py-1 text-[10px] font-semibold uppercase ${t.textMuted}`}
+                  className={`px-2 py-1 text-[12px] font-semibold uppercase ${t.textMuted}`}
                 >
                   Custom Range
                 </p>
                 <div className="flex gap-2 px-2">
                   <div className="flex-1">
-                    <label className={`text-[10px] ${t.textMuted}`}>From</label>
+                    <label className={`text-[12px] ${t.textMuted}`}>From</label>
                     <input
                       type="date"
                       value={fromDate}
                       onChange={(e) => setFromDate(e.target.value)}
-                      className={`w-full h-7 px-2 rounded border text-[11px] outline-none ${t.inputBg}`}
+                      className={`w-full h-7 px-2 rounded border text-[13px] outline-none ${t.inputBg}`}
                     />
                   </div>
                   <div className="flex-1">
-                    <label className={`text-[10px] ${t.textMuted}`}>To</label>
+                    <label className={`text-[12px] ${t.textMuted}`}>To</label>
                     <input
                       type="date"
                       value={toDate}
                       onChange={(e) => setToDate(e.target.value)}
-                      className={`w-full h-7 px-2 rounded border text-[11px] outline-none ${t.inputBg}`}
+                      className={`w-full h-7 px-2 rounded border text-[13px] outline-none ${t.inputBg}`}
                     />
                   </div>
                 </div>
@@ -180,14 +180,14 @@ export const Header = ({ dateRange, onDateRangeChange }: HeaderProps) => {
                   <button
                     onClick={applyCustom}
                     disabled={!fromDate || !toDate}
-                    className={`flex-1 h-7 rounded text-[11px] font-semibold ${t.ctaBtn} disabled:opacity-40`}
+                    className={`flex-1 h-7 rounded text-[13px] font-semibold ${t.ctaBtn} disabled:opacity-40`}
                   >
                     Apply
                   </button>
                   {dateRange && (
                     <button
                       onClick={clearRange}
-                      className={`h-7 px-3 rounded text-[11px] border ${t.outlineBtn}`}
+                      className={`h-7 px-3 rounded text-[13px] border ${t.outlineBtn}`}
                     >
                       Clear
                     </button>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -232,10 +232,10 @@ export const Sidebar = ({ open, onToggle, onMobileClose }: SidebarProps) => {
               </div>
               {open && (
                 <div className="leading-tight">
-                  <div className={`text-[13px] font-bold ${t.text}`}>
+                  <div className={`text-[15px] font-bold ${t.text}`}>
                     Fee Collections
                   </div>
-                  <div className={`text-[10px] ${t.textMuted}`}>
+                  <div className={`text-[12px] ${t.textMuted}`}>
                     Hogan Smith Law
                   </div>
                 </div>
@@ -262,7 +262,7 @@ export const Sidebar = ({ open, onToggle, onMobileClose }: SidebarProps) => {
               <Search className="h-3.5 w-3.5" />
               <span>Search cases</span>
               <span
-                className={`ml-auto text-[10px] px-1 py-0.5 rounded border ${t.kbdBg}`}
+                className={`ml-auto text-[12px] px-1 py-0.5 rounded border ${t.kbdBg}`}
               >
                 {"\u2318"}K
               </span>
@@ -294,7 +294,7 @@ export const Sidebar = ({ open, onToggle, onMobileClose }: SidebarProps) => {
             <div key={group.section}>
               {open && (
                 <div
-                  className={`px-2 pt-4 pb-1 text-[10px] font-semibold ${t.textMuted} uppercase tracking-wider`}
+                  className={`px-2 pt-4 pb-1 text-[12px] font-semibold ${t.textMuted} uppercase tracking-wider`}
                 >
                   {group.section}
                 </div>
@@ -306,7 +306,7 @@ export const Sidebar = ({ open, onToggle, onMobileClose }: SidebarProps) => {
                     key={item.path}
                     href={item.path}
                     onClick={() => onMobileClose?.()}
-                    className={`w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-[13px] font-medium transition-colors ${open ? "" : "justify-center"} ${active ? `${t.activeNav} font-semibold` : `${t.textSub} ${t.hover}`}`}
+                    className={`w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-[15px] font-medium transition-colors ${open ? "" : "justify-center"} ${active ? `${t.activeNav} font-semibold` : `${t.textSub} ${t.hover}`}`}
                   >
                     <div className="relative shrink-0">
                       <item.icon
@@ -323,7 +323,7 @@ export const Sidebar = ({ open, onToggle, onMobileClose }: SidebarProps) => {
                       <span className="flex items-center gap-2 flex-1">
                         {item.label}
                         {item.path === "/notifications" && notifCount > 0 && (
-                          <span className="min-w-4 h-4 px-1 rounded-full bg-red-500 text-white text-[9px] font-bold flex items-center justify-center">
+                          <span className="min-w-4 h-4 px-1 rounded-full bg-red-500 text-white text-[11px] font-bold flex items-center justify-center">
                             {notifCount > 99 ? "99+" : notifCount}
                           </span>
                         )}
@@ -351,7 +351,7 @@ export const Sidebar = ({ open, onToggle, onMobileClose }: SidebarProps) => {
                   setUserMenuOpen(false);
                   setChangePasswordOpen(true);
                 }}
-                className={`w-full flex items-center gap-2 px-3 py-2 text-[13px] font-medium text-left transition-colors ${t.textSub} ${dark ? "hover:bg-neutral-800" : "hover:bg-neutral-50"}`}
+                className={`w-full flex items-center gap-2 px-3 py-2 text-[15px] font-medium text-left transition-colors ${t.textSub} ${dark ? "hover:bg-neutral-800" : "hover:bg-neutral-50"}`}
               >
                 <KeyRound aria-hidden="true" className="h-4 w-4 shrink-0" />
                 Change password
@@ -359,7 +359,7 @@ export const Sidebar = ({ open, onToggle, onMobileClose }: SidebarProps) => {
               <div className={`border-t ${t.borderLight}`} />
               <button
                 onClick={() => signOut({ callbackUrl: "/login" })}
-                className={`w-full flex items-center gap-2 px-3 py-2 text-[13px] font-medium text-left transition-colors ${dark ? "text-red-400 hover:bg-neutral-800" : "text-red-600 hover:bg-neutral-50"}`}
+                className={`w-full flex items-center gap-2 px-3 py-2 text-[15px] font-medium text-left transition-colors ${dark ? "text-red-400 hover:bg-neutral-800" : "text-red-600 hover:bg-neutral-50"}`}
               >
                 <LogOut aria-hidden="true" className="h-4 w-4 shrink-0" />
                 Sign out
@@ -378,11 +378,11 @@ export const Sidebar = ({ open, onToggle, onMobileClose }: SidebarProps) => {
                 {userInitial}
               </div>
               <div className="flex-1 min-w-0 text-left">
-                <div className={`text-[12px] font-semibold ${t.text} truncate`}>
+                <div className={`text-[14px] font-semibold ${t.text} truncate`}>
                   {userName}
                 </div>
                 {userEmail && (
-                  <div className={`text-[10px] ${t.textMuted} truncate`}>
+                  <div className={`text-[12px] ${t.textMuted} truncate`}>
                     {userEmail}
                   </div>
                 )}
@@ -452,7 +452,7 @@ export const Sidebar = ({ open, onToggle, onMobileClose }: SidebarProps) => {
               {searchQuery && searchResults.length > 0 && (
                 <div className="px-2 py-2">
                   <p
-                    className={`px-3 py-1.5 text-[10px] font-semibold uppercase ${t.textMuted}`}
+                    className={`px-3 py-1.5 text-[12px] font-semibold uppercase ${t.textMuted}`}
                   >
                     Cases ({searchResults.length})
                   </p>
@@ -466,16 +466,16 @@ export const Sidebar = ({ open, onToggle, onMobileClose }: SidebarProps) => {
                         <span className={`text-sm font-semibold ${t.text}`}>
                           {c.name}
                         </span>
-                        <span className={`ml-2 text-[10px] ${t.textMuted}`}>
+                        <span className={`ml-2 text-[12px] ${t.textMuted}`}>
                           #{c.id}
                         </span>
                       </div>
                       <span
-                        className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${t.pillBg}`}
+                        className={`text-[12px] font-medium px-1.5 py-0.5 rounded ${t.pillBg}`}
                       >
                         {fmtClaim(c.claim)}
                       </span>
-                      <span className={`text-[10px] ${t.textMuted}`}>
+                      <span className={`text-[12px] ${t.textMuted}`}>
                         {c.assigned}
                       </span>
                     </button>
@@ -497,7 +497,7 @@ export const Sidebar = ({ open, onToggle, onMobileClose }: SidebarProps) => {
               {!searchQuery && (
                 <div className="px-2 py-2">
                   <p
-                    className={`px-3 py-1.5 text-[10px] font-semibold uppercase ${t.textMuted}`}
+                    className={`px-3 py-1.5 text-[12px] font-semibold uppercase ${t.textMuted}`}
                   >
                     Quick Navigation
                   </p>
@@ -532,13 +532,13 @@ export const Sidebar = ({ open, onToggle, onMobileClose }: SidebarProps) => {
             <div
               className={`border-t ${t.borderLight} px-4 py-2 flex items-center gap-4`}
             >
-              <span className={`text-[10px] ${t.textMuted}`}>
+              <span className={`text-[12px] ${t.textMuted}`}>
                 {"\u2191\u2193"} Navigate
               </span>
-              <span className={`text-[10px] ${t.textMuted}`}>
+              <span className={`text-[12px] ${t.textMuted}`}>
                 {"\u21B5"} Select
               </span>
-              <span className={`text-[10px] ${t.textMuted}`}>esc Close</span>
+              <span className={`text-[12px] ${t.textMuted}`}>esc Close</span>
             </div>
           </div>
         </div>

--- a/src/components/modals/AddCaseModal.tsx
+++ b/src/components/modals/AddCaseModal.tsx
@@ -194,7 +194,7 @@ export default function AddCaseModal({
     }
   };
 
-  const lblCls = `block text-[10px] font-semibold uppercase tracking-wider mb-1 ${t.textMuted}`;
+  const lblCls = `block text-[12px] font-semibold uppercase tracking-wider mb-1 ${t.textMuted}`;
   const inputCls = `h-9 w-full px-3 rounded-md border text-sm outline-none ${t.inputBg}`;
 
   return (
@@ -228,7 +228,7 @@ export default function AddCaseModal({
             >
               <div className="flex items-start gap-3">
                 <CheckCircle2 className="h-5 w-5 mt-0.5 shrink-0" />
-                <div className="text-[13px]">
+                <div className="text-[15px]">
                   <p className="font-bold">
                     Case created for {form.firstName} {form.lastName}.
                   </p>
@@ -301,18 +301,18 @@ export default function AddCaseModal({
                   )}
                 </div>
                 {form.chronicleUrl.trim() !== "" && !form.chronicleId && (
-                  <p className="mt-2 text-[11px] text-amber-600 dark:text-amber-400">
+                  <p className="mt-2 text-[13px] text-amber-600 dark:text-amber-400">
                     Couldn’t read a Chronicle client id from that — paste the
                     full client URL or just the numeric id.
                   </p>
                 )}
                 {caseLinkMissingAlj && (
-                  <p className="mt-2 text-[11px] text-amber-600 dark:text-amber-400">
+                  <p className="mt-2 text-[13px] text-amber-600 dark:text-amber-400">
                     No “v.” separator found — ALJ wasn’t captured. Add it as
                     “… v. ALJ NAME” or fill the ALJ fields below.
                   </p>
                 )}
-                <p className={`mt-2 text-[11px] ${t.textMuted}`}>
+                <p className={`mt-2 text-[13px] ${t.textMuted}`}>
                   Fills Client ID, name, approval date, and ALJ below — all
                   editable.
                 </p>
@@ -330,13 +330,13 @@ export default function AddCaseModal({
                     className={`${inputCls} ${clientIdStatus === "duplicate" ? "border-red-500 dark:border-red-600" : ""}`}
                   />
                   {clientIdStatus === "checking" && (
-                    <p className={`mt-1 text-[11px] flex items-center gap-1 ${t.textMuted}`}>
+                    <p className={`mt-1 text-[13px] flex items-center gap-1 ${t.textMuted}`}>
                       <RefreshCw className="h-3 w-3 animate-spin" aria-hidden="true" />
                       Checking…
                     </p>
                   )}
                   {clientIdStatus === "duplicate" && (
-                    <p className="mt-1 text-[11px] text-red-600 dark:text-red-400 flex items-center gap-1" role="alert">
+                    <p className="mt-1 text-[13px] text-red-600 dark:text-red-400 flex items-center gap-1" role="alert">
                       <AlertCircle className="h-3 w-3 shrink-0" aria-hidden="true" />
                       Already exists: {duplicateName}
                     </p>
@@ -454,7 +454,7 @@ export default function AddCaseModal({
                   />
                 </div>
               </div>
-              <p className={`mt-4 text-[11px] ${t.textMuted}`}>
+              <p className={`mt-4 text-[13px] ${t.textMuted}`}>
                 Fees and amounts start at zero — edit them from the case row
                 after creating it.
               </p>

--- a/src/components/modals/CsvImportModal.tsx
+++ b/src/components/modals/CsvImportModal.tsx
@@ -209,7 +209,7 @@ export default function CsvImportModal({
 
   const activeStepIndex = STEPS.findIndex((s) => s.id === step);
 
-  const lblCls = `text-[10px] font-semibold uppercase tracking-wider ${t.textMuted}`;
+  const lblCls = `text-[12px] font-semibold uppercase tracking-wider ${t.textMuted}`;
   const errBg = dark
     ? "bg-red-900/20 border-red-800 text-red-300"
     : "bg-red-50 border-red-200 text-red-700";
@@ -231,7 +231,7 @@ export default function CsvImportModal({
         <div className={`flex items-center justify-between px-5 py-3 border-b ${t.borderLight}`}>
           <div>
             <h3 className={`text-sm font-bold ${t.text}`}>{title}</h3>
-            <p className={`text-[11px] ${t.textMuted} mt-0.5`}>{description}</p>
+            <p className={`text-[13px] ${t.textMuted} mt-0.5`}>{description}</p>
           </div>
           <button
             onClick={onClose}
@@ -251,7 +251,7 @@ export default function CsvImportModal({
               return (
                 <div
                   key={s.id}
-                  className={`text-center py-1.5 rounded-md text-[11px] font-medium transition-colors ${
+                  className={`text-center py-1.5 rounded-md text-[13px] font-medium transition-colors ${
                     isActive
                       ? dark ? "bg-neutral-100 text-neutral-900" : "bg-neutral-900 text-white"
                       : isDone
@@ -300,12 +300,12 @@ export default function CsvImportModal({
                 <p className={`text-sm font-semibold ${t.text}`}>
                   {fileName ?? "Drag & drop a CSV file, or click to browse"}
                 </p>
-                <p className={`text-[11px] mt-1 ${t.textMuted}`}>Only .csv files. Any column names — you'll map them in the next step.</p>
+                <p className={`text-[13px] mt-1 ${t.textMuted}`}>Only .csv files. Any column names — you'll map them in the next step.</p>
               </div>
 
               {/* Header row selector */}
               <div className={`flex items-center gap-3 px-1`}>
-                <label className={`text-[11px] font-medium ${t.textSub} shrink-0`}>
+                <label className={`text-[13px] font-medium ${t.textSub} shrink-0`}>
                   Column headers are on row:
                 </label>
                 <div className="flex items-center gap-1">
@@ -317,7 +317,7 @@ export default function CsvImportModal({
                         setHeaderRow(n);
                         if (fileText) parseAndAdvance(fileText, n);
                       }}
-                      className={`h-7 w-7 rounded-md border text-[11px] font-semibold transition-colors ${
+                      className={`h-7 w-7 rounded-md border text-[13px] font-semibold transition-colors ${
                         headerRow === n
                           ? dark ? "bg-neutral-100 text-neutral-900 border-neutral-100" : "bg-neutral-900 text-white border-neutral-900"
                           : `${t.outlineBtn}`
@@ -327,7 +327,7 @@ export default function CsvImportModal({
                     </button>
                   ))}
                 </div>
-                <p className={`text-[11px] ${t.textMuted}`}>
+                <p className={`text-[13px] ${t.textMuted}`}>
                   {headerRow > 1 ? `Rows 1–${headerRow - 1} will be skipped as metadata.` : "Row 1 is the header row."}
                 </p>
               </div>
@@ -337,13 +337,13 @@ export default function CsvImportModal({
                   <span className={lblCls}>Dashboard fields available for import</span>
                   <button
                     onClick={downloadTemplate}
-                    className={`text-[11px] font-medium underline ${t.textSub} hover:opacity-80`}
+                    className={`text-[13px] font-medium underline ${t.textSub} hover:opacity-80`}
                   >
                     Download template
                   </button>
                 </div>
                 <div className="overflow-x-auto">
-                  <table className="w-full text-[11px]">
+                  <table className="w-full text-[13px]">
                     <thead>
                       <tr className={`border-b ${t.borderLight} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"}`}>
                         <th className={`${lblCls} text-left px-3 py-2`}>Field</th>
@@ -358,11 +358,11 @@ export default function CsvImportModal({
                           <td className={`${t.textSub} px-3 py-1.5`}>{col.hint ?? "—"}</td>
                           <td className="px-3 py-1.5 text-center">
                             {col.required ? (
-                              <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${dark ? "bg-red-900/40 text-red-400" : "bg-red-50 text-red-600"}`}>
+                              <span className={`text-[12px] font-semibold px-1.5 py-0.5 rounded ${dark ? "bg-red-900/40 text-red-400" : "bg-red-50 text-red-600"}`}>
                                 YES
                               </span>
                             ) : (
-                              <span className={`text-[10px] ${t.textMuted}`}>opt</span>
+                              <span className={`text-[12px] ${t.textMuted}`}>opt</span>
                             )}
                           </td>
                         </tr>
@@ -377,7 +377,7 @@ export default function CsvImportModal({
           {/* ── STEP 2: MAP COLUMNS ── */}
           {step === "map" && (
             <>
-              <div className={`rounded-md border p-3 text-[11px] ${dark ? "bg-neutral-800/60 border-neutral-700 text-neutral-300" : "bg-neutral-50 border-neutral-200 text-neutral-600"}`}>
+              <div className={`rounded-md border p-3 text-[13px] ${dark ? "bg-neutral-800/60 border-neutral-700 text-neutral-300" : "bg-neutral-50 border-neutral-200 text-neutral-600"}`}>
                 <p>
                   Your file has <span className="font-semibold">{csvHeaders.length} columns</span> and{" "}
                   <span className="font-semibold">{csvRows.length} rows</span>.
@@ -387,7 +387,7 @@ export default function CsvImportModal({
               </div>
 
               {requiredUnmapped.length > 0 && (
-                <div role="alert" className={`rounded-md border p-3 text-[11px] flex items-start gap-2 ${warnBg}`}>
+                <div role="alert" className={`rounded-md border p-3 text-[13px] flex items-start gap-2 ${warnBg}`}>
                   <AlertTriangle className="h-3.5 w-3.5 shrink-0 mt-0.5" aria-hidden="true" />
                   <span>
                     Required field{requiredUnmapped.length !== 1 ? "s" : ""} not yet mapped:{" "}
@@ -397,7 +397,7 @@ export default function CsvImportModal({
               )}
 
               <div className={`rounded-lg border ${t.borderLight} overflow-hidden`}>
-                <table className="w-full text-[12px]">
+                <table className="w-full text-[14px]">
                   <thead>
                     <tr className={`border-b ${t.borderLight} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"}`}>
                       <th className={`${lblCls} text-left px-3 py-2`}>Dashboard field</th>
@@ -417,7 +417,7 @@ export default function CsvImportModal({
                               <span className="ml-1 text-red-500" aria-label="required">*</span>
                             )}
                           </td>
-                          <td className={`px-3 py-2 ${t.textMuted} text-[11px] hidden sm:table-cell`}>
+                          <td className={`px-3 py-2 ${t.textMuted} text-[13px] hidden sm:table-cell`}>
                             {col.hint ?? "—"}
                           </td>
                           <td className="px-3 py-2">
@@ -426,7 +426,7 @@ export default function CsvImportModal({
                               onChange={(e) =>
                                 setMapping((prev) => ({ ...prev, [col.key]: e.target.value }))
                               }
-                              className={`w-full h-7 px-2 rounded-md border text-[11px] outline-none cursor-pointer ${
+                              className={`w-full h-7 px-2 rounded-md border text-[13px] outline-none cursor-pointer ${
                                 isReqUnmapped
                                   ? dark ? "border-red-700 bg-neutral-900 text-red-300" : "border-red-300 bg-white text-red-700"
                                   : t.inputBg
@@ -446,7 +446,7 @@ export default function CsvImportModal({
               </div>
 
               {/* CSV header preview */}
-              <div className={`text-[11px] ${t.textMuted}`}>
+              <div className={`text-[13px] ${t.textMuted}`}>
                 Columns detected in your file:{" "}
                 {csvHeaders.map((h, i) => (
                   <span key={`${h}-${i}`}>
@@ -479,7 +479,7 @@ export default function CsvImportModal({
               </div>
 
               {errorRows.length > 0 && (
-                <div className={`rounded-md border p-3 text-[11px] ${warnBg}`}>
+                <div className={`rounded-md border p-3 text-[13px] ${warnBg}`}>
                   <div className="flex items-center gap-1.5 font-semibold mb-1">
                     <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
                     {errorRows.length} row{errorRows.length !== 1 ? "s" : ""} will be skipped
@@ -497,7 +497,7 @@ export default function CsvImportModal({
 
               <div className={`rounded-lg border ${t.borderLight} overflow-hidden`}>
                 <div className="overflow-x-auto max-h-72 overflow-y-auto">
-                  <table className="w-full text-[11px]">
+                  <table className="w-full text-[13px]">
                     <thead className="sticky top-0">
                       <tr className={`border-b ${t.borderLight} ${dark ? "bg-neutral-900" : "bg-neutral-50"}`}>
                         <th className={`${lblCls} text-left px-3 py-2 w-10`}>#</th>
@@ -529,11 +529,11 @@ export default function CsvImportModal({
                             <td className={`px-3 py-1.5 ${t.textMuted} tabular-nums`}>{row.rowNumber}</td>
                             <td className="px-3 py-1.5">
                               {hasError ? (
-                                <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${dark ? "bg-red-900/40 text-red-400" : "bg-red-100 text-red-700"}`}>
+                                <span className={`text-[12px] font-semibold px-1.5 py-0.5 rounded ${dark ? "bg-red-900/40 text-red-400" : "bg-red-100 text-red-700"}`}>
                                   ERR
                                 </span>
                               ) : (
-                                <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${dark ? "bg-emerald-900/40 text-emerald-400" : "bg-emerald-100 text-emerald-700"}`}>
+                                <span className={`text-[12px] font-semibold px-1.5 py-0.5 rounded ${dark ? "bg-emerald-900/40 text-emerald-400" : "bg-emerald-100 text-emerald-700"}`}>
                                   OK
                                 </span>
                               )}
@@ -553,7 +553,7 @@ export default function CsvImportModal({
                   </table>
                 </div>
                 {parsedRows.length > 200 && (
-                  <div className={`px-3 py-2 text-[11px] ${t.textMuted} border-t ${t.borderLight} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"}`}>
+                  <div className={`px-3 py-2 text-[13px] ${t.textMuted} border-t ${t.borderLight} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"}`}>
                     Showing first 200 of {parsedRows.length} rows. All valid rows will be imported.
                   </div>
                 )}
@@ -578,7 +578,7 @@ export default function CsvImportModal({
                 <div className={`max-w-md mx-auto rounded-lg border p-5 ${dark ? "bg-red-900/20 border-red-800 text-red-300" : "bg-red-50 border-red-200 text-red-800"}`}>
                   <div className="flex items-start gap-3">
                     <AlertTriangle className="h-5 w-5 mt-0.5 shrink-0" aria-hidden="true" />
-                    <p className="text-[13px] font-bold">{importResult.error}</p>
+                    <p className="text-[15px] font-bold">{importResult.error}</p>
                   </div>
                 </div>
               ) : (
@@ -590,7 +590,7 @@ export default function CsvImportModal({
                   }`}>
                     <div className="flex items-start gap-3">
                       <CheckCircle2 className="h-5 w-5 mt-0.5 shrink-0" aria-hidden="true" />
-                      <div className="text-[13px]">
+                      <div className="text-[15px]">
                         <p className="font-bold">
                           {importResult.imported} row{importResult.imported !== 1 ? "s" : ""} imported.
                         </p>
@@ -604,7 +604,7 @@ export default function CsvImportModal({
                   </div>
 
                   {importResult.rowErrors.length > 0 && (
-                    <div className={`mt-3 max-w-md mx-auto rounded-md border p-3 text-[11px] ${warnBg}`}>
+                    <div className={`mt-3 max-w-md mx-auto rounded-md border p-3 text-[13px] ${warnBg}`}>
                       <p className="font-semibold mb-1">Row errors:</p>
                       <ul className="space-y-0.5 max-h-32 overflow-y-auto">
                         {importResult.rowErrors.map((e, i) => (

--- a/src/components/modals/ImportCasesModal.tsx
+++ b/src/components/modals/ImportCasesModal.tsx
@@ -207,7 +207,7 @@ export default function ImportCasesModal({
     return false;
   };
 
-  const lblCls = `text-[10px] font-semibold uppercase tracking-wider ${t.textMuted}`;
+  const lblCls = `text-[12px] font-semibold uppercase tracking-wider ${t.textMuted}`;
 
   return (
     <div
@@ -255,10 +255,10 @@ export default function ImportCasesModal({
                         : "text-neutral-400"
                 }`}
               >
-                <div className="text-[10px] font-bold uppercase tracking-wider">
+                <div className="text-[12px] font-bold uppercase tracking-wider">
                   {s.title}
                 </div>
-                <div className="text-[12px] font-medium">{s.subtitle}</div>
+                <div className="text-[14px] font-medium">{s.subtitle}</div>
               </button>
             );
           })}
@@ -283,7 +283,7 @@ export default function ImportCasesModal({
                   Upload Spreadsheet
                 </h4>
               </div>
-              <p className={`text-[11px] ${t.textMuted} mb-4`}>
+              <p className={`text-[13px] ${t.textMuted} mb-4`}>
                 Upload your XLSX file and select the sheet tab to compare against
                 the cases database.
               </p>
@@ -327,7 +327,7 @@ export default function ImportCasesModal({
                 <p className={`text-sm font-semibold ${t.text}`}>
                   {file ? file.name : "Drag & drop your file here, or click to browse"}
                 </p>
-                <p className={`text-[11px] mt-1 ${t.textMuted}`}>
+                <p className={`text-[13px] mt-1 ${t.textMuted}`}>
                   {file
                     ? `${(file.size / 1024).toFixed(0)} KB${busy === "preview" ? " · parsing…" : ""}`
                     : "Supports .xlsx, .xls, and .csv files"}
@@ -369,14 +369,14 @@ export default function ImportCasesModal({
               <h4 className={`text-sm font-semibold ${t.text} mb-1`}>
                 Map Columns
               </h4>
-              <p className={`text-[11px] ${t.textMuted} mb-4`}>
+              <p className={`text-[13px] ${t.textMuted} mb-4`}>
                 The mapping below was auto-detected from your file&apos;s header row. All
                 columns shown are mapped automatically — no action needed unless you see
                 a missing required field.
               </p>
 
               <div className={`rounded-lg border ${t.borderLight} overflow-hidden`}>
-                <table className="w-full text-[12px]">
+                <table className="w-full text-[14px]">
                   <thead>
                     <tr
                       className={`border-b ${t.borderLight} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"}`}
@@ -398,18 +398,18 @@ export default function ImportCasesModal({
                         <td className={`${t.text} px-3 py-2 font-medium`}>
                           {m.sheet}
                         </td>
-                        <td className={`${t.textSub} px-3 py-2 font-mono text-[11px]`}>
+                        <td className={`${t.textSub} px-3 py-2 font-mono text-[13px]`}>
                           {m.db}
                         </td>
                         <td className="px-3 py-2 text-center">
                           {m.required ? (
                             <span
-                              className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${dark ? "bg-red-900/40 text-red-400" : "bg-red-50 text-red-600"}`}
+                              className={`text-[12px] font-semibold px-1.5 py-0.5 rounded ${dark ? "bg-red-900/40 text-red-400" : "bg-red-50 text-red-600"}`}
                             >
                               REQUIRED
                             </span>
                           ) : (
-                            <span className={`text-[10px] ${t.textMuted}`}>
+                            <span className={`text-[12px] ${t.textMuted}`}>
                               optional
                             </span>
                           )}
@@ -422,7 +422,7 @@ export default function ImportCasesModal({
 
               {preview && preview.summary.warnings.length > 0 && (
                 <div
-                  className={`mt-4 rounded-md border p-3 text-[11px] ${dark ? "bg-amber-900/20 border-amber-800 text-amber-300" : "bg-amber-50 border-amber-200 text-amber-800"}`}
+                  className={`mt-4 rounded-md border p-3 text-[13px] ${dark ? "bg-amber-900/20 border-amber-800 text-amber-300" : "bg-amber-50 border-amber-200 text-amber-800"}`}
                 >
                   <div className="flex items-center gap-1.5 font-semibold mb-1">
                     <AlertTriangle className="h-3.5 w-3.5" />
@@ -447,7 +447,7 @@ export default function ImportCasesModal({
               <h4 className={`text-sm font-semibold ${t.text} mb-1`}>
                 Compare & Preview
               </h4>
-              <p className={`text-[11px] ${t.textMuted} mb-3`}>
+              <p className={`text-[13px] ${t.textMuted} mb-3`}>
                 Rows already in the database (matched by MyCase ID) are flagged
                 as duplicates. Use Step 4 to choose which rows to import.
               </p>
@@ -490,12 +490,12 @@ export default function ImportCasesModal({
                   <h4 className={`text-sm font-semibold ${t.text}`}>
                     Select & Update
                   </h4>
-                  <p className={`text-[11px] ${t.textMuted}`}>
+                  <p className={`text-[13px] ${t.textMuted}`}>
                     Choose which rows to import. By default only new rows are
                     selected.
                   </p>
                 </div>
-                <div className={`text-[11px] ${t.textSub}`}>
+                <div className={`text-[13px] ${t.textSub}`}>
                   <span className={`font-bold ${t.text}`}>
                     {selected.size.toLocaleString()}
                   </span>{" "}
@@ -567,7 +567,7 @@ export default function ImportCasesModal({
               >
                 <div className="flex items-start gap-3">
                   <CheckCircle2 className="h-5 w-5 mt-0.5 shrink-0" />
-                  <div className="text-[13px]">
+                  <div className="text-[15px]">
                     <p className="font-bold">
                       Imported {result.inserted.toLocaleString()} case
                       {result.inserted === 1 ? "" : "s"}.
@@ -662,11 +662,11 @@ const Stat = ({
   accent?: string;
 }) => (
   <div className={`rounded-lg border ${t.borderLight} p-3`}>
-    <p className={`text-[10px] font-semibold uppercase tracking-wider ${t.textMuted}`}>
+    <p className={`text-[12px] font-semibold uppercase tracking-wider ${t.textMuted}`}>
       {label}
     </p>
     <p
-      className={`text-[18px] font-bold mt-0.5 tabular-nums ${accent ?? t.text}`}
+      className={`text-[20px] font-bold mt-0.5 tabular-nums ${accent ?? t.text}`}
     >
       {value}
     </p>
@@ -688,7 +688,7 @@ const PreviewTable = ({
 }) => (
   <div className={`rounded-lg border ${t.borderLight} overflow-hidden`}>
     <div className="overflow-x-auto">
-      <table className="w-full text-[12px]">
+      <table className="w-full text-[14px]">
         <thead>
           <tr
             className={`border-b ${t.borderLight} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"}`}
@@ -707,7 +707,7 @@ const PreviewTable = ({
             <tr key={r.clientId} className={`border-b ${t.borderLight}`}>
               <td className="px-3 py-1.5">
                 <span
-                  className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${
+                  className={`text-[12px] font-semibold px-1.5 py-0.5 rounded ${
                     r.isDuplicate
                       ? dark
                         ? "bg-amber-900/40 text-amber-400"
@@ -745,13 +745,13 @@ const PreviewTable = ({
                     target="_blank"
                     rel="noreferrer"
                     onClick={(e) => e.stopPropagation()}
-                    className={`text-[11px] underline ${dark ? "text-blue-400" : "text-blue-600"} inline-flex items-center gap-1`}
+                    className={`text-[13px] underline ${dark ? "text-blue-400" : "text-blue-600"} inline-flex items-center gap-1`}
                   >
                     {r.winSheetLinkText ?? "Open"}
                     <ExternalLink className="h-3 w-3" />
                   </a>
                 ) : (
-                  <span className={`text-[11px] ${t.textMuted}`}>
+                  <span className={`text-[13px] ${t.textMuted}`}>
                     {r.winSheetLinkText ?? "—"}
                   </span>
                 )}
@@ -761,11 +761,11 @@ const PreviewTable = ({
               </td>
               <td className="px-3 py-1.5 text-center">
                 {r.hasNotes ? (
-                  <span className={`text-[10px] font-semibold ${dark ? "text-blue-400" : "text-blue-600"}`}>
+                  <span className={`text-[12px] font-semibold ${dark ? "text-blue-400" : "text-blue-600"}`}>
                     YES
                   </span>
                 ) : (
-                  <span className={`text-[10px] ${t.textMuted}`}>—</span>
+                  <span className={`text-[12px] ${t.textMuted}`}>—</span>
                 )}
               </td>
             </tr>
@@ -775,7 +775,7 @@ const PreviewTable = ({
     </div>
     {truncated && (
       <div
-        className={`text-[11px] px-3 py-2 ${t.textMuted} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"} border-t ${t.borderLight}`}
+        className={`text-[13px] px-3 py-2 ${t.textMuted} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"} border-t ${t.borderLight}`}
       >
         Showing first 100 of {total.toLocaleString()} rows. All will be processed
         on import.
@@ -803,7 +803,7 @@ const SelectionTable = ({
 }) => (
   <div className={`rounded-lg border ${t.borderLight} overflow-hidden`}>
     <div className="overflow-x-auto">
-      <table className="w-full text-[12px]">
+      <table className="w-full text-[14px]">
         <thead>
           <tr
             className={`border-b ${t.borderLight} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"} sticky top-0`}
@@ -839,7 +839,7 @@ const SelectionTable = ({
                 </td>
                 <td className="px-3 py-1.5">
                   <span
-                    className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${
+                    className={`text-[12px] font-semibold px-1.5 py-0.5 rounded ${
                       r.isDuplicate
                         ? dark
                           ? "bg-amber-900/40 text-amber-400"
@@ -860,7 +860,7 @@ const SelectionTable = ({
                 </td>
                 <td className="px-3 py-1.5">
                   <span
-                    className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${STATUS_PILL[r.winSheetStatus] ?? STATUS_PILL.not_started}`}
+                    className={`text-[12px] font-semibold px-1.5 py-0.5 rounded ${STATUS_PILL[r.winSheetStatus] ?? STATUS_PILL.not_started}`}
                   >
                     {r.winSheetStatus.replace(/_/g, " ")}
                   </span>
@@ -873,7 +873,7 @@ const SelectionTable = ({
     </div>
     {truncated && (
       <div
-        className={`text-[11px] px-3 py-2 ${t.textMuted} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"} border-t ${t.borderLight}`}
+        className={`text-[13px] px-3 py-2 ${t.textMuted} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"} border-t ${t.borderLight}`}
       >
         Showing first 200 of {total.toLocaleString()} matching rows. All matches
         respect your selection.
@@ -890,7 +890,7 @@ const Th = ({
   alignRight?: boolean;
 }) => (
   <th
-    className={`text-[10px] font-semibold uppercase tracking-wider px-3 py-2 ${alignRight ? "text-right" : "text-left"}`}
+    className={`text-[12px] font-semibold uppercase tracking-wider px-3 py-2 ${alignRight ? "text-right" : "text-left"}`}
   >
     {children}
   </th>

--- a/src/components/modals/MyCaseSyncModal.tsx
+++ b/src/components/modals/MyCaseSyncModal.tsx
@@ -331,7 +331,7 @@ export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncM
 
   const syncableCount = effectiveRows.length;
 
-  const lblCls = `text-[10px] font-semibold uppercase tracking-wider ${t.textMuted}`;
+  const lblCls = `text-[12px] font-semibold uppercase tracking-wider ${t.textMuted}`;
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center" onClick={onClose}>
@@ -375,8 +375,8 @@ export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncM
                       : dark ? "text-neutral-500" : "text-neutral-400"
                 }`}
               >
-                <div className="text-[10px] font-bold uppercase tracking-wider">{s.title}</div>
-                <div className="text-[12px] font-medium">{s.subtitle}</div>
+                <div className="text-[12px] font-bold uppercase tracking-wider">{s.title}</div>
+                <div className="text-[14px] font-medium">{s.subtitle}</div>
               </button>
             );
           })}
@@ -403,7 +403,7 @@ export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncM
                 <CloudDownload className={`h-4 w-4 ${t.textSub}`} aria-hidden="true" />
                 <h4 className={`text-sm font-semibold ${t.text}`}>Fetch from MyCase</h4>
               </div>
-              <p className={`text-[11px] ${t.textMuted} mb-6`}>
+              <p className={`text-[13px] ${t.textMuted} mb-6`}>
                 Queries the MyCase mirror database for all cases with an approval date and compares
                 them against the fee collections database.
               </p>
@@ -412,7 +412,7 @@ export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncM
                 <div className={`rounded-lg border-2 border-dashed p-12 text-center ${dark ? "border-neutral-700" : "border-neutral-300"}`}>
                   <Database className={`h-10 w-10 mx-auto mb-3 ${t.textMuted}`} aria-hidden="true" />
                   <p className={`text-sm font-semibold ${t.text} mb-1`}>Ready to sync</p>
-                  <p className={`text-[11px] ${t.textMuted} mb-5`}>
+                  <p className={`text-[13px] ${t.textMuted} mb-5`}>
                     Click the button below to pull the latest data from the MyCase mirror database
                   </p>
                   <button
@@ -463,7 +463,7 @@ export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncM
                     />
                   </div>
                   {preview.summary.warnings.length > 0 && (
-                    <div className={`rounded-md border p-3 text-[11px] ${dark ? "bg-amber-900/20 border-amber-800 text-amber-300" : "bg-amber-50 border-amber-200 text-amber-800"}`}>
+                    <div className={`rounded-md border p-3 text-[13px] ${dark ? "bg-amber-900/20 border-amber-800 text-amber-300" : "bg-amber-50 border-amber-200 text-amber-800"}`}>
                       <div className="flex items-center gap-1.5 font-semibold mb-1">
                         <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
                         {preview.summary.warnings.length} warning{preview.summary.warnings.length === 1 ? "" : "s"}
@@ -494,12 +494,12 @@ export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncM
           {step === 2 && (
             <div>
               <h4 className={`text-sm font-semibold ${t.text} mb-1`}>Field Map</h4>
-              <p className={`text-[11px] ${t.textMuted} mb-4`}>
+              <p className={`text-[13px] ${t.textMuted} mb-4`}>
                 How MyCase custom fields map to the fee collections database. All mappings are
                 automatic — no action needed.
               </p>
               <div className={`rounded-lg border ${t.borderLight} overflow-hidden`}>
-                <table className="w-full text-[12px]">
+                <table className="w-full text-[14px]">
                   <thead>
                     <tr className={`border-b ${t.borderLight} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"}`}>
                       <th className={`${lblCls} text-left px-3 py-2`}>MyCase field</th>
@@ -510,15 +510,15 @@ export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncM
                   <tbody>
                     {FIELD_MAP.map((m) => (
                       <tr key={m.source} className={`border-b ${t.borderLight}`}>
-                        <td className={`${t.text} px-3 py-2 font-medium font-mono text-[11px]`}>{m.source}</td>
-                        <td className={`${t.textSub} px-3 py-2 font-mono text-[11px]`}>{m.db}</td>
+                        <td className={`${t.text} px-3 py-2 font-medium font-mono text-[13px]`}>{m.source}</td>
+                        <td className={`${t.textSub} px-3 py-2 font-mono text-[13px]`}>{m.db}</td>
                         <td className="px-3 py-2 text-center">
                           {m.required ? (
-                            <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${dark ? "bg-red-900/40 text-red-400" : "bg-red-50 text-red-600"}`}>
+                            <span className={`text-[12px] font-semibold px-1.5 py-0.5 rounded ${dark ? "bg-red-900/40 text-red-400" : "bg-red-50 text-red-600"}`}>
                               REQUIRED
                             </span>
                           ) : (
-                            <span className={`text-[10px] ${t.textMuted}`}>optional</span>
+                            <span className={`text-[12px] ${t.textMuted}`}>optional</span>
                           )}
                         </td>
                       </tr>
@@ -533,7 +533,7 @@ export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncM
           {step === 3 && preview && (
             <div>
               <h4 className={`text-sm font-semibold ${t.text} mb-1`}>Compare & Preview</h4>
-              <p className={`text-[11px] ${t.textMuted} mb-4`}>
+              <p className={`text-[13px] ${t.textMuted} mb-4`}>
                 Categories based on how each record compares between MyCase and the fee collections database.
               </p>
               <div className="grid grid-cols-2 sm:grid-cols-5 gap-3 mb-5">
@@ -569,11 +569,11 @@ export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncM
               <div className="flex items-center justify-between mb-2">
                 <div>
                   <h4 className={`text-sm font-semibold ${t.text}`}>Select & Sync</h4>
-                  <p className={`text-[11px] ${t.textMuted}`}>
+                  <p className={`text-[13px] ${t.textMuted}`}>
                     Choose which rows to import. New cases are inserted; existing cases are updated.
                   </p>
                 </div>
-                <div className={`text-[11px] ${t.textSub}`}>
+                <div className={`text-[13px] ${t.textSub}`}>
                   <span className={`font-bold ${t.text}`}>{selected.size.toLocaleString()}</span>
                   {" "}/ {syncableCount.toLocaleString()} syncable selected
                 </div>
@@ -649,7 +649,7 @@ export default function MyCaseSyncModal({ dark, onClose, onSynced }: MyCaseSyncM
               <div className={`max-w-md mx-auto rounded-lg border p-5 ${dark ? "bg-emerald-900/20 border-emerald-800 text-emerald-300" : "bg-emerald-50 border-emerald-200 text-emerald-800"}`}>
                 <div className="flex items-start gap-3">
                   <CheckCircle2 className="h-5 w-5 mt-0.5 shrink-0" aria-hidden="true" />
-                  <div className="text-[13px]">
+                  <div className="text-[15px]">
                     <p className="font-bold">Sync complete.</p>
                     <p className="opacity-90 mt-1">
                       <span className="font-semibold">{result.inserted.toLocaleString()}</span> new
@@ -736,8 +736,8 @@ const Stat = ({
   accent?: string;
 }) => (
   <div className={`rounded-lg border ${t.borderLight} p-3`}>
-    <p className={`text-[10px] font-semibold uppercase tracking-wider ${t.textMuted}`}>{label}</p>
-    <p className={`text-[18px] font-bold mt-0.5 tabular-nums ${accent ?? t.text}`}>{value}</p>
+    <p className={`text-[12px] font-semibold uppercase tracking-wider ${t.textMuted}`}>{label}</p>
+    <p className={`text-[20px] font-bold mt-0.5 tabular-nums ${accent ?? t.text}`}>{value}</p>
   </div>
 );
 
@@ -758,14 +758,14 @@ const CategorySection = ({
 }) => (
   <div>
     <div className="flex items-center gap-2 mb-2">
-      <span className={`text-[10px] font-semibold px-2 py-0.5 rounded ${STATUS_BADGE[status](dark)}`}>
+      <span className={`text-[12px] font-semibold px-2 py-0.5 rounded ${STATUS_BADGE[status](dark)}`}>
         {STATUS_LABEL[status]}
       </span>
-      <span className={`text-[11px] font-semibold tabular-nums ${t.text}`}>{count.toLocaleString()}</span>
-      <span className={`text-[11px] ${t.textMuted}`}>{description}</span>
+      <span className={`text-[13px] font-semibold tabular-nums ${t.text}`}>{count.toLocaleString()}</span>
+      <span className={`text-[13px] ${t.textMuted}`}>{description}</span>
     </div>
     {count === 0 ? (
-      <div className={`rounded-lg border ${t.borderLight} px-3 py-4 text-center text-[11px] ${t.textMuted}`}>None</div>
+      <div className={`rounded-lg border ${t.borderLight} px-3 py-4 text-center text-[13px] ${t.textMuted}`}>None</div>
     ) : (
       children
     )}
@@ -789,7 +789,7 @@ const SourceRowsTable = ({
 }) => (
   <div className={`rounded-lg border ${t.borderLight} overflow-hidden`}>
     <div className="overflow-x-auto">
-      <table className="w-full text-[12px]">
+      <table className="w-full text-[14px]">
         <thead>
           <tr className={`border-b ${t.borderLight} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"}`}>
             <Th>Case</Th>
@@ -820,7 +820,7 @@ const SourceRowsTable = ({
               </td>
               {showChangedFields && (
                 <td className="px-3 py-1.5 max-w-64">
-                  <div className={`text-[10px] font-mono space-y-0.5 ${dark ? "text-blue-300" : "text-blue-700"}`}>
+                  <div className={`text-[12px] font-mono space-y-0.5 ${dark ? "text-blue-300" : "text-blue-700"}`}>
                     {r.changedFields.slice(0, 3).map((f) => (
                       <div key={f.field} className="leading-tight">
                         <span className="font-semibold">{f.field}</span>
@@ -840,7 +840,7 @@ const SourceRowsTable = ({
               <td className={`${t.textSub} px-3 py-1.5 tabular-nums`}>{fmtDate(r.approvalDate)}</td>
               <td className={`${t.textSub} px-3 py-1.5`}>{r.assignedTo ?? "—"}</td>
               <td className="px-3 py-1.5">
-                <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${STATUS_PILL[r.winSheetStatus] ?? STATUS_PILL.not_started}`}>
+                <span className={`text-[12px] font-semibold px-1.5 py-0.5 rounded ${STATUS_PILL[r.winSheetStatus] ?? STATUS_PILL.not_started}`}>
                   {r.winSheetStatus.replace(/_/g, " ")}
                 </span>
               </td>
@@ -849,9 +849,9 @@ const SourceRowsTable = ({
               </td>
               <td className="px-3 py-1.5 text-center">
                 {r.hasNotes ? (
-                  <span className={`text-[10px] font-semibold ${dark ? "text-blue-400" : "text-blue-600"}`}>YES</span>
+                  <span className={`text-[12px] font-semibold ${dark ? "text-blue-400" : "text-blue-600"}`}>YES</span>
                 ) : (
-                  <span className={`text-[10px] ${t.textMuted}`}>—</span>
+                  <span className={`text-[12px] ${t.textMuted}`}>—</span>
                 )}
               </td>
             </tr>
@@ -860,7 +860,7 @@ const SourceRowsTable = ({
       </table>
     </div>
     {truncated && (
-      <div className={`text-[11px] px-3 py-2 ${t.textMuted} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"} border-t ${t.borderLight}`}>
+      <div className={`text-[13px] px-3 py-2 ${t.textMuted} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"} border-t ${t.borderLight}`}>
         Showing first 100 of {total.toLocaleString()} rows.
       </div>
     )}
@@ -878,7 +878,7 @@ const MissingRowsTable = ({
 }) => (
   <div className={`rounded-lg border ${t.borderLight} overflow-hidden`}>
     <div className="overflow-x-auto">
-      <table className="w-full text-[12px]">
+      <table className="w-full text-[14px]">
         <thead>
           <tr className={`border-b ${t.borderLight} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"}`}>
             <Th>Case</Th>
@@ -891,7 +891,7 @@ const MissingRowsTable = ({
             <tr key={r.clientId} className={`border-b ${t.borderLight}`}>
               <td className={`${t.text} px-3 py-1.5 font-medium`}>{r.caseName}</td>
               <td className={`${t.textSub} px-3 py-1.5 tabular-nums`}>{fmtDate(r.approvalDate)}</td>
-              <td className={`${t.textMuted} px-3 py-1.5 text-[11px] max-w-80 truncate`} title={r.caseLink}>
+              <td className={`${t.textMuted} px-3 py-1.5 text-[13px] max-w-80 truncate`} title={r.caseLink}>
                 {r.caseLink || "—"}
               </td>
             </tr>
@@ -921,7 +921,7 @@ const SelectionTable = ({
 }) => (
   <div className={`rounded-lg border ${t.borderLight} overflow-hidden`}>
     <div className="overflow-x-auto">
-      <table className="w-full text-[12px]">
+      <table className="w-full text-[14px]">
         <thead>
           <tr className={`border-b ${t.borderLight} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"} sticky top-0`}>
             <Th>{""}</Th>
@@ -959,7 +959,7 @@ const SelectionTable = ({
                   {r.caseName}
                 </td>
                 <td className="px-3 py-1.5">
-                  <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${STATUS_BADGE[r.status](dark)}`}>
+                  <span className={`text-[12px] font-semibold px-1.5 py-0.5 rounded ${STATUS_BADGE[r.status](dark)}`}>
                     {STATUS_LABEL[r.status]}
                   </span>
                 </td>
@@ -969,11 +969,11 @@ const SelectionTable = ({
                 </td>
                 <td className="px-3 py-1.5">
                   {"winSheetStatus" in r ? (
-                    <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${STATUS_PILL[r.winSheetStatus] ?? STATUS_PILL.not_started}`}>
+                    <span className={`text-[12px] font-semibold px-1.5 py-0.5 rounded ${STATUS_PILL[r.winSheetStatus] ?? STATUS_PILL.not_started}`}>
                       {r.winSheetStatus.replace(/_/g, " ")}
                     </span>
                   ) : (
-                    <span className={`text-[10px] ${t.textMuted}`}>—</span>
+                    <span className={`text-[12px] ${t.textMuted}`}>—</span>
                   )}
                 </td>
                 <td className="px-3 py-1.5 text-right">
@@ -981,7 +981,7 @@ const SelectionTable = ({
                     <button
                       onClick={(e) => { e.stopPropagation(); onTag(r.clientId); }}
                       title="Mark as viewed — hide from future new cases"
-                      className={`h-6 px-2 rounded text-[10px] font-medium flex items-center gap-1 ml-auto transition-colors ${dark ? "text-violet-400 hover:bg-violet-900/40" : "text-violet-600 hover:bg-violet-100"}`}
+                      className={`h-6 px-2 rounded text-[12px] font-medium flex items-center gap-1 ml-auto transition-colors ${dark ? "text-violet-400 hover:bg-violet-900/40" : "text-violet-600 hover:bg-violet-100"}`}
                     >
                       <Eye className="h-3 w-3" aria-hidden="true" />
                       Mark Viewed
@@ -991,7 +991,7 @@ const SelectionTable = ({
                     <button
                       onClick={(e) => { e.stopPropagation(); onUntag(r.clientId); }}
                       title="Unmark — restore to new"
-                      className={`h-6 px-2 rounded text-[10px] font-medium flex items-center gap-1 ml-auto transition-colors ${dark ? "text-neutral-400 hover:bg-neutral-700" : "text-neutral-500 hover:bg-neutral-200"}`}
+                      className={`h-6 px-2 rounded text-[12px] font-medium flex items-center gap-1 ml-auto transition-colors ${dark ? "text-neutral-400 hover:bg-neutral-700" : "text-neutral-500 hover:bg-neutral-200"}`}
                     >
                       <EyeOff className="h-3 w-3" aria-hidden="true" />
                       Unmark
@@ -1008,7 +1008,7 @@ const SelectionTable = ({
 );
 
 const Th = ({ children, alignRight }: { children: React.ReactNode; alignRight?: boolean }) => (
-  <th className={`text-[10px] font-semibold uppercase tracking-wider px-3 py-2 ${alignRight ? "text-right" : "text-left"}`}>
+  <th className={`text-[12px] font-semibold uppercase tracking-wider px-3 py-2 ${alignRight ? "text-right" : "text-left"}`}>
     {children}
   </th>
 );

--- a/src/components/modals/NotesModal.tsx
+++ b/src/components/modals/NotesModal.tsx
@@ -131,7 +131,7 @@ export default function NotesModal({
           <div>
             <h3 className={`text-sm font-bold ${t.text}`}>{isLeader ? "Leader Notes" : "Case Log"}</h3>
             <p
-              className={`text-[11px] ${t.textMuted} mt-0.5 truncate max-w-md`}
+              className={`text-[13px] ${t.textMuted} mt-0.5 truncate max-w-md`}
             >
               {caseName}
             </p>
@@ -146,7 +146,7 @@ export default function NotesModal({
 
         {/* Add New Note */}
         <div className="mb-6">
-          <label className={`block text-[11px] font-semibold ${t.text} mb-1.5`}>
+          <label className={`block text-[13px] font-semibold ${t.text} mb-1.5`}>
             Add New Note
           </label>
           <textarea
@@ -154,7 +154,7 @@ export default function NotesModal({
             onChange={(e) => setDraft(e.target.value)}
             placeholder="Enter your note…"
             rows={3}
-            className={`w-full px-3 py-2 rounded-md border text-[13px] outline-none resize-y ${t.inputBg}`}
+            className={`w-full px-3 py-2 rounded-md border text-[15px] outline-none resize-y ${t.inputBg}`}
           />
           <div className="mt-2 flex items-center gap-3">
             <button
@@ -167,7 +167,7 @@ export default function NotesModal({
             </button>
             {actionError && (
               <span
-                className={`text-[11px] ${dark ? "text-red-400" : "text-red-600"}`}
+                className={`text-[13px] ${dark ? "text-red-400" : "text-red-600"}`}
               >
                 {actionError}
               </span>
@@ -176,7 +176,7 @@ export default function NotesModal({
         </div>
 
         {/* History */}
-        <h4 className={`text-[11px] font-semibold ${t.text} mb-2`}>
+        <h4 className={`text-[13px] font-semibold ${t.text} mb-2`}>
           {isLeader ? "Notes History" : "Log History"} ({count})
         </h4>
 
@@ -211,11 +211,11 @@ export default function NotesModal({
             {notes.map((n) => (
               <div
                 key={n.id}
-                className={`relative rounded-lg border ${t.borderLight} p-3 text-[12px] leading-relaxed`}
+                className={`relative rounded-lg border ${t.borderLight} p-3 text-[14px] leading-relaxed`}
               >
                 <div className="flex items-start justify-between gap-2">
                   <div
-                    className={`flex items-center gap-2 mb-1.5 text-[10px] font-semibold uppercase tracking-wider ${t.textMuted}`}
+                    className={`flex items-center gap-2 mb-1.5 text-[12px] font-semibold uppercase tracking-wider ${t.textMuted}`}
                   >
                     <span>{n.createdBy ?? "—"}</span>
                     <span>·</span>
@@ -224,13 +224,13 @@ export default function NotesModal({
                   {canDelete &&
                     (confirmingId === n.id ? (
                       <div className="flex items-center gap-1.5 shrink-0">
-                        <span className={`text-[10px] ${t.textMuted}`}>
+                        <span className={`text-[12px] ${t.textMuted}`}>
                           Delete?
                         </span>
                         <button
                           onClick={() => deleteNote(n.id)}
                           disabled={deletingId === n.id}
-                          className={`h-6 px-2 rounded text-[10px] font-semibold flex items-center gap-1 disabled:opacity-50 ${dark ? "bg-red-900/40 text-red-300 hover:bg-red-900/60" : "bg-red-600 text-white hover:bg-red-700"}`}
+                          className={`h-6 px-2 rounded text-[12px] font-semibold flex items-center gap-1 disabled:opacity-50 ${dark ? "bg-red-900/40 text-red-300 hover:bg-red-900/60" : "bg-red-600 text-white hover:bg-red-700"}`}
                         >
                           {deletingId === n.id && (
                             <Loader2 className="h-3 w-3 animate-spin" />
@@ -240,7 +240,7 @@ export default function NotesModal({
                         <button
                           onClick={() => setConfirmingId(null)}
                           disabled={deletingId === n.id}
-                          className={`h-6 px-2 rounded border text-[10px] font-medium ${t.outlineBtn} disabled:opacity-50`}
+                          className={`h-6 px-2 rounded border text-[12px] font-medium ${t.outlineBtn} disabled:opacity-50`}
                         >
                           Cancel
                         </button>

--- a/src/components/modals/SheetSyncModal.tsx
+++ b/src/components/modals/SheetSyncModal.tsx
@@ -503,7 +503,7 @@ export default function SheetSyncModal({
     return false;
   };
 
-  const lblCls = `text-[10px] font-semibold uppercase tracking-wider ${t.textMuted}`;
+  const lblCls = `text-[12px] font-semibold uppercase tracking-wider ${t.textMuted}`;
 
   return (
     <div
@@ -558,8 +558,8 @@ export default function SheetSyncModal({
                         : "text-neutral-400"
                 }`}
               >
-                <div className="text-[10px] font-bold uppercase tracking-wider">{s.title}</div>
-                <div className="text-[12px] font-medium">{s.subtitle}</div>
+                <div className="text-[12px] font-bold uppercase tracking-wider">{s.title}</div>
+                <div className="text-[14px] font-medium">{s.subtitle}</div>
               </button>
             );
           })}
@@ -589,7 +589,7 @@ export default function SheetSyncModal({
                 <CloudDownload className={`h-4 w-4 ${t.textSub}`} aria-hidden="true" />
                 <h4 className={`text-sm font-semibold ${t.text}`}>Fetch from Google Sheets</h4>
               </div>
-              <p className={`text-[11px] ${t.textMuted} mb-6`}>
+              <p className={`text-[13px] ${t.textMuted} mb-6`}>
                 Pulls the latest rows from the MASTER LIST and Fees Closed tabs via the sync
                 webhook and compares them against the cases database.
               </p>
@@ -598,7 +598,7 @@ export default function SheetSyncModal({
                 <div className={`rounded-lg border-2 border-dashed p-12 text-center ${dark ? "border-neutral-700" : "border-neutral-300"}`}>
                   <FileSpreadsheet className={`h-10 w-10 mx-auto mb-3 ${t.textMuted}`} aria-hidden="true" />
                   <p className={`text-sm font-semibold ${t.text} mb-1`}>Ready to sync</p>
-                  <p className={`text-[11px] ${t.textMuted} mb-5`}>
+                  <p className={`text-[13px] ${t.textMuted} mb-5`}>
                     Click the button below to pull the latest data from Google Sheets
                   </p>
                   <button
@@ -621,7 +621,7 @@ export default function SheetSyncModal({
               {preview && !fetching && (
                 <div className="space-y-4">
                   {preview.usingMock && (
-                    <div className={`rounded-md border p-3 flex items-center gap-2 text-[11px] ${dark ? "bg-amber-900/20 border-amber-800 text-amber-300" : "bg-amber-50 border-amber-200 text-amber-700"}`}>
+                    <div className={`rounded-md border p-3 flex items-center gap-2 text-[13px] ${dark ? "bg-amber-900/20 border-amber-800 text-amber-300" : "bg-amber-50 border-amber-200 text-amber-700"}`}>
                       <AlertTriangle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
                       Using mock data — set{" "}
                       <code className="font-mono">SHEETS_SYNC_WEBHOOK_URL</code> in .env.local to
@@ -680,7 +680,7 @@ export default function SheetSyncModal({
                     />
                   </div>
                   {preview.summary.warnings.length > 0 && (
-                    <div className={`rounded-md border p-3 text-[11px] ${dark ? "bg-amber-900/20 border-amber-800 text-amber-300" : "bg-amber-50 border-amber-200 text-amber-800"}`}>
+                    <div className={`rounded-md border p-3 text-[13px] ${dark ? "bg-amber-900/20 border-amber-800 text-amber-300" : "bg-amber-50 border-amber-200 text-amber-800"}`}>
                       <div className="flex items-center gap-1.5 font-semibold mb-1">
                         <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
                         {preview.summary.warnings.length} warning
@@ -697,7 +697,7 @@ export default function SheetSyncModal({
                     </div>
                   )}
                   {needsLinkRows.length > 0 && (
-                    <div className={`rounded-md border p-3 text-[11px] ${dark ? "bg-red-900/20 border-red-800 text-red-300" : "bg-red-50 border-red-200 text-red-800"}`}>
+                    <div className={`rounded-md border p-3 text-[13px] ${dark ? "bg-red-900/20 border-red-800 text-red-300" : "bg-red-50 border-red-200 text-red-800"}`}>
                       <div className="flex items-center gap-1.5 font-semibold mb-1">
                         <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
                         {needsLinkRows.length} row{needsLinkRows.length === 1 ? "" : "s"} {needsLinkRows.length === 1 ? "has" : "have"} no MyCase link — skipped
@@ -715,7 +715,7 @@ export default function SheetSyncModal({
                               onChange={(e) =>
                                 setLinkOverrides((prev) => ({ ...prev, [r.row]: e.target.value }))
                               }
-                              className={`w-full h-6 px-2 rounded border text-[10px] outline-none focus:ring-1 focus:ring-neutral-400 dark:focus:ring-neutral-500 ${dark ? "bg-neutral-800 border-neutral-700 text-neutral-200 placeholder:text-neutral-600" : "bg-white border-neutral-300 text-neutral-800 placeholder:text-neutral-400"}`}
+                              className={`w-full h-6 px-2 rounded border text-[12px] outline-none focus:ring-1 focus:ring-neutral-400 dark:focus:ring-neutral-500 ${dark ? "bg-neutral-800 border-neutral-700 text-neutral-200 placeholder:text-neutral-600" : "bg-white border-neutral-300 text-neutral-800 placeholder:text-neutral-400"}`}
                             />
                           </li>
                         ))}
@@ -728,7 +728,7 @@ export default function SheetSyncModal({
                   {fcPreviewError && (
                     <div
                       role="alert"
-                      className={`rounded-md border p-3 text-[11px] flex items-start gap-2 ${dark ? "bg-amber-900/20 border-amber-800 text-amber-300" : "bg-amber-50 border-amber-200 text-amber-800"}`}
+                      className={`rounded-md border p-3 text-[13px] flex items-start gap-2 ${dark ? "bg-amber-900/20 border-amber-800 text-amber-300" : "bg-amber-50 border-amber-200 text-amber-800"}`}
                     >
                       <AlertTriangle className="h-3.5 w-3.5 shrink-0 mt-0.5" aria-hidden="true" />
                       <span>
@@ -753,12 +753,12 @@ export default function SheetSyncModal({
           {step === 2 && (
             <div>
               <h4 className={`text-sm font-semibold ${t.text} mb-1`}>Map Columns</h4>
-              <p className={`text-[11px] ${t.textMuted} mb-4`}>
+              <p className={`text-[13px] ${t.textMuted} mb-4`}>
                 The mapping below defines how Google Sheet columns write to the database. No action
                 needed — all columns are mapped automatically.
               </p>
               <div className={`rounded-lg border ${t.borderLight} overflow-hidden`}>
-                <table className="w-full text-[12px]">
+                <table className="w-full text-[14px]">
                   <thead>
                     <tr className={`border-b ${t.borderLight} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"}`}>
                       <th className={`${lblCls} text-left px-3 py-2`}>Sheet column</th>
@@ -770,14 +770,14 @@ export default function SheetSyncModal({
                     {COLUMN_MAP.map((m) => (
                       <tr key={m.sheet} className={`border-b ${t.borderLight}`}>
                         <td className={`${t.text} px-3 py-2 font-medium`}>{m.sheet}</td>
-                        <td className={`${t.textSub} px-3 py-2 font-mono text-[11px]`}>{m.db}</td>
+                        <td className={`${t.textSub} px-3 py-2 font-mono text-[13px]`}>{m.db}</td>
                         <td className="px-3 py-2 text-center">
                           {m.required ? (
-                            <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${dark ? "bg-red-900/40 text-red-400" : "bg-red-50 text-red-600"}`}>
+                            <span className={`text-[12px] font-semibold px-1.5 py-0.5 rounded ${dark ? "bg-red-900/40 text-red-400" : "bg-red-50 text-red-600"}`}>
                               REQUIRED
                             </span>
                           ) : (
-                            <span className={`text-[10px] ${t.textMuted}`}>optional</span>
+                            <span className={`text-[12px] ${t.textMuted}`}>optional</span>
                           )}
                         </td>
                       </tr>
@@ -792,7 +792,7 @@ export default function SheetSyncModal({
           {step === 3 && preview && (
             <div>
               <h4 className={`text-sm font-semibold ${t.text} mb-1`}>Compare & Preview</h4>
-              <p className={`text-[11px] ${t.textMuted} mb-4`}>
+              <p className={`text-[13px] ${t.textMuted} mb-4`}>
                 Four categories based on where each record exists.
               </p>
               <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-3 mb-5">
@@ -891,7 +891,7 @@ export default function SheetSyncModal({
                         </button>
                         <button
                           onClick={() => setSelectedMissing(new Set())}
-                          className={`text-[11px] ${dark ? "text-neutral-400 hover:text-neutral-200" : "text-neutral-500 hover:text-neutral-700"}`}
+                          className={`text-[13px] ${dark ? "text-neutral-400 hover:text-neutral-200" : "text-neutral-500 hover:text-neutral-700"}`}
                         >
                           Clear
                         </button>
@@ -940,7 +940,7 @@ export default function SheetSyncModal({
                         </button>
                         <button
                           onClick={() => setSelectedMissingClosed(new Set())}
-                          className={`text-[11px] ${dark ? "text-neutral-400 hover:text-neutral-200" : "text-neutral-500 hover:text-neutral-700"}`}
+                          className={`text-[13px] ${dark ? "text-neutral-400 hover:text-neutral-200" : "text-neutral-500 hover:text-neutral-700"}`}
                         >
                           Clear
                         </button>
@@ -981,12 +981,12 @@ export default function SheetSyncModal({
               <div className="flex items-center justify-between mb-2">
                 <div>
                   <h4 className={`text-sm font-semibold ${t.text}`}>Select & Sync</h4>
-                  <p className={`text-[11px] ${t.textMuted}`}>
+                  <p className={`text-[13px] ${t.textMuted}`}>
                     Choose which rows to sync. MASTER LIST rows are inserted or updated; Fees Closed
                     rows are marked closed and moved to the Fees Closed page.
                   </p>
                 </div>
-                <div className={`text-[11px] ${t.textSub}`}>
+                <div className={`text-[13px] ${t.textSub}`}>
                   <span className={`font-bold ${t.text}`}>{(selected.size + selectedFcNames.size).toLocaleString()}</span>
                   {" "}/ {(step4Rows.filter((r) => r.syncable).length + fcNewRows.length).toLocaleString()} syncable selected
                 </div>
@@ -1039,7 +1039,7 @@ export default function SheetSyncModal({
               </div>
 
               {syntheticRows.length > 0 && (
-                <div className={`rounded-md border p-3 mb-3 text-[11px] ${dark ? "bg-amber-900/20 border-amber-800 text-amber-300" : "bg-amber-50 border-amber-200 text-amber-800"}`}>
+                <div className={`rounded-md border p-3 mb-3 text-[13px] ${dark ? "bg-amber-900/20 border-amber-800 text-amber-300" : "bg-amber-50 border-amber-200 text-amber-800"}`}>
                   <div className="flex items-start gap-2">
                     <AlertTriangle className="h-3.5 w-3.5 shrink-0 mt-0.5" aria-hidden="true" />
                     <div className="flex-1">
@@ -1087,24 +1087,24 @@ export default function SheetSyncModal({
                 <div className="mt-5">
                   <div className="flex items-center justify-between mb-2">
                     <div className="flex items-center gap-2">
-                      <span className={`text-[10px] font-semibold px-2 py-0.5 rounded ${STATUS_BADGE.fees_closed_new(dark)}`}>
+                      <span className={`text-[12px] font-semibold px-2 py-0.5 rounded ${STATUS_BADGE.fees_closed_new(dark)}`}>
                         FEES CLOSED NEW
                       </span>
-                      <span className={`text-[11px] font-semibold tabular-nums ${t.text}`}>{fcNewRows.length.toLocaleString()}</span>
-                      <span className={`text-[11px] ${t.textMuted}`}>
+                      <span className={`text-[13px] font-semibold tabular-nums ${t.text}`}>{fcNewRows.length.toLocaleString()}</span>
+                      <span className={`text-[13px] ${t.textMuted}`}>
                         Not yet in database — will be created with isClosed=true
                       </span>
                     </div>
                     <div className="flex items-center gap-2">
                       <button
                         onClick={() => setSelectedFcNames(new Set(fcNewRows.map((r) => r.caseName)))}
-                        className={`h-7 px-2.5 rounded border text-[11px] font-medium ${t.outlineBtn} transition-colors`}
+                        className={`h-7 px-2.5 rounded border text-[13px] font-medium ${t.outlineBtn} transition-colors`}
                       >
                         Select all
                       </button>
                       <button
                         onClick={() => setSelectedFcNames(new Set())}
-                        className={`h-7 px-2.5 rounded border text-[11px] font-medium ${t.outlineBtn} transition-colors`}
+                        className={`h-7 px-2.5 rounded border text-[13px] font-medium ${t.outlineBtn} transition-colors`}
                       >
                         Deselect all
                       </button>
@@ -1129,7 +1129,7 @@ export default function SheetSyncModal({
 
           {/* STEP 4 inline results */}
           {step === 4 && result && (
-            <div role="alert" className={`mt-4 rounded-lg border p-3 flex items-start gap-2.5 text-[12px] ${dark ? "bg-emerald-900/20 border-emerald-800 text-emerald-300" : "bg-emerald-50 border-emerald-200 text-emerald-800"}`}>
+            <div role="alert" className={`mt-4 rounded-lg border p-3 flex items-start gap-2.5 text-[14px] ${dark ? "bg-emerald-900/20 border-emerald-800 text-emerald-300" : "bg-emerald-50 border-emerald-200 text-emerald-800"}`}>
               <CheckCircle2 className="h-4 w-4 mt-0.5 shrink-0" aria-hidden="true" />
               <span>
                 <span className="font-semibold">Master list synced.</span>{" "}
@@ -1138,7 +1138,7 @@ export default function SheetSyncModal({
             </div>
           )}
           {step === 4 && fcResult && (
-            <div role="alert" className={`mt-3 rounded-lg border p-3 flex items-start gap-2.5 text-[12px] ${dark ? "bg-teal-900/20 border-teal-800 text-teal-300" : "bg-teal-50 border-teal-200 text-teal-800"}`}>
+            <div role="alert" className={`mt-3 rounded-lg border p-3 flex items-start gap-2.5 text-[14px] ${dark ? "bg-teal-900/20 border-teal-800 text-teal-300" : "bg-teal-50 border-teal-200 text-teal-800"}`}>
               <CheckCircle2 className="h-4 w-4 mt-0.5 shrink-0" aria-hidden="true" />
               <span>
                 <span className="font-semibold">Fees Closed synced.</span>{" "}
@@ -1215,8 +1215,8 @@ const Stat = ({
   accent?: string;
 }) => (
   <div className={`rounded-lg border ${t.borderLight} p-3`}>
-    <p className={`text-[10px] font-semibold uppercase tracking-wider ${t.textMuted}`}>{label}</p>
-    <p className={`text-[18px] font-bold mt-0.5 tabular-nums ${accent ?? t.text}`}>{value}</p>
+    <p className={`text-[12px] font-semibold uppercase tracking-wider ${t.textMuted}`}>{label}</p>
+    <p className={`text-[20px] font-bold mt-0.5 tabular-nums ${accent ?? t.text}`}>{value}</p>
   </div>
 );
 
@@ -1239,16 +1239,16 @@ const CategorySection = ({
 }) => (
   <div>
     <div className="flex items-center gap-2 mb-2">
-      <span className={`text-[10px] font-semibold px-2 py-0.5 rounded ${STATUS_BADGE[status](dark)}`}>
+      <span className={`text-[12px] font-semibold px-2 py-0.5 rounded ${STATUS_BADGE[status](dark)}`}>
         {STATUS_LABEL[status]}
       </span>
-      <span className={`text-[11px] font-semibold tabular-nums ${t.text}`}>
+      <span className={`text-[13px] font-semibold tabular-nums ${t.text}`}>
         {count.toLocaleString()}
       </span>
-      <span className={`text-[11px] ${t.textMuted}`}>{description}</span>
+      <span className={`text-[13px] ${t.textMuted}`}>{description}</span>
     </div>
     {count === 0 ? (
-      <div className={`rounded-lg border ${t.borderLight} px-3 py-4 text-center text-[11px] ${t.textMuted}`}>
+      <div className={`rounded-lg border ${t.borderLight} px-3 py-4 text-center text-[13px] ${t.textMuted}`}>
         None
       </div>
     ) : (
@@ -1277,7 +1277,7 @@ const SheetRowsTable = ({
 }) => (
   <div className={`rounded-lg border ${t.borderLight} overflow-hidden`}>
     <div className="overflow-x-auto">
-      <table className="w-full text-[12px]">
+      <table className="w-full text-[14px]">
         <thead>
           <tr className={`border-b ${t.borderLight} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"}`}>
             <Th>Case</Th>
@@ -1308,7 +1308,7 @@ const SheetRowsTable = ({
               </td>
               {showChangedFields && (
                 <td className="px-3 py-1.5 max-w-64">
-                  <div className={`text-[10px] font-mono space-y-0.5 ${dark ? "text-blue-300" : "text-blue-700"}`}>
+                  <div className={`text-[12px] font-mono space-y-0.5 ${dark ? "text-blue-300" : "text-blue-700"}`}>
                     {r.changedFields.slice(0, 3).map((f) => (
                       <div key={f.field} className="leading-tight">
                         <span className="font-semibold">{f.field}</span>
@@ -1334,13 +1334,13 @@ const SheetRowsTable = ({
                     target="_blank"
                     rel="noreferrer"
                     onClick={(e) => e.stopPropagation()}
-                    className={`text-[11px] underline ${dark ? "text-blue-400" : "text-blue-600"} inline-flex items-center gap-1`}
+                    className={`text-[13px] underline ${dark ? "text-blue-400" : "text-blue-600"} inline-flex items-center gap-1`}
                   >
                     {r.winSheetLinkText ?? "Open"}
                     <ExternalLink className="h-3 w-3" aria-hidden="true" />
                   </a>
                 ) : (
-                  <span className={`text-[11px] ${t.textMuted}`}>{r.winSheetLinkText ?? "—"}</span>
+                  <span className={`text-[13px] ${t.textMuted}`}>{r.winSheetLinkText ?? "—"}</span>
                 )}
               </td>
               <td className={`${t.text} px-3 py-1.5 text-right tabular-nums font-medium`}>
@@ -1348,9 +1348,9 @@ const SheetRowsTable = ({
               </td>
               <td className="px-3 py-1.5 text-center">
                 {r.hasNotes ? (
-                  <span className={`text-[10px] font-semibold ${dark ? "text-blue-400" : "text-blue-600"}`}>YES</span>
+                  <span className={`text-[12px] font-semibold ${dark ? "text-blue-400" : "text-blue-600"}`}>YES</span>
                 ) : (
-                  <span className={`text-[10px] ${t.textMuted}`}>—</span>
+                  <span className={`text-[12px] ${t.textMuted}`}>—</span>
                 )}
               </td>
             </tr>
@@ -1359,7 +1359,7 @@ const SheetRowsTable = ({
       </table>
     </div>
     {truncated && (
-      <div className={`text-[11px] px-3 py-2 ${t.textMuted} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"} border-t ${t.borderLight}`}>
+      <div className={`text-[13px] px-3 py-2 ${t.textMuted} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"} border-t ${t.borderLight}`}>
         Showing first 100 of {total.toLocaleString()} rows.
       </div>
     )}
@@ -1381,7 +1381,7 @@ const DbOnlyTable = ({
 }) => (
   <div className={`rounded-lg border ${t.borderLight} overflow-hidden`}>
     <div className="overflow-x-auto">
-      <table className="w-full text-[12px]">
+      <table className="w-full text-[14px]">
         <thead>
           <tr className={`border-b ${t.borderLight} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"}`}>
             {onToggle && <Th>{""}</Th>}
@@ -1410,7 +1410,7 @@ const DbOnlyTable = ({
               )}
               <td className={`${t.text} px-3 py-1.5 font-medium`}>{r.caseName}</td>
               <td className={`${t.textSub} px-3 py-1.5 tabular-nums`}>{fmtDate(r.approvalDate)}</td>
-              <td className={`${t.textMuted} px-3 py-1.5 text-[11px] max-w-80 truncate`} title={r.caseLink}>
+              <td className={`${t.textMuted} px-3 py-1.5 text-[13px] max-w-80 truncate`} title={r.caseLink}>
                 {r.caseLink || "—"}
               </td>
             </tr>
@@ -1442,7 +1442,7 @@ const SelectionTable = ({
 }) => (
   <div className={`rounded-lg border ${t.borderLight} overflow-hidden`}>
     <div className="overflow-x-auto">
-      <table className="w-full text-[12px]">
+      <table className="w-full text-[14px]">
         <thead>
           <tr className={`border-b ${t.borderLight} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"} sticky top-0`}>
             <Th>{""}</Th>
@@ -1488,7 +1488,7 @@ const SelectionTable = ({
                   </span>
                 </td>
                 <td className="px-3 py-1.5">
-                  <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${STATUS_BADGE[r.status](dark)}`}>
+                  <span className={`text-[12px] font-semibold px-1.5 py-0.5 rounded ${STATUS_BADGE[r.status](dark)}`}>
                     {STATUS_LABEL[r.status]}
                   </span>
                 </td>
@@ -1496,11 +1496,11 @@ const SelectionTable = ({
                 <td className={`${t.textSub} px-3 py-1.5`}>{"assignedTo" in r ? (r.assignedTo ?? "—") : "—"}</td>
                 <td className="px-3 py-1.5">
                   {"winSheetStatus" in r ? (
-                    <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${STATUS_PILL[r.winSheetStatus] ?? STATUS_PILL.not_started}`}>
+                    <span className={`text-[12px] font-semibold px-1.5 py-0.5 rounded ${STATUS_PILL[r.winSheetStatus] ?? STATUS_PILL.not_started}`}>
                       {r.winSheetStatus.replace(/_/g, " ")}
                     </span>
                   ) : (
-                    <span className={`text-[10px] ${t.textMuted}`}>—</span>
+                    <span className={`text-[12px] ${t.textMuted}`}>—</span>
                   )}
                 </td>
               </tr>
@@ -1510,7 +1510,7 @@ const SelectionTable = ({
       </table>
     </div>
     {truncated && (
-      <div className={`text-[11px] px-3 py-2 ${t.textMuted} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"} border-t ${t.borderLight}`}>
+      <div className={`text-[13px] px-3 py-2 ${t.textMuted} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"} border-t ${t.borderLight}`}>
         Showing first 200 of {total.toLocaleString()} matching rows.
       </div>
     )}
@@ -1532,7 +1532,7 @@ const FcNewTable = ({
 }) => (
   <div className={`rounded-lg border ${t.borderLight} overflow-hidden`}>
     <div className="overflow-x-auto">
-      <table className="w-full text-[12px]">
+      <table className="w-full text-[14px]">
         <thead>
           <tr className={`border-b ${t.borderLight} ${dark ? "bg-neutral-900/40" : "bg-neutral-50"}`}>
             {selectedNames && <Th>{""}</Th>}
@@ -1585,7 +1585,7 @@ const Th = ({
   children: React.ReactNode;
   alignRight?: boolean;
 }) => (
-  <th className={`text-[10px] font-semibold uppercase tracking-wider px-3 py-2 ${alignRight ? "text-right" : "text-left"}`}>
+  <th className={`text-[12px] font-semibold uppercase tracking-wider px-3 py-2 ${alignRight ? "text-right" : "text-left"}`}>
     {children}
   </th>
 );

--- a/src/components/notifications/AuditLogTab.tsx
+++ b/src/components/notifications/AuditLogTab.tsx
@@ -27,7 +27,7 @@ const fmtDate = (iso: string): string =>
     day: "numeric",
   });
 
-const thBase = "px-3 py-2 text-[11px] font-semibold uppercase tracking-wide";
+const thBase = "px-3 py-2 text-[13px] font-semibold uppercase tracking-wide";
 const tdBase = "px-3 py-2 text-xs";
 
 export function AuditLogTab({ dark, t }: AuditLogTabProps) {
@@ -90,7 +90,7 @@ export function AuditLogTab({ dark, t }: AuditLogTabProps) {
           </div>
           <div>
             <h3 className={`text-sm font-bold ${t.text}`}>Audit Log</h3>
-            <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
+            <p className={`text-[13px] ${t.textMuted} mt-0.5`}>
               Daily agent activity — {formatWeekLabel(monday)}
             </p>
           </div>
@@ -103,7 +103,7 @@ export function AuditLogTab({ dark, t }: AuditLogTabProps) {
           >
             <ChevronLeft className="h-4 w-4" aria-hidden="true" />
           </button>
-          <span className={`text-[11px] font-medium ${t.textSub} whitespace-nowrap px-2`}>
+          <span className={`text-[13px] font-medium ${t.textSub} whitespace-nowrap px-2`}>
             {formatWeekLabel(monday)}
           </span>
           <button

--- a/src/components/notifications/NewCasesTab.tsx
+++ b/src/components/notifications/NewCasesTab.tsx
@@ -42,7 +42,7 @@ const isToday = (iso: string): boolean =>
 const fmtTime = (iso: string): string =>
   new Date(iso).toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
 
-const thBase = "px-3 py-2 text-[11px] font-semibold uppercase tracking-wide";
+const thBase = "px-3 py-2 text-[13px] font-semibold uppercase tracking-wide";
 const tdBase = "px-3 py-2 text-xs";
 
 export function NewCasesTab({ dark, t }: NewCasesTabProps) {
@@ -113,7 +113,7 @@ export function NewCasesTab({ dark, t }: NewCasesTabProps) {
           </div>
           <div>
             <h3 className={`text-sm font-bold ${t.text}`}>New Cases</h3>
-            <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
+            <p className={`text-[13px] ${t.textMuted} mt-0.5`}>
               {weekTotal} added — {formatWeekLabel(monday)}
             </p>
           </div>
@@ -126,7 +126,7 @@ export function NewCasesTab({ dark, t }: NewCasesTabProps) {
           >
             <ChevronLeft className="h-4 w-4" aria-hidden="true" />
           </button>
-          <span className={`text-[11px] font-medium ${t.textSub} whitespace-nowrap px-2`}>
+          <span className={`text-[13px] font-medium ${t.textSub} whitespace-nowrap px-2`}>
             {formatWeekLabel(monday)}
           </span>
           <button
@@ -187,7 +187,7 @@ export function NewCasesTab({ dark, t }: NewCasesTabProps) {
                   <td className={`${tdBase} ${t.text} font-medium`}>
                     {fmtDate(d.date)}
                     {isToday(d.date) && (
-                      <span className={`ml-1.5 text-[10px] font-semibold ${dark ? "text-indigo-400" : "text-indigo-600"}`}>
+                      <span className={`ml-1.5 text-[12px] font-semibold ${dark ? "text-indigo-400" : "text-indigo-600"}`}>
                         Today
                       </span>
                     )}

--- a/src/components/notifications/RecentActivityTab.tsx
+++ b/src/components/notifications/RecentActivityTab.tsx
@@ -29,7 +29,7 @@ const fmtDateOnly = (iso: string): string =>
 const toDateKey = (iso: string): string =>
   new Date(iso).toLocaleDateString("en-CA");
 
-const thBase = "px-3 py-2 text-[11px] font-semibold uppercase tracking-wide";
+const thBase = "px-3 py-2 text-[13px] font-semibold uppercase tracking-wide";
 const tdBase = "px-3 py-2 text-xs";
 
 export function RecentActivityTab({ dark, t }: RecentActivityTabProps) {
@@ -93,7 +93,7 @@ export function RecentActivityTab({ dark, t }: RecentActivityTabProps) {
           </div>
           <div>
             <h3 className={`text-sm font-bold ${t.text}`}>Recent Activity</h3>
-            <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
+            <p className={`text-[13px] ${t.textMuted} mt-0.5`}>
               Case activity log — {formatWeekLabel(monday)}
             </p>
           </div>
@@ -106,7 +106,7 @@ export function RecentActivityTab({ dark, t }: RecentActivityTabProps) {
           >
             <ChevronLeft className="h-4 w-4" aria-hidden="true" />
           </button>
-          <span className={`text-[11px] font-medium ${t.textSub} whitespace-nowrap px-2`}>
+          <span className={`text-[13px] font-medium ${t.textSub} whitespace-nowrap px-2`}>
             {formatWeekLabel(monday)}
           </span>
           <button

--- a/src/components/overpaid-cases/ClearedCases.tsx
+++ b/src/components/overpaid-cases/ClearedCases.tsx
@@ -347,8 +347,8 @@ export const ClearedCases = ({ dark, t, refreshToken, onRestored }: Props) => {
   const isInitialLoad = loading && rows.length === 0;
   const isRefreshing = loading && rows.length > 0;
 
-  const thBase = `py-2 px-3 text-[10px] font-semibold uppercase tracking-wider whitespace-nowrap`;
-  const tdBase = `py-2 px-3 text-[12px] whitespace-nowrap`;
+  const thBase = `py-2 px-3 text-[12px] font-semibold uppercase tracking-wider whitespace-nowrap`;
+  const tdBase = `py-2 px-3 text-[14px] whitespace-nowrap`;
   const rowBorder = dark ? "border-neutral-800/50" : "border-neutral-100";
   const rowHover = dark ? "hover:bg-neutral-800/40" : "hover:bg-neutral-50/80";
   const stickyHeaderBg = dark ? "bg-neutral-900" : "bg-white";
@@ -375,7 +375,7 @@ export const ClearedCases = ({ dark, t, refreshToken, onRestored }: Props) => {
           <span className={`text-sm font-bold ${t.text}`}>Cleared Cases</span>
           {total != null && total > 0 && (
             <span
-              className={`inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold ${
+              className={`inline-flex items-center px-2 py-0.5 rounded-full text-[13px] font-semibold ${
                 dark ? "bg-emerald-900/40 text-emerald-300" : "bg-emerald-100 text-emerald-700"
               }`}
             >
@@ -453,13 +453,13 @@ export const ClearedCases = ({ dark, t, refreshToken, onRestored }: Props) => {
                       <Loader2 aria-hidden="true" className={`h-3 w-3 animate-spin ${t.textMuted}`} />
                     )}
                   </p>
-                  <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
+                  <p className={`text-[13px] ${t.textMuted} mt-0.5`}>
                     {safeTotal === 0
                       ? "0 cases"
                       : `Showing ${rangeStart}–${rangeEnd} of ${safeTotal} cases`}
                   </p>
                   {safeTotal > 0 && (
-                    <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
+                    <p className={`text-[13px] ${t.textMuted} mt-0.5`}>
                       Total Overpaid {fmt(totalOverpaid)}
                     </p>
                   )}
@@ -729,7 +729,7 @@ export const ClearedCases = ({ dark, t, refreshToken, onRestored }: Props) => {
           {/* Pagination */}
           {safeTotal > pageSize && (
             <div className={`px-4 py-3 flex items-center justify-between border-t ${t.borderLight}`}>
-              <p className={`text-[11px] ${t.textMuted}`}>Page {page} of {totalPages}</p>
+              <p className={`text-[13px] ${t.textMuted}`}>Page {page} of {totalPages}</p>
               <div className="flex items-center gap-1">
                 <button
                   onClick={() => setPage((p) => Math.max(1, p - 1))}
@@ -738,7 +738,7 @@ export const ClearedCases = ({ dark, t, refreshToken, onRestored }: Props) => {
                 >
                   <ChevronLeft aria-hidden="true" className="h-3.5 w-3.5" /> Prev
                 </button>
-                <span className={`text-[11px] px-2 ${t.textMuted}`}>{page} / {totalPages}</span>
+                <span className={`text-[13px] px-2 ${t.textMuted}`}>{page} / {totalPages}</span>
                 <button
                   onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
                   disabled={page >= totalPages || loading}

--- a/src/components/overpaid-cases/OverpaidCases.tsx
+++ b/src/components/overpaid-cases/OverpaidCases.tsx
@@ -772,16 +772,16 @@ export const OverpaidCases = () => {
   const isRefreshing = loading && rows.length > 0;
 
   const sectionCard = `rounded-xl border ${t.card}`;
-  const thBase = `py-2 px-3 text-[10px] font-semibold uppercase tracking-wider whitespace-nowrap`;
-  const tdBase = `py-2 px-3 text-[12px] whitespace-nowrap`;
+  const thBase = `py-2 px-3 text-[12px] font-semibold uppercase tracking-wider whitespace-nowrap`;
+  const tdBase = `py-2 px-3 text-[14px] whitespace-nowrap`;
   const rowBorder = dark ? "border-neutral-800/50" : "border-neutral-100";
   const rowHover = dark ? "hover:bg-neutral-800/40" : "hover:bg-neutral-50/80";
   const stickyHeaderBg = dark ? "bg-neutral-900" : "bg-white";
-  const chipBase = `inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium ${dark ? "bg-neutral-700 text-neutral-200" : "bg-neutral-100 text-neutral-700"}`;
+  const chipBase = `inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[13px] font-medium ${dark ? "bg-neutral-700 text-neutral-200" : "bg-neutral-100 text-neutral-700"}`;
   const presetActive = dark
     ? "bg-indigo-700 border-indigo-600 text-white"
     : "bg-indigo-100 border-indigo-400 text-indigo-800";
-  const presetBase = `shrink-0 px-2.5 py-1 rounded-full text-[11px] font-medium border transition-colors`;
+  const presetBase = `shrink-0 px-2.5 py-1 rounded-full text-[13px] font-medium border transition-colors`;
 
   return (
     <div className="space-y-4">
@@ -823,7 +823,7 @@ export const OverpaidCases = () => {
           </div>
           <div>
             <h3 className={`text-sm font-bold ${t.text}`}>Overpaid Cases</h3>
-            <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
+            <p className={`text-[13px] ${t.textMuted} mt-0.5`}>
               Cases where fees received exceed expected amount
             </p>
           </div>
@@ -833,17 +833,17 @@ export const OverpaidCases = () => {
       {/* Stats bar */}
       <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
         <div className={`${sectionCard} p-4`}>
-          <p className={`text-[10px] font-semibold uppercase tracking-wider ${t.textMuted}`}>Pending Cases</p>
+          <p className={`text-[12px] font-semibold uppercase tracking-wider ${t.textMuted}`}>Pending Cases</p>
           <p className={`text-xl font-bold mt-1 ${t.text}`}>{isInitialLoad ? "—" : String(total)}</p>
-          <p className={`text-[10px] ${t.textMuted} mt-0.5`}>awaiting cleared checks</p>
+          <p className={`text-[12px] ${t.textMuted} mt-0.5`}>awaiting cleared checks</p>
         </div>
         <div className={`${sectionCard} p-4`}>
-          <p className={`text-[10px] font-semibold uppercase tracking-wider ${t.textMuted}`}>Total Overpaid</p>
+          <p className={`text-[12px] font-semibold uppercase tracking-wider ${t.textMuted}`}>Total Overpaid</p>
           <p className={`text-xl font-bold mt-1 ${dark ? "text-amber-400" : "text-amber-600"}`}>{isInitialLoad ? "—" : fmtFull(stats.totalOverpaid)}</p>
-          <p className={`text-[10px] ${t.textMuted} mt-0.5`}>across filtered cases</p>
+          <p className={`text-[12px] ${t.textMuted} mt-0.5`}>across filtered cases</p>
         </div>
         <div className={`${sectionCard} p-4`}>
-          <p className={`text-[10px] font-semibold uppercase tracking-wider ${t.textMuted}`}>LTR Received</p>
+          <p className={`text-[12px] font-semibold uppercase tracking-wider ${t.textMuted}`}>LTR Received</p>
           <p className={`text-xl font-bold mt-1 ${t.text}`}>{isInitialLoad ? "—" : `${stats.ltrCount} / ${total}`}</p>
           {!isInitialLoad && total > 0 && (
             <div className={`mt-2 h-1.5 rounded-full ${dark ? "bg-neutral-700" : "bg-neutral-200"}`}>
@@ -853,7 +853,7 @@ export const OverpaidCases = () => {
               />
             </div>
           )}
-          <p className={`text-[10px] ${t.textMuted} mt-1`}>
+          <p className={`text-[12px] ${t.textMuted} mt-1`}>
             {!isInitialLoad && total > 0 ? `${Math.round((stats.ltrCount / total) * 100)}% on file` : "letters on file"}
           </p>
         </div>
@@ -956,7 +956,7 @@ export const OverpaidCases = () => {
                     <Loader2 aria-label="Refreshing" className={`h-3 w-3 animate-spin ${t.textMuted}`} />
                   )}
                 </h3>
-                <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
+                <p className={`text-[13px] ${t.textMuted} mt-0.5`}>
                   {total === 0 ? "0 cases" : `Showing ${rangeStart}–${rangeEnd} of ${total} cases`}
                 </p>
               </>
@@ -1043,7 +1043,7 @@ export const OverpaidCases = () => {
 
         {/* Quick filter presets + amount range */}
         <div className={`px-4 py-2 flex items-center gap-2 flex-wrap border-b ${t.borderLight}`}>
-          <span className={`text-[10px] font-semibold uppercase tracking-wider ${t.textMuted} shrink-0`}>Quick:</span>
+          <span className={`text-[12px] font-semibold uppercase tracking-wider ${t.textMuted} shrink-0`}>Quick:</span>
           <button
             onClick={() => {
               urlMethodRef.current = "push";
@@ -1069,7 +1069,7 @@ export const OverpaidCases = () => {
             No LTR Sent
           </button>
           <div className="ml-auto flex items-center gap-1.5 shrink-0">
-            <span className={`text-[11px] ${t.textMuted}`}>$</span>
+            <span className={`text-[13px] ${t.textMuted}`}>$</span>
             <input
               type="number"
               min={0}
@@ -1077,9 +1077,9 @@ export const OverpaidCases = () => {
               onChange={(e) => setMinAmount(e.target.value)}
               placeholder="Min"
               aria-label="Minimum overpaid amount"
-              className={`h-7 w-20 px-2 rounded-md border text-[11px] outline-none focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-600 ${t.inputBg}`}
+              className={`h-7 w-20 px-2 rounded-md border text-[13px] outline-none focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-600 ${t.inputBg}`}
             />
-            <span className={`text-[11px] ${t.textMuted}`}>–</span>
+            <span className={`text-[13px] ${t.textMuted}`}>–</span>
             <input
               type="number"
               min={0}
@@ -1087,7 +1087,7 @@ export const OverpaidCases = () => {
               onChange={(e) => setMaxAmount(e.target.value)}
               placeholder="Max"
               aria-label="Maximum overpaid amount"
-              className={`h-7 w-20 px-2 rounded-md border text-[11px] outline-none focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-600 ${t.inputBg}`}
+              className={`h-7 w-20 px-2 rounded-md border text-[13px] outline-none focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-600 ${t.inputBg}`}
             />
           </div>
         </div>
@@ -1135,7 +1135,7 @@ export const OverpaidCases = () => {
                 </button>
               </span>
             )}
-            <button onClick={clearAllFilters} className={`text-[11px] font-medium underline ${t.textMuted} hover:opacity-70`}>
+            <button onClick={clearAllFilters} className={`text-[13px] font-medium underline ${t.textMuted} hover:opacity-70`}>
               Clear all
             </button>
           </div>
@@ -1143,14 +1143,14 @@ export const OverpaidCases = () => {
 
         {/* Legend */}
         <div className={`px-4 py-1.5 flex items-center gap-4 flex-wrap border-b ${t.borderLight}`}>
-          <span className={`text-[10px] font-semibold uppercase tracking-wider ${t.textMuted}`}>Key</span>
+          <span className={`text-[12px] font-semibold uppercase tracking-wider ${t.textMuted}`}>Key</span>
           <span className="flex items-center gap-1.5">
             <span className={`inline-block w-4 h-4 rounded-sm border-l-2 border-l-amber-500 ${dark ? "bg-neutral-800" : "bg-neutral-100"}`} />
-            <span className={`text-[11px] ${t.textMuted}`}>Overpaid amount ≥ $3,000</span>
+            <span className={`text-[13px] ${t.textMuted}`}>Overpaid amount ≥ $3,000</span>
           </span>
           <span className="flex items-center gap-1.5">
             <span className={`w-1.5 h-1.5 rounded-full ${dark ? "bg-amber-400" : "bg-amber-500"}`} />
-            <span className={`text-[11px] ${t.textMuted}`}>No workflow data entered</span>
+            <span className={`text-[13px] ${t.textMuted}`}>No workflow data entered</span>
           </span>
         </div>
 
@@ -1296,7 +1296,7 @@ export const OverpaidCases = () => {
                               {row.claimant}
                             </Link>
                             {row.updatedAt && (
-                              <p className={`text-[10px] ${t.textMuted} mt-0.5 font-normal`}>
+                              <p className={`text-[12px] ${t.textMuted} mt-0.5 font-normal`}>
                                 Updated {formatRelativeDate(row.updatedAt)}
                               </p>
                             )}
@@ -1313,7 +1313,7 @@ export const OverpaidCases = () => {
                             onBlur={() => persistRegion(row)}
                             placeholder="—"
                             maxLength={100}
-                            className={`w-full h-7 pl-2 pr-7 rounded-md border text-[11px] outline-none focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-600 ${t.inputBg}`}
+                            className={`w-full h-7 pl-2 pr-7 rounded-md border text-[13px] outline-none focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-600 ${t.inputBg}`}
                           />
                           {regionState[row.id] === "saving" && (
                             <Loader2 aria-hidden="true" className={`absolute right-2 top-1/2 -translate-y-1/2 h-3 w-3 animate-spin ${t.textMuted}`} />
@@ -1335,7 +1335,7 @@ export const OverpaidCases = () => {
                             onBlur={() => persistOverpaidAmount(row)}
                             placeholder="—"
                             aria-label="Overpaid amount"
-                            className={`w-full h-7 pl-2 pr-7 rounded-md border text-[11px] outline-none focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-600 ${t.inputBg}`}
+                            className={`w-full h-7 pl-2 pr-7 rounded-md border text-[13px] outline-none focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-600 ${t.inputBg}`}
                           />
                           {overpaidAmountState[row.id] === "saving" && (
                             <Loader2 aria-hidden="true" className={`absolute right-2 top-1/2 -translate-y-1/2 h-3 w-3 animate-spin ${t.textMuted}`} />
@@ -1356,7 +1356,7 @@ export const OverpaidCases = () => {
                             maxLength={50}
                             disabled={!canEditFeesConf}
                             title={!canEditFeesConf ? "You don't have permission to update Fees Confirmation." : undefined}
-                            className={`w-full h-7 pl-2 pr-7 rounded-md border text-[11px] outline-none focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-600 ${t.inputBg} disabled:opacity-50 disabled:cursor-not-allowed`}
+                            className={`w-full h-7 pl-2 pr-7 rounded-md border text-[13px] outline-none focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-600 ${t.inputBg} disabled:opacity-50 disabled:cursor-not-allowed`}
                           />
                           {confirmationState[row.id] === "saving" && (
                             <Loader2 aria-hidden="true" className={`absolute right-2 top-1/2 -translate-y-1/2 h-3 w-3 animate-spin ${t.textMuted}`} />
@@ -1374,7 +1374,7 @@ export const OverpaidCases = () => {
                             onChange={(e) => setOpLtrDateLocal(row.id, e.target.value)}
                             onBlur={() => persistOpLtrDate(row)}
                             aria-label="O/P letter sent date"
-                            className={`w-36 h-7 px-2 rounded-md border text-[11px] outline-none focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-600 ${t.inputBg}`}
+                            className={`w-36 h-7 px-2 rounded-md border text-[13px] outline-none focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-600 ${t.inputBg}`}
                           />
                           {opLtrDateState[row.id] === "saving" && (
                             <Loader2 aria-hidden="true" className={`absolute right-2 top-1/2 -translate-y-1/2 h-3 w-3 animate-spin ${t.textMuted}`} />
@@ -1392,7 +1392,7 @@ export const OverpaidCases = () => {
                             onChange={(e) => setLtrDateLocal(row.id, e.target.value)}
                             onBlur={() => persistLtrDate(row)}
                             aria-label="O/P letter received date"
-                            className={`w-36 h-7 px-2 rounded-md border text-[11px] outline-none focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-600 ${t.inputBg}`}
+                            className={`w-36 h-7 px-2 rounded-md border text-[13px] outline-none focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-600 ${t.inputBg}`}
                           />
                           {ltrState[row.id] === "saving" && (
                             <Loader2 aria-hidden="true" className={`absolute right-2 top-1/2 -translate-y-1/2 h-3 w-3 animate-spin ${t.textMuted}`} />
@@ -1443,7 +1443,7 @@ export const OverpaidCases = () => {
 
         {/* Pagination footer */}
         <div className={`px-4 py-3 flex items-center justify-between border-t ${t.borderLight}`}>
-          <p className={`text-[11px] ${t.textMuted}`}>Page {page} of {totalPages}</p>
+          <p className={`text-[13px] ${t.textMuted}`}>Page {page} of {totalPages}</p>
           <div className="flex items-center gap-1">
             <button
               onClick={() => { urlMethodRef.current = "push"; setPage((p) => Math.max(1, p - 1)); }}
@@ -1474,7 +1474,7 @@ export const OverpaidCases = () => {
                 onBlur={(e) => { e.target.value = String(page); }}
                 className={`h-8 w-12 px-1 rounded-md border text-xs text-center outline-none focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-600 disabled:opacity-40 ${t.inputBg}`}
               />
-              <span className={`text-[11px] ${t.textMuted}`}>/ {totalPages}</span>
+              <span className={`text-[13px] ${t.textMuted}`}>/ {totalPages}</span>
             </div>
             <button
               onClick={() => { urlMethodRef.current = "push"; setPage((p) => Math.min(totalPages, p + 1)); }}

--- a/src/components/reports/RecentActivityFeed.tsx
+++ b/src/components/reports/RecentActivityFeed.tsx
@@ -21,7 +21,7 @@ export function RecentActivityFeed({ activities, dark, t }: RecentActivityFeedPr
     <div className={`rounded-xl border ${t.card} p-4`}>
       <h4 className={`text-xs font-bold ${t.text} flex items-center gap-2 mb-3`}>
         <Clock aria-hidden="true" className="h-3.5 w-3.5" /> Recent Activity
-        <span className={`text-[10px] font-normal ${t.textMuted}`}>
+        <span className={`text-[12px] font-normal ${t.textMuted}`}>
           ({activities.length})
         </span>
       </h4>
@@ -37,19 +37,19 @@ export function RecentActivityFeed({ activities, dark, t }: RecentActivityFeedPr
               className={`rounded-md p-2 ${dark ? "bg-neutral-800/40" : "bg-neutral-50"}`}
             >
               <div className="flex items-center gap-2">
-                <span className={`text-[10px] font-semibold ${t.text}`}>
+                <span className={`text-[12px] font-semibold ${t.text}`}>
                   {a.createdBy}
                 </span>
                 {a.caseName && (
-                  <span className={`text-[10px] ${t.textMuted}`}>
+                  <span className={`text-[12px] ${t.textMuted}`}>
                     on {a.caseName}
                   </span>
                 )}
               </div>
-              <p className={`text-[11px] ${t.textSub} mt-0.5 leading-snug line-clamp-2`}>
+              <p className={`text-[13px] ${t.textSub} mt-0.5 leading-snug line-clamp-2`}>
                 {a.message}
               </p>
-              <p className={`text-[9px] ${t.textMuted} mt-0.5`}>
+              <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
                 {new Date(a.createdAt).toLocaleDateString("en-US", {
                   month: "short",
                   day: "numeric",

--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -475,11 +475,11 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
     setDaySel(`${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`);
   };
 
-  const thBase = `py-2.5 px-3 text-[10px] font-semibold uppercase tracking-wider whitespace-nowrap`;
-  const tdBase = `py-2.5 px-3 text-[12px] whitespace-nowrap tabular-nums`;
+  const thBase = `py-2.5 px-3 text-[12px] font-semibold uppercase tracking-wider whitespace-nowrap`;
+  const tdBase = `py-2.5 px-3 text-[14px] whitespace-nowrap tabular-nums`;
   const rowBorder = dark ? "border-neutral-800/50" : "border-neutral-100";
   const rowHover  = dark ? "hover:bg-neutral-800/40" : "hover:bg-neutral-50/80";
-  const miniInput = `w-12 h-6 px-1 text-center text-[11px] rounded border outline-none tabular-nums ${t.inputBg}`;
+  const miniInput = `w-12 h-6 px-1 text-center text-[13px] rounded border outline-none tabular-nums ${t.inputBg}`;
 
   return (
     <div className="space-y-4">
@@ -510,7 +510,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
               { label: "No Fees Over 90 Days",  value: data.noFeesAging.over90,         tone: dark ? "text-red-400"   : "text-red-600"   },
             ].map(({ label, value, tone }) => (
               <div key={label} className="py-3 text-center">
-                <div className={`text-[10px] font-semibold uppercase tracking-wider ${t.textMuted} mb-1`}>{label}</div>
+                <div className={`text-[12px] font-semibold uppercase tracking-wider ${t.textMuted} mb-1`}>{label}</div>
                 <div className={`text-xl font-extrabold tabular-nums ${tone}`}>{value}</div>
               </div>
             ))}
@@ -523,7 +523,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
         <div className={`rounded-xl border ${t.card} overflow-hidden`}>
           <div className={`px-4 py-2.5 flex items-center justify-between border-b ${t.borderLight}`}>
             <span className={`text-xs font-bold ${t.text}`}>No Fees Cases</span>
-            <span className="text-[11px] font-medium tabular-nums">
+            <span className="text-[13px] font-medium tabular-nums">
               <span className={dark ? "text-amber-400" : "text-amber-600"}>{data.noFeesAging.over60} over 60 days</span>
               <span className={t.textMuted}> · </span>
               <span className={dark ? "text-red-400" : "text-red-600"}>{data.noFeesAging.over90} over 90 days</span>
@@ -592,7 +592,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
             </div>
             <div>
               <h3 className={`text-sm font-bold ${t.text}`}>Agent Tracking</h3>
-              <p className={`text-[11px] ${t.textMuted} mt-0.5`}>{windowLabel}</p>
+              <p className={`text-[13px] ${t.textMuted} mt-0.5`}>{windowLabel}</p>
             </div>
           </div>
 
@@ -724,7 +724,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                   aria-label="From date"
                   className={`h-8 px-2 rounded-md border text-xs outline-none ${t.inputBg}`}
                 />
-                <span className={`text-[11px] ${t.textMuted}`}>to</span>
+                <span className={`text-[13px] ${t.textMuted}`}>to</span>
                 <input
                   type="date"
                   value={rangeTo}
@@ -804,7 +804,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                 <AlertTriangle aria-hidden="true" className="h-3 w-3" />
                 Needs attention
               </button>
-              <span className={`ml-auto text-[11px] ${t.textMuted}`}>
+              <span className={`ml-auto text-[13px] ${t.textMuted}`}>
                 {filteredAgents.length} of {data.agents.length} agents
               </span>
             </div>
@@ -938,7 +938,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
               <Phone className={`h-4 w-4 ${dark ? "text-indigo-400" : "text-indigo-500"}`} aria-hidden="true" />
               <div>
                 <h3 className={`text-sm font-bold ${t.text}`}>Daily Call Log</h3>
-                <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
+                <p className={`text-[13px] ${t.textMuted} mt-0.5`}>
                   {windowLabel} — Enter SSA &amp; client call counts per agent
                 </p>
               </div>
@@ -979,7 +979,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                   {entryDays.map((day) => (
                     <th key={day.date} className={`${thBase} ${t.textSub} text-center`}>
                       <div>{day.dayName}</div>
-                      <div className={`text-[9px] font-normal ${t.textMuted}`}>{day.label}</div>
+                      <div className={`text-[11px] font-normal ${t.textMuted}`}>{day.label}</div>
                     </th>
                   ))}
                   {entryDays.length > 1 && <th className={`${thBase} ${t.textSub} text-center`}>Total</th>}
@@ -995,16 +995,16 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                       <tr className={rowBorder}>
                         <td className={`${tdBase} ${t.text} font-semibold align-middle`} rowSpan={5}>
                           <div className="flex items-center gap-2">
-                            <div className={`w-7 h-7 rounded-full flex items-center justify-center text-[10px] font-bold ${dark ? "bg-neutral-700 text-neutral-300" : "bg-neutral-200 text-neutral-600"}`}>
+                            <div className={`w-7 h-7 rounded-full flex items-center justify-center text-[12px] font-bold ${dark ? "bg-neutral-700 text-neutral-300" : "bg-neutral-200 text-neutral-600"}`}>
                               {agent.agent[0]}
                             </div>
                             {agent.agent}
                             {!editable && (
-                              <span className={`text-[9px] font-normal ${t.textMuted}`}>(read-only)</span>
+                              <span className={`text-[11px] font-normal ${t.textMuted}`}>(read-only)</span>
                             )}
                           </div>
                         </td>
-                        <td className={`px-2 py-1.5 text-[10px] font-medium whitespace-nowrap ${dark ? "text-blue-400" : "text-blue-600"}`}>SSA</td>
+                        <td className={`px-2 py-1.5 text-[12px] font-medium whitespace-nowrap ${dark ? "text-blue-400" : "text-blue-600"}`}>SSA</td>
                         {entryDays.map((day) => (
                           <td key={day.date} className="px-1 py-1 text-center">
                             <input type="number" min="0" placeholder="0" className={miniInput}
@@ -1015,14 +1015,14 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                           </td>
                         ))}
                         {entryDays.length > 1 && (
-                          <td className={`px-2 py-1 text-center text-[11px] font-semibold tabular-nums ${totals.ssa > 0 ? (dark ? "text-blue-400" : "text-blue-600") : t.textMuted}`}>
+                          <td className={`px-2 py-1 text-center text-[13px] font-semibold tabular-nums ${totals.ssa > 0 ? (dark ? "text-blue-400" : "text-blue-600") : t.textMuted}`}>
                             {totals.ssa || "—"}
                           </td>
                         )}
                       </tr>
                       {/* Client IB */}
                       <tr className={rowBorder}>
-                        <td className={`px-2 py-1.5 text-[10px] font-medium whitespace-nowrap ${dark ? "text-emerald-400" : "text-emerald-600"}`}>Client IB</td>
+                        <td className={`px-2 py-1.5 text-[12px] font-medium whitespace-nowrap ${dark ? "text-emerald-400" : "text-emerald-600"}`}>Client IB</td>
                         {entryDays.map((day) => (
                           <td key={day.date} className="px-1 py-1 text-center">
                             <input type="number" min="0" placeholder="0" className={miniInput}
@@ -1033,14 +1033,14 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                           </td>
                         ))}
                         {entryDays.length > 1 && (
-                          <td className={`px-2 py-1 text-center text-[11px] font-semibold tabular-nums ${totals.ib > 0 ? (dark ? "text-emerald-400" : "text-emerald-600") : t.textMuted}`}>
+                          <td className={`px-2 py-1 text-center text-[13px] font-semibold tabular-nums ${totals.ib > 0 ? (dark ? "text-emerald-400" : "text-emerald-600") : t.textMuted}`}>
                             {totals.ib || "—"}
                           </td>
                         )}
                       </tr>
                       {/* Client OB */}
                       <tr className={rowBorder}>
-                        <td className={`px-2 py-1.5 text-[10px] font-medium whitespace-nowrap ${dark ? "text-amber-400" : "text-amber-600"}`}>Client OB</td>
+                        <td className={`px-2 py-1.5 text-[12px] font-medium whitespace-nowrap ${dark ? "text-amber-400" : "text-amber-600"}`}>Client OB</td>
                         {entryDays.map((day) => (
                           <td key={day.date} className="px-1 py-1 text-center">
                             <input type="number" min="0" placeholder="0" className={miniInput}
@@ -1051,14 +1051,14 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                           </td>
                         ))}
                         {entryDays.length > 1 && (
-                          <td className={`px-2 py-1 text-center text-[11px] font-semibold tabular-nums ${totals.ob > 0 ? (dark ? "text-amber-400" : "text-amber-600") : t.textMuted}`}>
+                          <td className={`px-2 py-1 text-center text-[13px] font-semibold tabular-nums ${totals.ob > 0 ? (dark ? "text-amber-400" : "text-amber-600") : t.textMuted}`}>
                             {totals.ob || "—"}
                           </td>
                         )}
                       </tr>
                       {/* Win Sheets */}
                       <tr className={rowBorder}>
-                        <td className={`px-2 py-1.5 text-[10px] font-medium whitespace-nowrap ${dark ? "text-violet-400" : "text-violet-600"}`}>Win Sheets</td>
+                        <td className={`px-2 py-1.5 text-[12px] font-medium whitespace-nowrap ${dark ? "text-violet-400" : "text-violet-600"}`}>Win Sheets</td>
                         {entryDays.map((day) => (
                           <td key={day.date} className="px-1 py-1 text-center">
                             <input type="number" min="0" placeholder="0" className={miniInput}
@@ -1069,14 +1069,14 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                           </td>
                         ))}
                         {entryDays.length > 1 && (
-                          <td className={`px-2 py-1 text-center text-[11px] font-semibold tabular-nums ${totals.ws > 0 ? (dark ? "text-violet-400" : "text-violet-600") : t.textMuted}`}>
+                          <td className={`px-2 py-1 text-center text-[13px] font-semibold tabular-nums ${totals.ws > 0 ? (dark ? "text-violet-400" : "text-violet-600") : t.textMuted}`}>
                             {totals.ws || "—"}
                           </td>
                         )}
                       </tr>
                       {/* Fax Sent */}
                       <tr className={`border-b ${rowBorder}`}>
-                        <td className={`px-2 py-1.5 text-[10px] font-medium whitespace-nowrap ${dark ? "text-rose-400" : "text-rose-600"}`}>Fax Sent</td>
+                        <td className={`px-2 py-1.5 text-[12px] font-medium whitespace-nowrap ${dark ? "text-rose-400" : "text-rose-600"}`}>Fax Sent</td>
                         {entryDays.map((day) => (
                           <td key={day.date} className="px-1 py-1 text-center">
                             <input type="number" min="0" placeholder="0" className={miniInput}
@@ -1087,7 +1087,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                           </td>
                         ))}
                         {entryDays.length > 1 && (
-                          <td className={`px-2 py-1 text-center text-[11px] font-semibold tabular-nums ${totals.fax > 0 ? (dark ? "text-rose-400" : "text-rose-600") : t.textMuted}`}>
+                          <td className={`px-2 py-1 text-center text-[13px] font-semibold tabular-nums ${totals.fax > 0 ? (dark ? "text-rose-400" : "text-rose-600") : t.textMuted}`}>
                             {totals.fax || "—"}
                           </td>
                         )}
@@ -1099,20 +1099,20 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
               <tfoot>
                 <tr className={dark ? "bg-neutral-800/60" : "bg-neutral-50"}>
                   <td className={`${tdBase} font-bold ${t.text}`}>TOTAL</td>
-                  <td className={`px-2 py-1.5 text-[10px] font-bold ${t.textSub}`}>All</td>
+                  <td className={`px-2 py-1.5 text-[12px] font-bold ${t.textSub}`}>All</td>
                   {entryDays.map((day) => {
                     const dayTotal = data.agents.reduce((sum, a) => {
                       const c = getCell(a.agent, day.date);
                       return sum + (parseInt(c.ssaCalls) || 0) + (parseInt(c.clientCallsIb) || 0) + (parseInt(c.clientCallsOb) || 0);
                     }, 0);
                     return (
-                      <td key={day.date} className={`px-2 py-1.5 text-center text-[11px] font-bold tabular-nums ${dayTotal > 0 ? t.text : t.textMuted}`}>
+                      <td key={day.date} className={`px-2 py-1.5 text-center text-[13px] font-bold tabular-nums ${dayTotal > 0 ? t.text : t.textMuted}`}>
                         {dayTotal || "—"}
                       </td>
                     );
                   })}
                   {entryDays.length > 1 && (
-                    <td className={`px-2 py-1.5 text-center text-[11px] font-bold tabular-nums ${t.text}`}>
+                    <td className={`px-2 py-1.5 text-center text-[13px] font-bold tabular-nums ${t.text}`}>
                       {data.agents.reduce((sum, a) => sum + agentCellTotals(a.agent).total, 0) || "—"}
                     </td>
                   )}

--- a/src/components/scoreboard/Scoreboard.tsx
+++ b/src/components/scoreboard/Scoreboard.tsx
@@ -189,7 +189,7 @@ export const Scoreboard = () => {
       <div className={`px-5 py-4 border-b ${t.borderLight} flex items-center justify-between gap-4`}>
         <div>
           <h2 className={`text-sm font-bold ${t.text}`}>Total Number of Closed Cases</h2>
-          <p className={`text-[11px] ${t.textMuted} mt-0.5`}>
+          <p className={`text-[13px] ${t.textMuted} mt-0.5`}>
             {weekOffset === 0
               ? "Current week + 4 previous weeks"
               : `5 weeks ending ${weekRangeLabel(getMonday(weekOffset)).split("–")[0].trim()}`}
@@ -199,7 +199,7 @@ export const Scoreboard = () => {
           {canImport && (
             <button
               onClick={() => setCsvImportOpen(true)}
-              className={`flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium border transition-colors ${dark ? "border-neutral-700 text-neutral-300 hover:bg-neutral-800" : "border-neutral-200 text-neutral-600 hover:bg-neutral-50"}`}
+              className={`flex items-center gap-1 px-2 py-1 rounded-md text-[13px] font-medium border transition-colors ${dark ? "border-neutral-700 text-neutral-300 hover:bg-neutral-800" : "border-neutral-200 text-neutral-600 hover:bg-neutral-50"}`}
               aria-label="Import daily metrics from CSV"
             >
               <Upload aria-hidden="true" className="h-3.5 w-3.5" />
@@ -208,7 +208,7 @@ export const Scoreboard = () => {
           )}
           <button
             onClick={() => setWeekOffset(weekOffset - 1)}
-            className={`flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium border transition-colors ${dark ? "border-neutral-700 text-neutral-300 hover:bg-neutral-800" : "border-neutral-200 text-neutral-600 hover:bg-neutral-50"}`}
+            className={`flex items-center gap-1 px-2 py-1 rounded-md text-[13px] font-medium border transition-colors ${dark ? "border-neutral-700 text-neutral-300 hover:bg-neutral-800" : "border-neutral-200 text-neutral-600 hover:bg-neutral-50"}`}
             aria-label="Previous 5 weeks"
           >
             <ChevronLeft aria-hidden="true" className="h-3.5 w-3.5" />
@@ -217,7 +217,7 @@ export const Scoreboard = () => {
           {weekOffset < 0 && (
             <button
               onClick={() => setWeekOffset(0)}
-              className={`px-2 py-1 rounded-md text-[11px] font-medium border transition-colors ${dark ? "border-amber-700 text-amber-400 hover:bg-amber-900/20" : "border-amber-300 text-amber-700 hover:bg-amber-50"}`}
+              className={`px-2 py-1 rounded-md text-[13px] font-medium border transition-colors ${dark ? "border-amber-700 text-amber-400 hover:bg-amber-900/20" : "border-amber-300 text-amber-700 hover:bg-amber-50"}`}
             >
               This week
             </button>
@@ -225,7 +225,7 @@ export const Scoreboard = () => {
           <button
             onClick={() => setWeekOffset(weekOffset + 1)}
             disabled={weekOffset >= 0}
-            className={`flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium border transition-colors ${weekOffset >= 0 ? (dark ? "border-neutral-800 text-neutral-600 cursor-not-allowed" : "border-neutral-100 text-neutral-300 cursor-not-allowed") : (dark ? "border-neutral-700 text-neutral-300 hover:bg-neutral-800" : "border-neutral-200 text-neutral-600 hover:bg-neutral-50")}`}
+            className={`flex items-center gap-1 px-2 py-1 rounded-md text-[13px] font-medium border transition-colors ${weekOffset >= 0 ? (dark ? "border-neutral-800 text-neutral-600 cursor-not-allowed" : "border-neutral-100 text-neutral-300 cursor-not-allowed") : (dark ? "border-neutral-700 text-neutral-300 hover:bg-neutral-800" : "border-neutral-200 text-neutral-600 hover:bg-neutral-50")}`}
             aria-label="Next 5 weeks"
             aria-disabled={weekOffset >= 0}
           >
@@ -284,14 +284,14 @@ export const Scoreboard = () => {
                       <thead>
                         <tr className={`border-b ${t.borderLight}`}>
                           <th
-                            className={`py-2 px-4 text-left text-[10px] font-semibold uppercase tracking-wider ${t.textMuted} w-40`}
+                            className={`py-2 px-4 text-left text-[12px] font-semibold uppercase tracking-wider ${t.textMuted} w-40`}
                           >
                             Agent
                           </th>
                           {weeks.map((w, i) => (
                             <th
                               key={i}
-                              className={`py-2 px-3 text-center text-[10px] font-semibold uppercase tracking-wider ${i === 0 ? t.text : t.textMuted}`}
+                              className={`py-2 px-3 text-center text-[12px] font-semibold uppercase tracking-wider ${i === 0 ? t.text : t.textMuted}`}
                             >
                               {w.label}
                             </th>
@@ -304,19 +304,19 @@ export const Scoreboard = () => {
                             key={row.agent}
                             className={`border-b ${t.borderLight} ${rowIdx % 2 !== 0 ? (dark ? "bg-neutral-800/20" : "bg-neutral-50/50") : ""}`}
                           >
-                            <td className={`py-2.5 px-4 text-[12px] font-medium ${t.text}`}>
+                            <td className={`py-2.5 px-4 text-[14px] font-medium ${t.text}`}>
                               {row.agent}
                             </td>
                             {row.weekValues.map((val, i) => (
                               <td key={i} className="py-2.5 px-3 text-center">
                                 {i === 0 ? (
                                   <span
-                                    className={`inline-block min-w-8 rounded px-2 py-0.5 text-[12px] font-semibold ${thisWeekCellColor(val, currentWeekMax)}`}
+                                    className={`inline-block min-w-8 rounded px-2 py-0.5 text-[14px] font-semibold ${thisWeekCellColor(val, currentWeekMax)}`}
                                   >
                                     {val}
                                   </span>
                                 ) : (
-                                  <span className={`text-[12px] ${t.textSub}`}>{val}</span>
+                                  <span className={`text-[14px] ${t.textSub}`}>{val}</span>
                                 )}
                               </td>
                             ))}

--- a/src/components/scoreboard/ScoreboardSummaryCards.tsx
+++ b/src/components/scoreboard/ScoreboardSummaryCards.tsx
@@ -114,7 +114,7 @@ export function ScoreboardSummaryCards({
                     : t.card
                 }`}
               >
-                <p className={`text-[10px] font-medium uppercase ${item.toggled ? (dark ? "text-violet-400" : "text-violet-600") : t.textMuted}`}>
+                <p className={`text-[12px] font-medium uppercase ${item.toggled ? (dark ? "text-violet-400" : "text-violet-600") : t.textMuted}`}>
                   {item.label}
                 </p>
                 <p className={`text-lg font-bold mt-1 ${item.toggled ? (dark ? "text-violet-300" : "text-violet-700") : t.text}`}>
@@ -127,7 +127,7 @@ export function ScoreboardSummaryCards({
                 className={`rounded-lg border p-3 border-l-[3px] ${t.card}`}
                 style={item.accent ? { borderLeftColor: item.accent } : undefined}
               >
-                <p className={`flex items-center gap-1.5 text-[10px] font-medium ${t.textMuted} uppercase`}>
+                <p className={`flex items-center gap-1.5 text-[12px] font-medium ${t.textMuted} uppercase`}>
                   {item.accent && (
                     <span
                       aria-hidden="true"
@@ -147,7 +147,7 @@ export function ScoreboardSummaryCards({
       {/* Team breakdown */}
       {teams.length > 0 && (
         <div>
-          <p className={`text-[10px] font-semibold uppercase tracking-wider ${t.textMuted} mb-3`}>
+          <p className={`text-[12px] font-semibold uppercase tracking-wider ${t.textMuted} mb-3`}>
             By Team — {label}
           </p>
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
@@ -160,7 +160,7 @@ export function ScoreboardSummaryCards({
                     <span className={`text-xs font-bold ${accentText}`}>
                       {teamLabel(team.team)}
                     </span>
-                    <span className={`text-[10px] ${t.textMuted}`}>
+                    <span className={`text-[12px] ${t.textMuted}`}>
                       {team.agentCount} agent{team.agentCount !== 1 ? "s" : ""}
                     </span>
                   </div>
@@ -174,7 +174,7 @@ export function ScoreboardSummaryCards({
                       { label: "Open Cases", value: team.openCases },
                     ].map((stat) => (
                       <div key={stat.label}>
-                        <p className={`text-[9px] font-medium uppercase tracking-wide ${t.textMuted}`}>
+                        <p className={`text-[11px] font-medium uppercase tracking-wide ${t.textMuted}`}>
                           {stat.label}
                         </p>
                         <p className={`text-sm font-bold ${t.text} mt-0.5`}>

--- a/src/components/settings/DropdownOptionsCard.tsx
+++ b/src/components/settings/DropdownOptionsCard.tsx
@@ -234,7 +234,7 @@ export function DropdownOptionsCard({ category, label, description }: Props) {
         <h4 className={`text-xs font-bold ${t.text} flex items-center gap-2`}>
           <ListChecks className="h-3.5 w-3.5" /> {label} Options
         </h4>
-        <span className={`text-[11px] ${t.textMuted}`}>
+        <span className={`text-[13px] ${t.textMuted}`}>
           {loading
             ? "Loading…"
             : options.length === 1
@@ -245,7 +245,7 @@ export function DropdownOptionsCard({ category, label, description }: Props) {
 
       <div className="p-4 space-y-3">
         {description && (
-          <p className={`text-[11px] ${t.textMuted}`}>{description}</p>
+          <p className={`text-[13px] ${t.textMuted}`}>{description}</p>
         )}
 
         {error && (
@@ -296,7 +296,7 @@ export function DropdownOptionsCard({ category, label, description }: Props) {
           </div>
         ) : options.length === 0 ? (
           <div
-            className={`py-8 text-center text-[11px] ${t.textMuted} border rounded-md ${t.borderLight}`}
+            className={`py-8 text-center text-[13px] ${t.textMuted} border rounded-md ${t.borderLight}`}
           >
             No options yet. Add the first one above to populate the dropdown.
           </div>
@@ -367,7 +367,7 @@ export function DropdownOptionsCard({ category, label, description }: Props) {
                           onClick={() => handleMove(opt.id, "up")}
                           disabled={rowBusy || busyId !== null || options.indexOf(opt) === 0}
                           aria-label={`Move ${opt.name} up`}
-                          className={`h-4 w-5 flex items-center justify-center rounded text-[10px] disabled:opacity-30 ${t.hover} ${t.textSub}`}
+                          className={`h-4 w-5 flex items-center justify-center rounded text-[12px] disabled:opacity-30 ${t.hover} ${t.textSub}`}
                         >
                           <ChevronUp aria-hidden="true" className="h-3 w-3" />
                         </button>
@@ -376,7 +376,7 @@ export function DropdownOptionsCard({ category, label, description }: Props) {
                           onClick={() => handleMove(opt.id, "down")}
                           disabled={rowBusy || busyId !== null || options.indexOf(opt) === options.length - 1}
                           aria-label={`Move ${opt.name} down`}
-                          className={`h-4 w-5 flex items-center justify-center rounded text-[10px] disabled:opacity-30 ${t.hover} ${t.textSub}`}
+                          className={`h-4 w-5 flex items-center justify-center rounded text-[12px] disabled:opacity-30 ${t.hover} ${t.textSub}`}
                         >
                           <ChevronDown aria-hidden="true" className="h-3 w-3" />
                         </button>
@@ -395,7 +395,7 @@ export function DropdownOptionsCard({ category, label, description }: Props) {
                           disabled={rowBusy}
                           aria-label={`${opt.isActive ? "Deactivate" : "Activate"} ${opt.name}`}
                         />
-                        <span className={`text-[10px] ${t.textMuted} w-12`}>
+                        <span className={`text-[12px] ${t.textMuted} w-12`}>
                           {opt.isActive ? "Active" : "Inactive"}
                         </span>
                       </div>

--- a/src/components/settings/DropdownOptionsManager.tsx
+++ b/src/components/settings/DropdownOptionsManager.tsx
@@ -42,7 +42,7 @@ export function DropdownOptionsManager() {
               aria-selected={isActive}
               type="button"
               onClick={() => setActive(cat.key)}
-              className={`px-2.5 py-1 rounded-md text-[11px] font-medium transition-colors ${
+              className={`px-2.5 py-1 rounded-md text-[13px] font-medium transition-colors ${
                 isActive
                   ? dark
                     ? "bg-neutral-800 text-neutral-100"

--- a/src/components/shared/Listbox.tsx
+++ b/src/components/shared/Listbox.tsx
@@ -212,7 +212,7 @@ export function Listbox({
           else openAt(initialIndex());
         }}
         onKeyDown={onTriggerKeyDown}
-        className={`h-7 px-2 rounded-md border text-[11px] outline-none flex items-center justify-between gap-1.5 cursor-pointer ${selected?.tint ?? t.inputBg} ${className}`}
+        className={`h-7 px-2 rounded-md border text-[13px] outline-none flex items-center justify-between gap-1.5 cursor-pointer ${selected?.tint ?? t.inputBg} ${className}`}
       >
         <span className="flex items-center gap-1.5 truncate">
           {selected?.icon && (
@@ -240,7 +240,7 @@ export function Listbox({
               className={`rounded-lg border shadow-lg p-1 max-h-64 overflow-auto ${t.card}`}
             >
               {options.length === 0 ? (
-                <div className={`px-2 py-1.5 text-[11px] ${t.textMuted}`}>
+                <div className={`px-2 py-1.5 text-[13px] ${t.textMuted}`}>
                   No options configured — add them in Settings
                 </div>
               ) : (
@@ -269,7 +269,7 @@ export function Listbox({
                         onChange(o.value);
                         setOpen(false);
                       }}
-                      className={`w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-[11px] font-medium text-left ${rowTone}`}
+                      className={`w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-[13px] font-medium text-left ${rowTone}`}
                     >
                       {o.icon && (
                         <span

--- a/src/components/shared/NoteField.tsx
+++ b/src/components/shared/NoteField.tsx
@@ -48,7 +48,7 @@ export function NoteField({
         maxLength={maxLength}
         rows={expanded ? 5 : 1}
         aria-label={ariaLabel}
-        className={`pl-2 pr-7 py-1 rounded-md border text-[11px] outline-none resize-none transition-[height] focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-600 ${
+        className={`pl-2 pr-7 py-1 rounded-md border text-[13px] outline-none resize-none transition-[height] focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-600 ${
           expanded ? "w-full min-w-80" : "w-full h-7 overflow-hidden whitespace-nowrap"
         } ${t.inputBg}`}
       />

--- a/src/components/team/TeamManagement.tsx
+++ b/src/components/team/TeamManagement.tsx
@@ -317,7 +317,7 @@ export const TeamManagement = () => {
               />
             </div>
             <div>
-              <p className={`text-[11px] ${t.textMuted}`}>{card.label}</p>
+              <p className={`text-[13px] ${t.textMuted}`}>{card.label}</p>
               <p className={`text-xl font-bold ${t.text}`}>{card.value}</p>
             </div>
           </div>
@@ -345,7 +345,7 @@ export const TeamManagement = () => {
           )}
         </div>
         <label
-          className={`inline-flex items-center gap-1.5 text-[11px] ${t.textMuted} cursor-pointer select-none`}
+          className={`inline-flex items-center gap-1.5 text-[13px] ${t.textMuted} cursor-pointer select-none`}
         >
           <input
             type="checkbox"
@@ -364,47 +364,47 @@ export const TeamManagement = () => {
             <thead>
               <tr className={dark ? "bg-neutral-800/50" : "bg-neutral-50"}>
                 <th
-                  className={`px-4 py-2.5 text-left font-semibold ${t.textMuted} text-[11px]`}
+                  className={`px-4 py-2.5 text-left font-semibold ${t.textMuted} text-[13px]`}
                 >
                   Name
                 </th>
                 <th
-                  className={`px-4 py-2.5 text-left font-semibold ${t.textMuted} text-[11px]`}
+                  className={`px-4 py-2.5 text-left font-semibold ${t.textMuted} text-[13px]`}
                 >
                   Role
                 </th>
                 <th
-                  className={`px-4 py-2.5 text-left font-semibold ${t.textMuted} text-[11px]`}
+                  className={`px-4 py-2.5 text-left font-semibold ${t.textMuted} text-[13px]`}
                 >
                   Team
                 </th>
                 <th
-                  className={`px-4 py-2.5 text-center font-semibold ${t.textMuted} text-[11px]`}
+                  className={`px-4 py-2.5 text-center font-semibold ${t.textMuted} text-[13px]`}
                 >
                   Status
                 </th>
                 <th
-                  className={`px-4 py-2.5 text-right font-semibold ${t.textMuted} text-[11px]`}
+                  className={`px-4 py-2.5 text-right font-semibold ${t.textMuted} text-[13px]`}
                 >
                   Cases
                 </th>
                 <th
-                  className={`px-4 py-2.5 text-right font-semibold ${t.textMuted} text-[11px]`}
+                  className={`px-4 py-2.5 text-right font-semibold ${t.textMuted} text-[13px]`}
                 >
                   Active
                 </th>
                 <th
-                  className={`px-4 py-2.5 text-right font-semibold ${t.textMuted} text-[11px]`}
+                  className={`px-4 py-2.5 text-right font-semibold ${t.textMuted} text-[13px]`}
                 >
                   PIF
                 </th>
                 <th
-                  className={`px-4 py-2.5 text-right font-semibold ${t.textMuted} text-[11px]`}
+                  className={`px-4 py-2.5 text-right font-semibold ${t.textMuted} text-[13px]`}
                 >
                   Collected
                 </th>
                 <th
-                  className={`px-4 py-2.5 text-right font-semibold ${t.textMuted} text-[11px]`}
+                  className={`px-4 py-2.5 text-right font-semibold ${t.textMuted} text-[13px]`}
                 >
                   Actions
                 </th>
@@ -434,7 +434,7 @@ export const TeamManagement = () => {
                     <td className="px-4 py-2.5">
                       <div className="flex items-center gap-2.5">
                         <div
-                          className={`w-7 h-7 rounded-full flex items-center justify-center text-[11px] font-bold ${t.avatarBg}`}
+                          className={`w-7 h-7 rounded-full flex items-center justify-center text-[13px] font-bold ${t.avatarBg}`}
                         >
                           {m.name.charAt(0).toUpperCase()}
                         </div>
@@ -453,12 +453,12 @@ export const TeamManagement = () => {
                     <td className="px-4 py-2.5">
                       {m.team ? (
                         <span
-                          className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold ${teamBadgeClasses(m.team, dark)}`}
+                          className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[12px] font-semibold ${teamBadgeClasses(m.team, dark)}`}
                         >
                           {m.team}
                         </span>
                       ) : (
-                        <span className={`text-[10px] ${t.textMuted}`}>—</span>
+                        <span className={`text-[12px] ${t.textMuted}`}>—</span>
                       )}
                     </td>
 
@@ -466,7 +466,7 @@ export const TeamManagement = () => {
                     <td className="px-4 py-2.5 text-center">
                       {m.isActive ? (
                         <span
-                          className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium ${
+                          className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[12px] font-medium ${
                             dark
                               ? "bg-emerald-900/30 text-emerald-400"
                               : "bg-emerald-50 text-emerald-700"
@@ -477,7 +477,7 @@ export const TeamManagement = () => {
                         </span>
                       ) : (
                         <span
-                          className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium ${
+                          className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[12px] font-medium ${
                             dark
                               ? "bg-neutral-800 text-neutral-500"
                               : "bg-neutral-100 text-neutral-500"
@@ -567,7 +567,7 @@ export const TeamManagement = () => {
               {/* Name */}
               <div>
                 <label
-                  className={`block text-[11px] font-semibold ${t.textMuted} mb-1`}
+                  className={`block text-[13px] font-semibold ${t.textMuted} mb-1`}
                 >
                   Name
                 </label>
@@ -585,7 +585,7 @@ export const TeamManagement = () => {
               {/* Role */}
               <div>
                 <label
-                  className={`block text-[11px] font-semibold ${t.textMuted} mb-1`}
+                  className={`block text-[13px] font-semibold ${t.textMuted} mb-1`}
                 >
                   Role
                 </label>
@@ -611,7 +611,7 @@ export const TeamManagement = () => {
               {/* Team */}
               <div>
                 <label
-                  className={`block text-[11px] font-semibold ${t.textMuted} mb-1`}
+                  className={`block text-[13px] font-semibold ${t.textMuted} mb-1`}
                 >
                   Team
                 </label>


### PR DESCRIPTION
## Summary
Older staff reported the dashboard's text was hard to read — most of the app uses hardcoded pixel text sizes (`text-[10px]`, `text-[11px]`, etc.) rather than Tailwind's relative scale, so there was no single setting to bump.

- Every hardcoded `text-[Npx]` size found in the codebase (8, 9, 10, 11, 12, 13, 18px) is bumped by 2px, applied atomically across ~52 files/~590 occurrences so relative size ordering is preserved exactly.
- `text-xs` (12px) and `text-sm` (14px) are bumped one tier via a global `@theme` override in `globals.css` (now 14px/16px) — this covers the ~130 files using Tailwind's semantic classes without touching them individually, and any future usage inherits it automatically.
- `text-base` and larger (headings, stat numbers) are untouched — those weren't the complaint.

## Test plan
- [x] `npx tsc --noEmit`, `npm run lint`, `npm test` (62 passing), `npm run build`
- [x] Verified live across Master Fees (including the two-row sticky header, which has a fixed `h-8` height coupled to a second sticky row — confirmed it still aligns with zero gap/overlap after the bump), Fee Petitions, the Case Page, Settings, Overview, Reports, Overpaid Cases, the sidebar, and a sync modal — no clipping or layout breaks
- [x] Known minor side effect: fixed-width truncated columns (e.g. "Region" in Overpaid Cases) show slightly fewer characters before the ellipsis, since larger text needs more room — not a bug, just an inherent tradeoff; can widen specific columns on request