### PR TITLE
Fix week-start date off by one day for timezones east of UTC

### DIFF
--- a/src/app/api/scoreboard/route.ts
+++ b/src/app/api/scoreboard/route.ts
@@ -23,17 +23,23 @@ export const GET = async (req: NextRequest) => {
     const fromParam = searchParams.get("from");
     const toParam = searchParams.get("to");
 
-    // Calculate Monday of the target week (used as the default window)
-    const now = new Date();
+    // Calculate Monday of the target week (used as the default window).
+    // Local getters, not toISOString() — this route only hits this branch
+    // when no `week` param is supplied, and every current caller always
+    // supplies one, but toISOString() would still be wrong by a day for a
+    // server running outside UTC.
     let monday: string;
     if (weekParam) {
       monday = weekParam;
     } else {
-      const d = new Date(now);
+      const d = new Date();
       const day = d.getDay();
       const diff = d.getDate() - day + (day === 0 ? -6 : 1);
       d.setDate(diff);
-      monday = d.toISOString().split("T")[0];
+      const y = d.getFullYear();
+      const m = String(d.getMonth() + 1).padStart(2, "0");
+      const dd = String(d.getDate()).padStart(2, "0");
+      monday = `${y}-${m}-${dd}`;
     }
 
     // Resolve the call-aggregation window: explicit range when both from/to

--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -23,7 +23,7 @@ import {
 } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { themeClasses } from "@/lib/theme-classes";
-import { fmt, fmtDate, namesMatch } from "@/lib/formatters";
+import { fmt, fmtDate, namesMatch, getMonday, formatWeekLabel } from "@/lib/formatters";
 import { teamBadgeClasses } from "@/lib/team-colors";
 import { useCapabilities } from "@/hooks/useCapabilities";
 import {
@@ -133,19 +133,14 @@ const MONTH_NAMES = [
 
 // ---------- helpers ----------
 
-const getMonday = (offset = 0): string => {
-  const d = new Date();
-  const day = d.getDay();
-  d.setDate(d.getDate() - day + (day === 0 ? -6 : 1) + offset * 7);
-  return d.toISOString().split("T")[0];
-};
-
-const formatWeekLabel = (monday: string): string => {
-  const start = new Date(monday + "T00:00:00");
-  const end = new Date(monday + "T00:00:00");
-  end.setDate(end.getDate() + 4);
-  const opts: Intl.DateTimeFormatOptions = { month: "short", day: "numeric" };
-  return `${start.toLocaleDateString("en-US", opts)} – ${end.toLocaleDateString("en-US", { ...opts, year: "numeric" })}`;
+// Local getters, never toISOString() — that converts to UTC and rolls the
+// date back a day for anyone east of UTC (e.g. Philippines, UTC+8) on any
+// local date built via setDate()/local-midnight parsing.
+const toLocalIso = (d: Date): string => {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${dd}`;
 };
 
 const getWeekDays = (monday: string) => {
@@ -153,7 +148,7 @@ const getWeekDays = (monday: string) => {
     const d = new Date(monday + "T00:00:00");
     d.setDate(d.getDate() + i);
     return {
-      date: d.toISOString().split("T")[0],
+      date: toLocalIso(d),
       label: d.toLocaleDateString("en-US", { month: "short", day: "numeric" }),
       dayName,
     };

--- a/src/components/scoreboard/Scoreboard.tsx
+++ b/src/components/scoreboard/Scoreboard.tsx
@@ -9,6 +9,7 @@ import { bulkImportDailyMetrics } from "@/app/(dashboard)/scoreboard/actions";
 import { parseDate, parseNonNegativeInt } from "@/lib/import/csv-parser";
 import { teamHeaderBg } from "@/lib/team-colors";
 import { useCapabilities } from "@/hooks/useCapabilities";
+import { getMonday } from "@/lib/formatters";
 
 // ---------- types ----------
 
@@ -26,13 +27,6 @@ interface WeekSlot {
 }
 
 // ---------- helpers ----------
-
-const getMonday = (offsetWeeks: number): string => {
-  const d = new Date();
-  const day = d.getDay();
-  d.setDate(d.getDate() - day + (day === 0 ? -6 : 1) + offsetWeeks * 7);
-  return d.toISOString().split("T")[0];
-};
 
 const weekRangeLabel = (monday: string): string => {
   const start = new Date(monday + "T12:00:00");

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -34,11 +34,21 @@ export const fmtDate = (d: string | null | undefined): string => {
 
 // Monday (YYYY-MM-DD) of the current week, shifted by `offset` weeks.
 // Shared by the week-nav tabs on Notifications and Reports.
+//
+// Builds the string from local Y/M/D getters rather than toISOString()
+// (which converts to UTC) — for anyone east of UTC (e.g. Philippines,
+// UTC+8), toISOString() rolls back to the previous calendar day for any
+// local time before 8am, making this return Sunday's date on a Monday
+// morning. Local getters always reflect the calendar date setDate() above
+// actually produced, regardless of timezone.
 export const getMonday = (offset = 0): string => {
   const d = new Date();
   const day = d.getDay();
   d.setDate(d.getDate() - day + (day === 0 ? -6 : 1) + offset * 7);
-  return d.toISOString().split("T")[0];
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${dd}`;
 };
 
 // "Jun 29 – Jul 3, 2026"-style label for the week starting at `monday`.


### PR DESCRIPTION
## Summary
- Kentshin reported the Daily Call Log modal (Reports > Log Calls) showed wrong dates: labeled Mon=Jul 5 when Jul 6 is the actual Monday.
- Root cause: `getMonday()` computed the correct local calendar date via `setDate()`, then converted it to a string via `.toISOString()` — which converts to UTC first. For anyone east of UTC (Philippines, UTC+8, matching this team), any local time before 8am rolls the date back to the previous day, shifting the whole Mon–Fri week one day early.
- This was a bug class, not a one-off — found the identical pattern independently duplicated in 4 places: the shared `getMonday()` in `formatters.ts`, local copies in `ScoreboardTracker.tsx` and `Scoreboard.tsx`, and a server-side fallback in `/api/scoreboard/route.ts`.
- Also fixed a second, more serious variant in `ScoreboardTracker.tsx`'s `getWeekDays()`: the *internal date key* used to save/load each day's call counts had the same bug independently of the displayed label — meaning data could silently save under the wrong date even when the label looked correct.
- Fix: build date strings from local `getFullYear()/getMonth()/getDate()` getters instead of `toISOString()`. Deduplicated the two local copies to import the shared, now-fixed helper.

## Test plan
- [x] Verified in a real browser with timezone forced to Asia/Manila at 4:40 AM (the exact bug-triggering window) — Daily Call Log now correctly shows Mon=Jul 6, Tue=Jul 7, Wed=Jul 8, Thu=Jul 9, Fri=Jul 10.
- [ ] Spot-check Scoreboard's week navigation (5-week view) for correct week-start dates in the affected timezone/time window.
- [ ] Note: since the internal date key was also wrong, some historical call-log entries saved while this bug was active may now display under a different (correct) day than before — this is the data surfacing under its true date, not new data loss.