### PR TITLE
Allow clearing Fee Due back to null via "-"

### DIFF
--- a/src/app/cases/[id]/page.tsx
+++ b/src/app/cases/[id]/page.tsx
@@ -323,9 +323,11 @@ const FeeSection = memo(
               </div>
               <div>
                 <p className={lbl}>Fee Due</p>
+                {/* type="text" — a native number input sanitizes a bare "-"
+                    to "" before onChange sees it, breaking clear-to-null. */}
                 <input
-                  type="number"
-                  step="0.01"
+                  type="text"
+                  inputMode="decimal"
                   value={fields.ld}
                   onChange={(e) => setField("ld", e.target.value)}
                   title='Type "-" to clear back to blank'

--- a/src/app/cases/[id]/page.tsx
+++ b/src/app/cases/[id]/page.tsx
@@ -229,8 +229,10 @@ const FeeSection = memo(
         const newRetro = parseFloat(fields.lr) || 0;
         // An empty box means "didn't touch it" — treat as unchanged rather
         // than coercing to 0, which would wrongly turn an untouched (null)
-        // Fee Due into an explicit $0.00 on every save.
-        const newDue = fields.ld.trim() === "" ? due : parseFloat(fields.ld) || 0;
+        // Fee Due into an explicit $0.00 on every save. A literal "-" is the
+        // deliberate gesture to clear an already-set Fee Due back to null.
+        const dueTrimmed = fields.ld.trim();
+        const newDue = dueTrimmed === "" ? due : dueTrimmed === "-" ? null : parseFloat(fields.ld) || 0;
         const newReceived = parseFloat(fields.lrcv) || 0;
 
         if (newRetro !== retro) {
@@ -239,7 +241,7 @@ const FeeSection = memo(
         }
         if (newDue !== due) {
           feeFields[`${prefix}FeeDue`] = newDue;
-          changes.push(`${title} Fee Due: ${due == null ? "—" : `$${due}`} → $${newDue}`);
+          changes.push(`${title} Fee Due: ${due == null ? "—" : `$${due}`} → ${newDue == null ? "—" : `$${newDue}`}`);
         }
         if (newReceived !== received) {
           feeFields[`${prefix}FeeReceived`] = newReceived;
@@ -326,6 +328,7 @@ const FeeSection = memo(
                   step="0.01"
                   value={fields.ld}
                   onChange={(e) => setField("ld", e.target.value)}
+                  title='Type "-" to clear back to blank'
                   className={inpCls}
                 />
               </div>

--- a/src/components/cases/FeeAmountCell.tsx
+++ b/src/components/cases/FeeAmountCell.tsx
@@ -51,6 +51,7 @@ export function FeeAmountCell({
             type="number" min="0" step="0.01" value={draft} autoFocus
             onChange={(e) => onDraftChange(e.target.value)}
             onKeyDown={(e) => { if (e.key === "Enter") onSave(); if (e.key === "Escape") onCancel(); }}
+            title={allowExplicitZero ? 'Type "-" to clear back to blank' : undefined}
             className={`h-6 px-1.5 rounded border text-[13px] outline-none w-24 text-right ${inputBg}`}
           />
           {saving ? (

--- a/src/components/cases/FeeAmountCell.tsx
+++ b/src/components/cases/FeeAmountCell.tsx
@@ -47,8 +47,14 @@ export function FeeAmountCell({
     return (
       <div className="flex flex-col items-end gap-1 min-w-[110px]">
         <div className="flex items-center gap-0.5">
+          {/* Fee Due uses type="text" — a native number input sanitizes a
+              bare "-" straight to "" before onChange ever sees it, which
+              would silently break the clear-to-null gesture below. */}
           <input
-            type="number" min="0" step="0.01" value={draft} autoFocus
+            {...(allowExplicitZero
+              ? { type: "text" as const, inputMode: "decimal" as const }
+              : { type: "number" as const, min: "0", step: "0.01" })}
+            value={draft} autoFocus
             onChange={(e) => onDraftChange(e.target.value)}
             onKeyDown={(e) => { if (e.key === "Enter") onSave(); if (e.key === "Escape") onCancel(); }}
             title={allowExplicitZero ? 'Type "-" to clear back to blank' : undefined}

--- a/src/components/cases/FeeEditModal.tsx
+++ b/src/components/cases/FeeEditModal.tsx
@@ -141,11 +141,15 @@ export default function FeeEditModal({
   const lbl = `text-[12px] font-semibold uppercase tracking-wider ${t.textMuted}`;
   const inpCls = `mt-1 h-7 px-2 rounded border text-[14px] outline-none w-full ${t.inputBg}`;
 
-  const field = (label: string, value: string, onChange: (e: React.ChangeEvent<HTMLInputElement>) => void, type: "number" | "date" = "number", title?: string) => (
+  // "decimal" renders type="text" inputMode="decimal" — a native number
+  // input sanitizes a bare "-" to "" before onChange sees it, breaking the
+  // Fee Due clear-to-null gesture below.
+  const field = (label: string, value: string, onChange: (e: React.ChangeEvent<HTMLInputElement>) => void, type: "number" | "date" | "decimal" = "number", title?: string) => (
     <div>
       <p className={lbl}>{label}</p>
       <input
-        type={type}
+        type={type === "decimal" ? "text" : type}
+        inputMode={type === "decimal" ? "decimal" : undefined}
         step={type === "number" ? "0.01" : undefined}
         value={value}
         onChange={onChange}
@@ -191,7 +195,7 @@ export default function FeeEditModal({
             </h4>
             <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
               {field("Retro Amount", f.t16Retro, set("t16Retro"))}
-              {field("Fee Due", f.t16Due, set("t16Due"), "number", FEE_DUE_HINT)}
+              {field("Fee Due", f.t16Due, set("t16Due"), "decimal", FEE_DUE_HINT)}
               {field("Fee Received", f.t16Rcv, set("t16Rcv"))}
               {field("Date Received", f.t16Dt, set("t16Dt"), "date")}
             </div>
@@ -206,7 +210,7 @@ export default function FeeEditModal({
             </h4>
             <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
               {field("Retro Amount", f.t2Retro, set("t2Retro"))}
-              {field("Fee Due", f.t2Due, set("t2Due"), "number", FEE_DUE_HINT)}
+              {field("Fee Due", f.t2Due, set("t2Due"), "decimal", FEE_DUE_HINT)}
               {field("Fee Received", f.t2Rcv, set("t2Rcv"))}
               {field("Date Received", f.t2Dt, set("t2Dt"), "date")}
             </div>
@@ -221,7 +225,7 @@ export default function FeeEditModal({
             </h4>
             <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
               {field("Retro Amount", f.auxRetro, set("auxRetro"))}
-              {field("Fee Due", f.auxDue, set("auxDue"), "number", FEE_DUE_HINT)}
+              {field("Fee Due", f.auxDue, set("auxDue"), "decimal", FEE_DUE_HINT)}
               {field("Fee Received", f.auxRcv, set("auxRcv"))}
               {field("Date Received", f.auxDt, set("auxDt"), "date")}
             </div>

--- a/src/components/cases/FeeEditModal.tsx
+++ b/src/components/cases/FeeEditModal.tsx
@@ -77,11 +77,14 @@ export default function FeeEditModal({
       // numeric diff can't tell apart from null (JS coerces null to 0 in
       // arithmetic, which would silently swallow an intentional $0.00 edit).
       const chkFeeDue = (rawStr: string, ov: number | null, key: string, label: string) => {
-        const touched = rawStr.trim() !== "";
-        const nv = touched ? parseFloat(rawStr) || 0 : ov;
+        const trimmed = rawStr.trim();
+        // A literal "-" is the deliberate gesture to clear an already-set
+        // Fee Due back to null — distinct from leaving the box empty, which
+        // means "didn't touch it."
+        const nv = trimmed === "" ? ov : trimmed === "-" ? null : parseFloat(rawStr) || 0;
         if (nv !== ov) {
           feeFields[key] = nv;
-          changes.push(`${label}: ${ov == null ? "—" : `$${ov}`} → $${nv}`);
+          changes.push(`${label}: ${ov == null ? "—" : `$${ov}`} → ${nv == null ? "—" : `$${nv}`}`);
         }
       };
       const chkDt = (
@@ -138,7 +141,7 @@ export default function FeeEditModal({
   const lbl = `text-[12px] font-semibold uppercase tracking-wider ${t.textMuted}`;
   const inpCls = `mt-1 h-7 px-2 rounded border text-[14px] outline-none w-full ${t.inputBg}`;
 
-  const field = (label: string, value: string, onChange: (e: React.ChangeEvent<HTMLInputElement>) => void, type: "number" | "date" = "number") => (
+  const field = (label: string, value: string, onChange: (e: React.ChangeEvent<HTMLInputElement>) => void, type: "number" | "date" = "number", title?: string) => (
     <div>
       <p className={lbl}>{label}</p>
       <input
@@ -146,10 +149,12 @@ export default function FeeEditModal({
         step={type === "number" ? "0.01" : undefined}
         value={value}
         onChange={onChange}
+        title={title}
         className={inpCls}
       />
     </div>
   );
+  const FEE_DUE_HINT = 'Type "-" to clear back to blank';
 
   return (
     <div
@@ -186,7 +191,7 @@ export default function FeeEditModal({
             </h4>
             <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
               {field("Retro Amount", f.t16Retro, set("t16Retro"))}
-              {field("Fee Due", f.t16Due, set("t16Due"))}
+              {field("Fee Due", f.t16Due, set("t16Due"), "number", FEE_DUE_HINT)}
               {field("Fee Received", f.t16Rcv, set("t16Rcv"))}
               {field("Date Received", f.t16Dt, set("t16Dt"), "date")}
             </div>
@@ -201,7 +206,7 @@ export default function FeeEditModal({
             </h4>
             <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
               {field("Retro Amount", f.t2Retro, set("t2Retro"))}
-              {field("Fee Due", f.t2Due, set("t2Due"))}
+              {field("Fee Due", f.t2Due, set("t2Due"), "number", FEE_DUE_HINT)}
               {field("Fee Received", f.t2Rcv, set("t2Rcv"))}
               {field("Date Received", f.t2Dt, set("t2Dt"), "date")}
             </div>
@@ -216,7 +221,7 @@ export default function FeeEditModal({
             </h4>
             <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
               {field("Retro Amount", f.auxRetro, set("auxRetro"))}
-              {field("Fee Due", f.auxDue, set("auxDue"))}
+              {field("Fee Due", f.auxDue, set("auxDue"), "number", FEE_DUE_HINT)}
               {field("Fee Received", f.auxRcv, set("auxRcv"))}
               {field("Date Received", f.auxDt, set("auxDt"), "date")}
             </div>

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -645,17 +645,26 @@ export const FeeRecordsTable = ({
 
   const handleFeeAmountSave = async () => {
     if (!feeAmountEdit || feeAmountSaving) return;
-    const amount = parseFloat(feeAmountEdit.draft);
-    if (isNaN(amount) || amount < 0) {
-      setFeeAmountError("Enter a valid amount (0 or more).");
+    const { caseId, field } = feeAmountEdit;
+    // Fee Due is the only field where null is a meaningful, distinct value
+    // ("never touched", renders "—") from an explicit $0.00 — Retro fields
+    // still default to 0 at the DB level, so a bare "-" there is just invalid
+    // input, not a clear-to-null gesture.
+    const isFeeDue = field.endsWith("FeeDue");
+    const clearing = isFeeDue && feeAmountEdit.draft.trim() === "-";
+    const parsed = parseFloat(feeAmountEdit.draft);
+    if (!clearing && (isNaN(parsed) || parsed < 0)) {
+      setFeeAmountError(
+        isFeeDue ? "Enter a valid amount (0 or more), or \"-\" to clear." : "Enter a valid amount (0 or more).",
+      );
       return;
     }
+    const amount: number | null = clearing ? null : parsed;
     feeAmountAbortRef.current?.abort();
     const controller = new AbortController();
     feeAmountAbortRef.current = controller;
     setFeeAmountSaving(true);
     setFeeAmountError(null);
-    const { caseId, field } = feeAmountEdit;
     const labelMap: Record<FeeAmountField, string> = {
       t16Retro: "T16 Retro", t16FeeDue: "T16 Fee Due",
       t2Retro: "T2 Retro",   t2FeeDue: "T2 Fee Due",
@@ -667,7 +676,9 @@ export const FeeRecordsTable = ({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           feeFields: { [field]: amount },
-          logMessage: `${labelMap[field]} updated to ${fmtFull(amount)}`,
+          logMessage: clearing
+            ? `${labelMap[field]} cleared`
+            : `${labelMap[field]} updated to ${fmtFull(parsed)}`,
         }),
         signal: controller.signal,
       });


### PR DESCRIPTION
## Summary
- Typing `-` into a Fee Due input (T16/T2/AUX) now clears it back to `null` instead of silently saving an explicit `$0.00` — across the Master Fees table, the case detail page's inline editor, and the Edit Fees modal.
- Fixes the underlying data-entry gap behind the Hassan Allen PIF report: an explicit `$0.00` correctly means "no fee owed" (PIF auto-satisfies it), but there was previously no way to clear a Fee Due back to "not yet determined" once it had a value — leaving stale legacy zeros indistinguishable from real determinations.
- No trigger/schema change — the server already accepted `null` for these fields end-to-end.

## Test plan
- [ ] Master Fees: edit a Fee Due cell, type `-`, save → cell shows "—", DB value is `null`.
- [ ] Case detail page inline Fee Due editor: same check.
- [ ] Edit Fees modal: same check for T16/T2/AUX Fee Due.
- [ ] Confirm Retro fields are unaffected (typing `-` there still shows a validation error, not a clear).