### PR TITLE
chore: sync develop → main

### DIFF
--- a/src/app/api/scoreboard/route.ts
+++ b/src/app/api/scoreboard/route.ts
@@ -23,17 +23,23 @@ export const GET = async (req: NextRequest) => {
     const fromParam = searchParams.get("from");
     const toParam = searchParams.get("to");
 
-    // Calculate Monday of the target week (used as the default window)
-    const now = new Date();
+    // Calculate Monday of the target week (used as the default window).
+    // Local getters, not toISOString() — this route only hits this branch
+    // when no `week` param is supplied, and every current caller always
+    // supplies one, but toISOString() would still be wrong by a day for a
+    // server running outside UTC.
     let monday: string;
     if (weekParam) {
       monday = weekParam;
     } else {
-      const d = new Date(now);
+      const d = new Date();
       const day = d.getDay();
       const diff = d.getDate() - day + (day === 0 ? -6 : 1);
       d.setDate(diff);
-      monday = d.toISOString().split("T")[0];
+      const y = d.getFullYear();
+      const m = String(d.getMonth() + 1).padStart(2, "0");
+      const dd = String(d.getDate()).padStart(2, "0");
+      monday = `${y}-${m}-${dd}`;
     }
 
     // Resolve the call-aggregation window: explicit range when both from/to

--- a/src/app/api/scoreboard/route.ts
+++ b/src/app/api/scoreboard/route.ts
@@ -313,15 +313,16 @@ export const GET = async (req: NextRequest) => {
       }),
     );
 
-    // "No fees" = has a real fee due but hasn't fully received it yet
-    // (outstanding balance > 0) — not a PIF/fees_confirmation check, since
-    // that flags whether staff have *reviewed* the case, not whether money
-    // is actually still owed. Bucketed the same way here and in the No Fees
-    // Cases aging query below so this card and that table can never disagree.
+    // "No fees" = has a real fee due and has received nothing at all yet —
+    // not a partial balance (some received, still owing) and not a
+    // PIF/fees_confirmation check, since that flags whether staff have
+    // *reviewed* the case, not whether any money has come in. Bucketed the
+    // same way here and in the No Fees Cases aging query below so this card
+    // and that table can never disagree.
     const [feesStatus] = await db.execute(sql`
       SELECT COUNT(*) FILTER (
         WHERE COALESCE(total_fees_expected, 0) > 0
-          AND COALESCE(total_fees_expected, 0) > COALESCE(total_fees_paid, 0)
+          AND COALESCE(total_fees_paid, 0) = 0
       )::int AS no_fees_count
       FROM fee_records
       WHERE is_closed = false
@@ -331,12 +332,12 @@ export const GET = async (req: NextRequest) => {
       noFees: Number(feesStatus?.no_fees_count) || 0,
     };
 
-    // No Fees Cases — open cases with a real fee due that hasn't been fully
-    // received (same predicate as openCasesFeesStatus.noFees above), aged
-    // over 60 days by approval_date. Returns the actual case rows (not just
-    // a count) so the Reports page can list them for reporting; over60/over90
-    // counts are derived from this same list below so the card and the table
-    // can never disagree.
+    // No Fees Cases — open cases with a real fee due and nothing received at
+    // all (same predicate as openCasesFeesStatus.noFees above), aged over 60
+    // days by approval_date. Returns the actual case rows (not just a count)
+    // so the Reports page can list them for reporting; over60/over90 counts
+    // are derived from this same list below so the card and the table can
+    // never disagree.
     const noFeesCaseRows = await db.execute(sql`
       SELECT
         c.client_id AS id,
@@ -351,7 +352,7 @@ export const GET = async (req: NextRequest) => {
       JOIN cases c ON c.client_id = fr.case_id
       WHERE fr.is_closed = FALSE
         AND COALESCE(fr.total_fees_expected, 0) > 0
-        AND COALESCE(fr.total_fees_expected, 0) > COALESCE(fr.total_fees_paid, 0)
+        AND COALESCE(fr.total_fees_paid, 0) = 0
         AND c.approval_date IS NOT NULL
         AND c.approval_date < CURRENT_DATE - INTERVAL '60 days'
       ORDER BY c.approval_date ASC
@@ -376,8 +377,11 @@ export const GET = async (req: NextRequest) => {
       daysSinceApproval: Number(r.days_since_approval) || 0,
     }));
 
+    // Mutually exclusive buckets — a case over 90 days counts only in the
+    // 90-day bucket, not in both, so the two numbers can be added together
+    // without double-counting.
     const noFeesAging = {
-      over60: noFeesCases.length,
+      over60: noFeesCases.filter((c) => c.daysSinceApproval > 60 && c.daysSinceApproval <= 90).length,
       over90: noFeesCases.filter((c) => c.daysSinceApproval > 90).length,
     };
 

--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -506,7 +506,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
           <div className={`grid grid-cols-3 divide-x divide-dashed ${dark ? "divide-neutral-700" : "divide-neutral-200"}`}>
             {[
               { label: "No Fees",              value: data.openCasesFeesStatus.noFees, tone: dark ? "text-amber-400" : "text-amber-600" },
-              { label: "No Fees Over 60 Days",  value: data.noFeesAging.over60,         tone: dark ? "text-orange-400" : "text-orange-600" },
+              { label: "No Fees 60–90 Days",    value: data.noFeesAging.over60,         tone: dark ? "text-orange-400" : "text-orange-600" },
               { label: "No Fees Over 90 Days",  value: data.noFeesAging.over90,         tone: dark ? "text-red-400"   : "text-red-600"   },
             ].map(({ label, value, tone }) => (
               <div key={label} className="py-3 text-center">
@@ -524,7 +524,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
           <div className={`px-4 py-2.5 flex items-center justify-between border-b ${t.borderLight}`}>
             <span className={`text-xs font-bold ${t.text}`}>No Fees Cases</span>
             <span className="text-[13px] font-medium tabular-nums">
-              <span className={dark ? "text-amber-400" : "text-amber-600"}>{data.noFeesAging.over60} over 60 days</span>
+              <span className={dark ? "text-amber-400" : "text-amber-600"}>{data.noFeesAging.over60} 60–90 days</span>
               <span className={t.textMuted}> · </span>
               <span className={dark ? "text-red-400" : "text-red-600"}>{data.noFeesAging.over90} over 90 days</span>
             </span>

--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -23,7 +23,7 @@ import {
 } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { themeClasses } from "@/lib/theme-classes";
-import { fmt, fmtDate, namesMatch } from "@/lib/formatters";
+import { fmt, fmtDate, namesMatch, getMonday, formatWeekLabel } from "@/lib/formatters";
 import { teamBadgeClasses } from "@/lib/team-colors";
 import { useCapabilities } from "@/hooks/useCapabilities";
 import {
@@ -133,19 +133,14 @@ const MONTH_NAMES = [
 
 // ---------- helpers ----------
 
-const getMonday = (offset = 0): string => {
-  const d = new Date();
-  const day = d.getDay();
-  d.setDate(d.getDate() - day + (day === 0 ? -6 : 1) + offset * 7);
-  return d.toISOString().split("T")[0];
-};
-
-const formatWeekLabel = (monday: string): string => {
-  const start = new Date(monday + "T00:00:00");
-  const end = new Date(monday + "T00:00:00");
-  end.setDate(end.getDate() + 4);
-  const opts: Intl.DateTimeFormatOptions = { month: "short", day: "numeric" };
-  return `${start.toLocaleDateString("en-US", opts)} – ${end.toLocaleDateString("en-US", { ...opts, year: "numeric" })}`;
+// Local getters, never toISOString() — that converts to UTC and rolls the
+// date back a day for anyone east of UTC (e.g. Philippines, UTC+8) on any
+// local date built via setDate()/local-midnight parsing.
+const toLocalIso = (d: Date): string => {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${dd}`;
 };
 
 const getWeekDays = (monday: string) => {
@@ -153,7 +148,7 @@ const getWeekDays = (monday: string) => {
     const d = new Date(monday + "T00:00:00");
     d.setDate(d.getDate() + i);
     return {
-      date: d.toISOString().split("T")[0],
+      date: toLocalIso(d),
       label: d.toLocaleDateString("en-US", { month: "short", day: "numeric" }),
       dayName,
     };

--- a/src/components/scoreboard/Scoreboard.tsx
+++ b/src/components/scoreboard/Scoreboard.tsx
@@ -9,6 +9,7 @@ import { bulkImportDailyMetrics } from "@/app/(dashboard)/scoreboard/actions";
 import { parseDate, parseNonNegativeInt } from "@/lib/import/csv-parser";
 import { teamHeaderBg } from "@/lib/team-colors";
 import { useCapabilities } from "@/hooks/useCapabilities";
+import { getMonday } from "@/lib/formatters";
 
 // ---------- types ----------
 
@@ -26,13 +27,6 @@ interface WeekSlot {
 }
 
 // ---------- helpers ----------
-
-const getMonday = (offsetWeeks: number): string => {
-  const d = new Date();
-  const day = d.getDay();
-  d.setDate(d.getDate() - day + (day === 0 ? -6 : 1) + offsetWeeks * 7);
-  return d.toISOString().split("T")[0];
-};
 
 const weekRangeLabel = (monday: string): string => {
   const start = new Date(monday + "T12:00:00");

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -34,11 +34,21 @@ export const fmtDate = (d: string | null | undefined): string => {
 
 // Monday (YYYY-MM-DD) of the current week, shifted by `offset` weeks.
 // Shared by the week-nav tabs on Notifications and Reports.
+//
+// Builds the string from local Y/M/D getters rather than toISOString()
+// (which converts to UTC) — for anyone east of UTC (e.g. Philippines,
+// UTC+8), toISOString() rolls back to the previous calendar day for any
+// local time before 8am, making this return Sunday's date on a Monday
+// morning. Local getters always reflect the calendar date setDate() above
+// actually produced, regardless of timezone.
 export const getMonday = (offset = 0): string => {
   const d = new Date();
   const day = d.getDay();
   d.setDate(d.getDate() - day + (day === 0 ? -6 : 1) + offset * 7);
-  return d.toISOString().split("T")[0];
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${dd}`;
 };
 
 // "Jun 29 – Jul 3, 2026"-style label for the week starting at `monday`.


### PR DESCRIPTION
## Summary
- #196 — Fix week-start date off by one day for timezones east of UTC
- #197 — No Fees stat: only zero-received cases, exclusive aging buckets