### PR TITLE
No Fees stat: only zero-received cases, exclusive aging buckets

### DIFF
--- a/src/app/api/scoreboard/route.ts
+++ b/src/app/api/scoreboard/route.ts
@@ -313,15 +313,16 @@ export const GET = async (req: NextRequest) => {
       }),
     );
 
-    // "No fees" = has a real fee due but hasn't fully received it yet
-    // (outstanding balance > 0) — not a PIF/fees_confirmation check, since
-    // that flags whether staff have *reviewed* the case, not whether money
-    // is actually still owed. Bucketed the same way here and in the No Fees
-    // Cases aging query below so this card and that table can never disagree.
+    // "No fees" = has a real fee due and has received nothing at all yet —
+    // not a partial balance (some received, still owing) and not a
+    // PIF/fees_confirmation check, since that flags whether staff have
+    // *reviewed* the case, not whether any money has come in. Bucketed the
+    // same way here and in the No Fees Cases aging query below so this card
+    // and that table can never disagree.
     const [feesStatus] = await db.execute(sql`
       SELECT COUNT(*) FILTER (
         WHERE COALESCE(total_fees_expected, 0) > 0
-          AND COALESCE(total_fees_expected, 0) > COALESCE(total_fees_paid, 0)
+          AND COALESCE(total_fees_paid, 0) = 0
       )::int AS no_fees_count
       FROM fee_records
       WHERE is_closed = false
@@ -331,12 +332,12 @@ export const GET = async (req: NextRequest) => {
       noFees: Number(feesStatus?.no_fees_count) || 0,
     };
 
-    // No Fees Cases — open cases with a real fee due that hasn't been fully
-    // received (same predicate as openCasesFeesStatus.noFees above), aged
-    // over 60 days by approval_date. Returns the actual case rows (not just
-    // a count) so the Reports page can list them for reporting; over60/over90
-    // counts are derived from this same list below so the card and the table
-    // can never disagree.
+    // No Fees Cases — open cases with a real fee due and nothing received at
+    // all (same predicate as openCasesFeesStatus.noFees above), aged over 60
+    // days by approval_date. Returns the actual case rows (not just a count)
+    // so the Reports page can list them for reporting; over60/over90 counts
+    // are derived from this same list below so the card and the table can
+    // never disagree.
     const noFeesCaseRows = await db.execute(sql`
       SELECT
         c.client_id AS id,
@@ -351,7 +352,7 @@ export const GET = async (req: NextRequest) => {
       JOIN cases c ON c.client_id = fr.case_id
       WHERE fr.is_closed = FALSE
         AND COALESCE(fr.total_fees_expected, 0) > 0
-        AND COALESCE(fr.total_fees_expected, 0) > COALESCE(fr.total_fees_paid, 0)
+        AND COALESCE(fr.total_fees_paid, 0) = 0
         AND c.approval_date IS NOT NULL
         AND c.approval_date < CURRENT_DATE - INTERVAL '60 days'
       ORDER BY c.approval_date ASC
@@ -376,8 +377,11 @@ export const GET = async (req: NextRequest) => {
       daysSinceApproval: Number(r.days_since_approval) || 0,
     }));
 
+    // Mutually exclusive buckets — a case over 90 days counts only in the
+    // 90-day bucket, not in both, so the two numbers can be added together
+    // without double-counting.
     const noFeesAging = {
-      over60: noFeesCases.length,
+      over60: noFeesCases.filter((c) => c.daysSinceApproval > 60 && c.daysSinceApproval <= 90).length,
       over90: noFeesCases.filter((c) => c.daysSinceApproval > 90).length,
     };
 

--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -506,7 +506,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
           <div className={`grid grid-cols-3 divide-x divide-dashed ${dark ? "divide-neutral-700" : "divide-neutral-200"}`}>
             {[
               { label: "No Fees",              value: data.openCasesFeesStatus.noFees, tone: dark ? "text-amber-400" : "text-amber-600" },
-              { label: "No Fees Over 60 Days",  value: data.noFeesAging.over60,         tone: dark ? "text-orange-400" : "text-orange-600" },
+              { label: "No Fees 60–90 Days",    value: data.noFeesAging.over60,         tone: dark ? "text-orange-400" : "text-orange-600" },
               { label: "No Fees Over 90 Days",  value: data.noFeesAging.over90,         tone: dark ? "text-red-400"   : "text-red-600"   },
             ].map(({ label, value, tone }) => (
               <div key={label} className="py-3 text-center">
@@ -524,7 +524,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
           <div className={`px-4 py-2.5 flex items-center justify-between border-b ${t.borderLight}`}>
             <span className={`text-xs font-bold ${t.text}`}>No Fees Cases</span>
             <span className="text-[13px] font-medium tabular-nums">
-              <span className={dark ? "text-amber-400" : "text-amber-600"}>{data.noFeesAging.over60} over 60 days</span>
+              <span className={dark ? "text-amber-400" : "text-amber-600"}>{data.noFeesAging.over60} 60–90 days</span>
               <span className={t.textMuted}> · </span>
               <span className={dark ? "text-red-400" : "text-red-600"}>{data.noFeesAging.over90} over 90 days</span>
             </span>


### PR DESCRIPTION
## Summary
Ms. Jazz clarified two things about the "No Fees" stat on Reports (follow-up to PR #190/#191):
- Only count cases with **nothing received at all**, not cases with a partial balance (some received, still owing). Predicate changed from `total_fees_expected > total_fees_paid` (any outstanding balance) to `total_fees_paid = 0`.
- The 60–90 day and 90+ day aging buckets should be **mutually exclusive**, not 90+ nested inside 60+, so the two numbers can be added together without double-counting.
- Relabeled "No Fees Over 60 Days" to "No Fees 60–90 Days" in the UI to make the new exclusivity explicit at a glance.

## Test plan
- [x] Verified live against production data: No Fees = 188, No Fees 60–90 Days = 43, No Fees Over 90 Days = 94 (43 + 94 = 137 ≤ 188, no double-counting — matches direct DB query).
- [x] Confirmed a real case with a partial balance ($5,936.83 received of $8,905.25 due) is now correctly excluded from the "No Fees Cases" list.
- [x] Confirmed real 60–90 day cases (89 days, 62 days) appear correctly in the list.