### PR TITLE
Restore manual Add Case on Overpaid Cases

### DIFF
--- a/src/app/(dashboard)/overpaid-cases/actions.ts
+++ b/src/app/(dashboard)/overpaid-cases/actions.ts
@@ -153,6 +153,31 @@ export async function bulkRemoveFromOverpaid(input: {
   }
 }
 
+// Marks a single case overpaid directly — for old cases that never came
+// through Master Fees and shouldn't be added there just to flag them here.
+// The normal path (setting PIF to "Overpaid" on Master Fees) already sets
+// marked_overpaid atomically; this covers the escape hatch for cases with
+// no fee history to track at all, right after AddCaseModal creates the bare
+// case record.
+export async function markCaseOverpaid(input: {
+  caseId: number;
+}): Promise<Result> {
+  try {
+    const guard = await requireCapability("case.finalize");
+    if (!guard.ok) return { ok: false, error: "You don't have permission to mark cases overpaid." };
+    if (!Number.isFinite(input.caseId)) return { ok: false, error: "Invalid case ID" };
+
+    await db
+      .update(feeRecords)
+      .set({ markedOverpaid: true, overpaidDismissedAt: null, updatedAt: new Date() })
+      .where(eq(feeRecords.caseId, input.caseId));
+    return { ok: true };
+  } catch (error) {
+    console.error("markCaseOverpaid error:", error);
+    return { ok: false, error: "Server error" };
+  }
+}
+
 export async function updateFeesConfirmation(input: {
   caseId: number;
   feesConfirmation: string;

--- a/src/components/overpaid-cases/OverpaidCases.tsx
+++ b/src/components/overpaid-cases/OverpaidCases.tsx
@@ -16,13 +16,16 @@ import {
   ChevronLeft,
   ChevronRight,
   Download,
+  Plus,
   X,
   Undo2,
   Trash2,
 } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
 import { fmt, fmtFull } from "@/lib/formatters";
-import { upsertOverpaidCase, updateFeesConfirmation, bulkMarkCleared, bulkRestoreCleared, bulkRemoveFromOverpaid } from "@/app/(dashboard)/overpaid-cases/actions";
+import { upsertOverpaidCase, updateFeesConfirmation, bulkMarkCleared, bulkRestoreCleared, bulkRemoveFromOverpaid, markCaseOverpaid } from "@/app/(dashboard)/overpaid-cases/actions";
+import AddCaseModal from "@/components/modals/AddCaseModal";
+import { fetchDropdownOptions, type DropdownOptionsByCategory } from "@/lib/dropdown-options";
 import { NoteField } from "@/components/shared/NoteField";
 import { ClearedCases } from "@/components/overpaid-cases/ClearedCases";
 import { useCapabilities } from "@/hooks/useCapabilities";
@@ -90,6 +93,7 @@ export const OverpaidCases = () => {
   const dark = mounted ? resolvedTheme === "dark" : false;
   const t = themeClasses(dark);
   const { can } = useCapabilities();
+  const canFinalize = can("case.finalize");
   const canEditFeesConf = can("feesConfirmation.edit");
 
   const router = useRouter();
@@ -660,6 +664,33 @@ export const OverpaidCases = () => {
   };
 
   const [exporting, setExporting] = useState(false);
+  const [addCaseOpen, setAddCaseOpen] = useState(false);
+  const [dropdownOptions, setDropdownOptions] = useState<DropdownOptionsByCategory>({});
+
+  // Lazy-loaded the first time the Add Case modal opens — this page doesn't
+  // otherwise need the full dropdown-options set, so there's no reason to
+  // fetch it on every page load.
+  const openAddCase = async () => {
+    if (Object.keys(dropdownOptions).length === 0) {
+      try {
+        setDropdownOptions(await fetchDropdownOptions());
+      } catch {
+        /* non-critical — modal falls back to empty dropdowns */
+      }
+    }
+    setAddCaseOpen(true);
+  };
+
+  // A manually-added case has no fee_records row marked overpaid yet (it
+  // isn't part of a Sheets/MyCase sync, just created bare via AddCaseModal),
+  // so flip that flag right after creation — this is what actually makes it
+  // show up in this page's own list. For old cases that never came through
+  // Master Fees and don't belong there.
+  const markNewCaseOverpaid = async (clientId: number) => {
+    const result = await markCaseOverpaid({ caseId: clientId });
+    if (!result.ok) throw new Error(result.error);
+    await fetchCases();
+  };
 
   const downloadCsv = async () => {
     setExporting(true);
@@ -744,6 +775,14 @@ export const OverpaidCases = () => {
 
   return (
     <div className="space-y-4">
+      {addCaseOpen && (
+        <AddCaseModal
+          dark={dark}
+          dropdownOptions={dropdownOptions}
+          onClose={() => setAddCaseOpen(false)}
+          onCreated={markNewCaseOverpaid}
+        />
+      )}
       <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
         {liveMessage}
       </div>
@@ -985,6 +1024,17 @@ export const OverpaidCases = () => {
                 {selectedIds.size > 0 ? `Export ${selectedIds.size} selected` : "Export"}
               </span>
             </button>
+            {canFinalize && (
+              <button
+                onClick={openAddCase}
+                className={`h-8 px-2.5 rounded-md border text-xs font-medium flex items-center gap-1.5 ${t.outlineBtn}`}
+                aria-label="Manually add an overpaid case"
+                title="For old cases that never came through Master Fees"
+              >
+                <Plus aria-hidden="true" className="h-3.5 w-3.5" />
+                <span className="hidden sm:inline">Add Case</span>
+              </button>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Kentshin reported the "Add Case" option was missing from Overpaid Cases, needed for old cases that never came through Master Fees and shouldn't be added there just to flag them as overpaid.
- Restores the "Add Case" button, `AddCaseModal` integration, and the create-then-mark-overpaid flow that was removed in PR #186.
- Re-implemented as a new server action `markCaseOverpaid` (rather than restoring the deleted `POST /api/cases/bulk-overpaid` route), consistent with this file's existing server-action conventions and correctly integrated with the `overpaid_dismissed_at` architecture built since the removal.
- CSV bulk-import for Overpaid Cases stays removed — only the single-case "Add Case" flow was requested back.

## Test plan
- [x] Browser-tested end to end with a disposable test case: created via the UI, confirmed `marked_overpaid = true` in the database, confirmed the case appears on Overpaid Cases (Pending Cases count incremented). Cleaned up afterward.
- [ ] Confirm the "Add Case" button is gated behind `case.finalize` (hidden for members).
- [ ] Confirm a case added this way does NOT appear on Master Fees.