### PR TITLE
fix: redefine Reports "No Fees" stat as fees due but not received

### DIFF
--- a/src/app/api/scoreboard/route.ts
+++ b/src/app/api/scoreboard/route.ts
@@ -313,10 +313,16 @@ export const GET = async (req: NextRequest) => {
       }),
     );
 
-    // Bucketed by fees_confirmation alone so this always matches the same
-    // definition used by the No Fees Cases aging query below.
+    // "No fees" = has a real fee due but hasn't fully received it yet
+    // (outstanding balance > 0) — not a PIF/fees_confirmation check, since
+    // that flags whether staff have *reviewed* the case, not whether money
+    // is actually still owed. Bucketed the same way here and in the No Fees
+    // Cases aging query below so this card and that table can never disagree.
     const [feesStatus] = await db.execute(sql`
-      SELECT COUNT(*) FILTER (WHERE fees_confirmation IS NULL OR fees_confirmation = '')::int AS no_fees_count
+      SELECT COUNT(*) FILTER (
+        WHERE COALESCE(total_fees_expected, 0) > 0
+          AND COALESCE(total_fees_expected, 0) > COALESCE(total_fees_paid, 0)
+      )::int AS no_fees_count
       FROM fee_records
       WHERE is_closed = false
     `) as unknown as [{ no_fees_count: number }];
@@ -325,12 +331,12 @@ export const GET = async (req: NextRequest) => {
       noFees: Number(feesStatus?.no_fees_count) || 0,
     };
 
-    // No Fees Cases — open cases with no fees_confirmation set (same
-    // predicate as openCasesFeesStatus.noFees above), aged over 60 days by
-    // approval_date. Returns the actual case rows (not just a count) so the
-    // Reports page can list them for reporting; over60/over90 counts are
-    // derived from this same list below so the card and the table can never
-    // disagree.
+    // No Fees Cases — open cases with a real fee due that hasn't been fully
+    // received (same predicate as openCasesFeesStatus.noFees above), aged
+    // over 60 days by approval_date. Returns the actual case rows (not just
+    // a count) so the Reports page can list them for reporting; over60/over90
+    // counts are derived from this same list below so the card and the table
+    // can never disagree.
     const noFeesCaseRows = await db.execute(sql`
       SELECT
         c.client_id AS id,
@@ -344,7 +350,8 @@ export const GET = async (req: NextRequest) => {
       FROM fee_records fr
       JOIN cases c ON c.client_id = fr.case_id
       WHERE fr.is_closed = FALSE
-        AND (fr.fees_confirmation IS NULL OR fr.fees_confirmation = '')
+        AND COALESCE(fr.total_fees_expected, 0) > 0
+        AND COALESCE(fr.total_fees_expected, 0) > COALESCE(fr.total_fees_paid, 0)
         AND c.approval_date IS NOT NULL
         AND c.approval_date < CURRENT_DATE - INTERVAL '60 days'
       ORDER BY c.approval_date ASC


### PR DESCRIPTION
## Summary
- Jazz asked how the "No Fees Over 60 Days" stat (239) on Reports was calculated, and requested it only count cases that actually have fees due but haven't received them — not just cases where PIF was never reviewed.
- Old definition: `fees_confirmation IS NULL OR fees_confirmation = ''` (measures whether staff reviewed PIF, not whether money is owed).
- New definition: `total_fees_expected > 0 AND total_fees_expected > total_fees_paid` — covers both zero-received and partially-paid cases (confirmed with Kentshin: partial payments still count as outstanding).
- Applied consistently to both the aggregate "No Fees" card and the "No Fees Cases" aging query (60/90 days), which the existing code deliberately keeps in sync.
- Verified against live production data: old definition = 239 (matches Jazz's reported number exactly), new definition = 210.

## Test plan
- [ ] Reports page: "No Fees" / "No Fees Over 60 Days" / "No Fees Over 90 Days" cards show the new counts.
- [ ] Spot-check a few cases in the "No Fees Cases" table — each should have `total_fees_expected > total_fees_paid > = 0`, regardless of PIF status.
- [ ] Confirm a case explicitly marked PIF "No" but with a real outstanding balance now correctly appears (previously excluded).
- [ ] Confirm a case with PIF never set but `total_fees_expected = 0` (or fully paid) no longer appears.