### PR TITLE
Link Fee Petitions claimant names to MyCase

### DIFF
--- a/src/app/api/fee-petitions/route.ts
+++ b/src/app/api/fee-petitions/route.ts
@@ -163,6 +163,7 @@ export const GET = async (req: NextRequest) => {
         clientId: cases.clientId,
         firstName: cases.firstName,
         lastName: cases.lastName,
+        externalId: cases.externalId,
         approvalDate: cases.approvalDate,
         claimTypeLabel: cases.claimTypeLabel,
         totalFeesExpected: feeRecords.totalFeesExpected,
@@ -191,6 +192,7 @@ export const GET = async (req: NextRequest) => {
     const data = rows.map((r) => ({
       id: r.clientId,
       claimant: `${r.lastName}, ${r.firstName}`,
+      externalId: r.externalId ?? null,
       approvalDate: r.approvalDate ?? null,
       updatedAt: r.updatedAt ? r.updatedAt.toISOString().slice(0, 10) : null,
       feeAmount: r.totalFeesExpected != null ? Number(r.totalFeesExpected) : null,

--- a/src/components/fee-petitions/CompletedPetitions.tsx
+++ b/src/components/fee-petitions/CompletedPetitions.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import Link from "next/link";
 import {
   Search,
   ArrowUp,
@@ -15,6 +14,7 @@ import {
   ChevronDown,
   ChevronUp,
   RefreshCw,
+  ExternalLink,
 } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
 import { fmt, fmtDate } from "@/lib/formatters";
@@ -24,6 +24,7 @@ import { NoteField } from "@/components/shared/NoteField";
 interface CompletedRow {
   id: number;
   claimant: string;
+  externalId: string | null;
   approvalDate: string | null;
   updatedAt: string | null;
   feeAmount: number | null;
@@ -446,12 +447,19 @@ export const CompletedPetitions = ({ dark }: Props) => {
                           className={`${tdBase} ${t.text} font-semibold w-40 min-w-40 max-w-40 sticky left-0 z-10 ${stickyBg} ${stickyHover}`}
                           title={row.claimant}
                         >
-                          <Link
-                            href={`/cases/${row.id}`}
-                            className={`hover:underline truncate block ${dark ? "text-indigo-400" : "text-indigo-600"}`}
-                          >
-                            {row.claimant}
-                          </Link>
+                          {row.externalId ? (
+                            <a
+                              href={row.externalId}
+                              target="_blank"
+                              rel="noreferrer"
+                              className={`inline-flex items-center gap-1 max-w-full truncate hover:underline ${dark ? "text-indigo-400" : "text-indigo-600"}`}
+                            >
+                              <span className="truncate">{row.claimant}</span>
+                              <ExternalLink className="h-3 w-3 shrink-0 opacity-50" aria-hidden="true" />
+                            </a>
+                          ) : (
+                            <span className="truncate block">{row.claimant}</span>
+                          )}
                           {row.updatedAt && (
                             <p className={`text-[12px] ${t.textMuted} mt-0.5 font-normal`}>
                               Completed {formatRelativeDate(row.updatedAt)}

--- a/src/components/fee-petitions/FeePetitions.tsx
+++ b/src/components/fee-petitions/FeePetitions.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
-import Link from "next/link";
 import { useTheme } from "next-themes";
 import {
   Search,
@@ -19,6 +18,7 @@ import {
   Upload,
   X,
   Undo2,
+  ExternalLink,
 } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
 import { fmt, fmtDate } from "@/lib/formatters";
@@ -34,6 +34,7 @@ import { useCapabilities } from "@/hooks/useCapabilities";
 interface FeePetitionRow {
   id: number;
   claimant: string;
+  externalId: string | null;
   approvalDate: string | null;
   updatedAt: string | null;
   feeAmount: number | null;
@@ -1169,12 +1170,19 @@ export const FeePetitions = () => {
                         className={`${tdBase} ${t.text} font-semibold w-40 sticky left-10 z-10 ${stickyBg} ${stickyHover}`}
                         title={row.claimant}
                       >
-                        <Link
-                          href={`/cases/${row.id}`}
-                          className={`hover:underline truncate block ${dark ? "text-indigo-400" : "text-indigo-600"}`}
-                        >
-                          {row.claimant}
-                        </Link>
+                        {row.externalId ? (
+                          <a
+                            href={row.externalId}
+                            target="_blank"
+                            rel="noreferrer"
+                            className={`inline-flex items-center gap-1 max-w-full truncate hover:underline ${dark ? "text-indigo-400" : "text-indigo-600"}`}
+                          >
+                            <span className="truncate">{row.claimant}</span>
+                            <ExternalLink className="h-3 w-3 shrink-0 opacity-50" aria-hidden="true" />
+                          </a>
+                        ) : (
+                          <span className="truncate block">{row.claimant}</span>
+                        )}
                         {row.updatedAt && (
                           <p className={`text-[12px] ${t.textMuted} mt-0.5 font-normal`}>
                             Updated {formatRelativeDate(row.updatedAt)}


### PR DESCRIPTION
## Summary
- The claimant-name link on both the Pending and Completed sections of Fee Petitions opened the internal case detail page. Changed to open MyCase in a new tab instead, matching the exact pattern already used on Master Fees (icon, `target="_blank"`, `rel="noreferrer"`, falling back to plain text if the case has no MyCase link yet).
- `/api/fee-petitions` now selects and returns `cases.externalId` (the MyCase URL), which wasn't previously included in the response.
- Fixed both `FeePetitions.tsx` (Pending) and `CompletedPetitions.tsx` (Completed) since they're the same page/feature sharing the identical pattern.

## Test plan
- [x] `npx tsc --noEmit`, `npm test` (62/62), `npm run build` all clean
- [x] Verified in a real browser: all 50 pending + 7 completed rows link to real `mycase.com` URLs, no console errors