### PR TITLE
Fix access overrides modal scroll; finish Fees Confirmation → PIF rename

### DIFF
--- a/src/app/(dashboard)/overpaid-cases/actions.ts
+++ b/src/app/(dashboard)/overpaid-cases/actions.ts
@@ -131,7 +131,7 @@ export async function updateFeesConfirmation(input: {
     // action was the last unguarded path to the same field.
     const guard = await requireCapability("feesConfirmation.edit");
     if (!guard.ok) {
-      return { ok: false, error: "You don't have permission to update Fees Confirmation." };
+      return { ok: false, error: "You don't have permission to update PIF." };
     }
 
     if (!Number.isFinite(input.caseId)) {

--- a/src/app/api/cases/[id]/route.ts
+++ b/src/app/api/cases/[id]/route.ts
@@ -399,7 +399,7 @@ export const PATCH = async (
       const feesConfGuard = await requireCapability("feesConfirmation.edit");
       if (!feesConfGuard.ok) {
         return NextResponse.json(
-          { error: "You don't have permission to update Fees Confirmation." },
+          { error: "You don't have permission to update PIF." },
           { status: guardStatus(feesConfGuard.error) },
         );
       }
@@ -523,7 +523,7 @@ export const PATCH = async (
         updates.push("marked_overpaid = true");
         logMessage = logMessage
           ? `${logMessage} — also flagged as overpaid`
-          : "Flagged as overpaid (Fees Confirmation set to \"Overpaid\")";
+          : "Flagged as overpaid (PIF set to \"Overpaid\")";
       }
 
       if (updates.length > 0) {

--- a/src/components/admin/AccessOverridesDialog.tsx
+++ b/src/components/admin/AccessOverridesDialog.tsx
@@ -140,7 +140,7 @@ export function AccessOverridesDialog({
             <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Loading…
           </div>
         ) : (
-          <div className="space-y-3">
+          <div className="max-h-[60vh] space-y-3 overflow-y-auto pr-1">
             <div className="flex justify-end">
               <Button
                 type="button"

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -1345,7 +1345,7 @@ export const FeeRecordsTable = ({
                               "fee",
                               "feesConfirmation",
                               "feesConfirmation",
-                              "Fees Confirmation",
+                              "PIF",
                               e.target.value,
                             );
                             setFeesConfEditId(null);

--- a/src/components/cases/FeesClosedConfirmDialog.tsx
+++ b/src/components/cases/FeesClosedConfirmDialog.tsx
@@ -54,7 +54,7 @@ export function FeesClosedConfirmDialog({
         : { isClosed: false, feesConfirmation: null, feesClosedTrigger: null };
       const logMessage = isClose
         ? "Fees Closed checked — moved to Fees Closed."
-        : "Reopened from Fees Closed — moved back to the active dashboard. Fees Confirmation and Fees Closed cleared.";
+        : "Reopened from Fees Closed — moved back to the active dashboard. PIF and Fees Closed cleared.";
       const res = await fetch(`/api/cases/${caseId}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
@@ -96,7 +96,7 @@ export function FeesClosedConfirmDialog({
             ) : (
               <>
                 <span className="font-semibold">{caseName}</span> will move back
-                to the active dashboard. Fees Confirmation and Fees Closed will
+                to the active dashboard. PIF and Fees Closed will
                 be cleared.
               </>
             )}

--- a/src/components/overpaid-cases/ClearedCases.tsx
+++ b/src/components/overpaid-cases/ClearedCases.tsx
@@ -228,7 +228,7 @@ export const ClearedCases = ({ dark, t, refreshToken, onRestored }: Props) => {
         const json = await res.json();
         all = json.data || [];
       }
-      const headers = ["Case", "Assigned To", "Region", "Fees Received", "Overpaid Amount", "Fees Confirmation", "Notice Received", "Notes", "Cleared On", "Last Updated"];
+      const headers = ["Case", "Assigned To", "Region", "Fees Received", "Overpaid Amount", "PIF", "Notice Received", "Notes", "Cleared On", "Last Updated"];
       const escape = (v: string) => {
         const safe = /^[=+\-@\t\r]/.test(v) ? `'${v}` : v;
         return `"${safe.replace(/"/g, '""')}"`;
@@ -603,7 +603,7 @@ export const ClearedCases = ({ dark, t, refreshToken, onRestored }: Props) => {
                       Overpaid Amount {sortIcon("overpaidAmount")}
                     </button>
                   </th>
-                  <th className={`${thBase} ${t.textSub} text-left sticky top-0 z-20 ${stickyHeaderBg}`}>Fees Confirmation</th>
+                  <th className={`${thBase} ${t.textSub} text-left sticky top-0 z-20 ${stickyHeaderBg}`}>PIF</th>
                   <th
                     aria-sort={sortKey === "opLtrDate" ? (sortDir === "asc" ? "ascending" : "descending") : "none"}
                     className={`${thBase} ${t.textSub} text-left sticky top-0 z-20 ${stickyHeaderBg}`}

--- a/src/components/overpaid-cases/OverpaidCases.tsx
+++ b/src/components/overpaid-cases/OverpaidCases.tsx
@@ -724,7 +724,7 @@ export const OverpaidCases = () => {
         const json = await res.json();
         all = json.data || [];
       }
-      const headers = ["Case", "Assigned To", "Region", "Fees Received", "Overpaid Amount", "Fees Confirmation", "Notice Sent", "Notice Received", "Notes", "Checks Cleared", "Last Updated"];
+      const headers = ["Case", "Assigned To", "Region", "Fees Received", "Overpaid Amount", "PIF", "Notice Sent", "Notice Received", "Notes", "Checks Cleared", "Last Updated"];
       const escape = (v: string) => {
         const safe = /^[=+\-@\t\r]/.test(v) ? `'${v}` : v;
         return `"${safe.replace(/"/g, '""')}"`;
@@ -1217,7 +1217,7 @@ export const OverpaidCases = () => {
                     Overpaid Amount {sortIcon("overpaidAmount")}
                   </button>
                 </th>
-                <th className={`${thBase} ${t.textSub} text-left sticky top-0 z-20 ${stickyHeaderBg}`}>Fees Confirmation</th>
+                <th className={`${thBase} ${t.textSub} text-left sticky top-0 z-20 ${stickyHeaderBg}`}>PIF</th>
                 <th className={`${thBase} ${t.textSub} text-left sticky top-0 z-20 ${stickyHeaderBg}`}>Notice Sent</th>
                 <th
                   aria-sort={ariaSortFor("opLtrDate")}
@@ -1355,7 +1355,7 @@ export const OverpaidCases = () => {
                             placeholder="—"
                             maxLength={50}
                             disabled={!canEditFeesConf}
-                            title={!canEditFeesConf ? "You don't have permission to update Fees Confirmation." : undefined}
+                            title={!canEditFeesConf ? "You don't have permission to update PIF." : undefined}
                             className={`w-full h-7 pl-2 pr-7 rounded-md border text-[13px] outline-none focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-600 ${t.inputBg} disabled:opacity-50 disabled:cursor-not-allowed`}
                           />
                           {confirmationState[row.id] === "saving" && (

--- a/src/lib/access/capabilities.ts
+++ b/src/lib/access/capabilities.ts
@@ -54,8 +54,8 @@ export const CAPABILITIES = [
   },
   {
     key: "feesConfirmation.edit",
-    label: "Edit Fees Confirmation",
-    description: "Change the Fees Confirmation dropdown on a case. Doesn't include Fees Closed, which stays admin-only.",
+    label: "Edit PIF",
+    description: "Change the PIF dropdown on a case. Doesn't include Fees Closed, which stays admin-only.",
   },
 ] as const;
 


### PR DESCRIPTION
## Summary
- The Access Overrides modal (Admin → Users → Access) had no height cap or internal scroll, so on shorter viewports the header and Save/Close buttons became inaccessible. Fixed by wrapping the checklist content in a `max-h-[60vh] overflow-y-auto` region, matching the existing pattern in `MyCaseDocumentsDialog.tsx` — header and footer buttons now stay fixed and reachable.
- Follow-up to the PIF rename (PR #170): several user-facing "Fees Confirmation" strings were missed in the first pass — the Admin capability label/description, Overpaid Cases and Cleared Cases table headers + CSV export headers, permission error messages, the Fees-Closed reopen dialog copy, and the Activity Log message when editing PIF from Master Fees. All renamed to "PIF" for consistency. Left untouched: `CaseDetailSheet.tsx`'s "Fees Confirmation" label, which displays a different field mirrored read-only from MyCase's own system, not our renamed dropdown.

## Test plan
- [x] `npx tsc --noEmit`, `npm test` (62/62), `npm run build` all clean
- [x] Verified the modal fix visually at a short viewport (700px) — header, "Apply Role Defaults", and Save/Close buttons stay visible while the checklist scrolls internally
- [x] Verified "PIF" now shows on the Overpaid Cases table header in a real browser