### PR TITLE
fix: tolerate name drift when matching session to team roster

### DIFF
--- a/src/app/api/daily-metrics/route.ts
+++ b/src/app/api/daily-metrics/route.ts
@@ -5,14 +5,16 @@ import { db } from "@/lib/db";
 import { dailyMetrics } from "@/lib/db/schema";
 import { eq, and, sql } from "drizzle-orm";
 import { sessionHasCapability } from "@/lib/auth-helpers";
+import { namesMatch } from "@/lib/formatters";
 
 // Members can only log their own calls — agent_name is matched against the
 // session's display name (team_members.name mirrors users.name for real
-// accounts). dailyMetrics.editOthers (lead/admin by default, grantable
+// accounts), tolerant of case/whitespace drift between the two independently
+// -edited fields. dailyMetrics.editOthers (lead/admin by default, grantable
 // per-user via the access overrides modal) can log for anyone.
 const canWriteAgent = (session: Session, agent: string): boolean =>
   sessionHasCapability(session, "dailyMetrics.editOthers") ||
-  agent === session.user?.name;
+  namesMatch(agent, session.user?.name);
 
 // GET /api/daily-metrics?agent=Drake&date=2026-02-20
 // GET /api/daily-metrics?week=2026-02-17  (returns all agents for the week)

--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -23,7 +23,7 @@ import {
 } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { themeClasses } from "@/lib/theme-classes";
-import { fmt, fmtDate } from "@/lib/formatters";
+import { fmt, fmtDate, namesMatch } from "@/lib/formatters";
 import { teamBadgeClasses } from "@/lib/team-colors";
 import { useCapabilities } from "@/hooks/useCapabilities";
 import {
@@ -224,7 +224,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
   const userName = session?.user?.name;
   const { can } = useCapabilities();
   const canEditAgent = (agentName: string) =>
-    can("dailyMetrics.editOthers") || (!!userName && agentName === userName);
+    can("dailyMetrics.editOthers") || namesMatch(agentName, userName);
 
   const currentYear = nowForInit.getFullYear();
   const yearOptions = useMemo(

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -1,5 +1,18 @@
 import type { WinSheetStatus, SyncStatus } from "@/types";
 
+// Trim/case-insensitive comparison for matching a session's display name
+// against an admin-managed roster name (team_members.name, agent_name on
+// daily_metrics, etc). These are two independently-edited free-text fields
+// that are supposed to mirror each other exactly — a stray space or
+// capitalization difference between them silently locks someone out of
+// editing their own row, so tolerate that class of drift rather than
+// requiring byte-for-byte equality.
+export const namesMatch = (
+  a: string | null | undefined,
+  b: string | null | undefined,
+): boolean =>
+  !!a && !!b && a.trim().toLowerCase() === b.trim().toLowerCase();
+
 export const fmt = (n: number) =>
   new Intl.NumberFormat("en-US", {
     style: "currency",


### PR DESCRIPTION
## Summary
- Daily call-log editing (Scoreboard's "Log Calls" panel) matched a signed-in agent's session name against the team roster with strict string equality — a stray space or casing difference between the two independently-edited fields silently locks someone out of editing their own row.
- Both the client-side gate and the server-side write check now use a shared trim/case-insensitive comparison.
- Doesn't fix a stale-session scenario (permissions frozen into the JWT at login) — if this recurs after this ships, the affected user needs to log out and back in.