### PR TITLE
Add Unassigned filter option to Fee Petitions and Overpaid Cases

### DIFF
--- a/src/app/api/fee-petitions/route.ts
+++ b/src/app/api/fee-petitions/route.ts
@@ -114,7 +114,12 @@ export const GET = async (req: NextRequest) => {
         : aging === "unpaid_90"
           ? sql`AND COALESCE(${feeRecords.totalFeesPaid}, 0) = 0 AND ${cases.approvalDate} IS NOT NULL AND (CURRENT_DATE - ${cases.approvalDate}::date) > 90`
           : sql``;
-    const assignedToClause = assignedTo ? sql`AND ${feePetitions.assignedTo} = ${assignedTo}` : sql``;
+    const assignedToClause =
+      assignedTo === "__unassigned__"
+        ? sql`AND ${feePetitions.assignedTo} IS NULL`
+        : assignedTo
+          ? sql`AND ${feePetitions.assignedTo} = ${assignedTo}`
+          : sql``;
 
     // Accept both the legacy enum value and the worksheet-direct label
     // saved via the dashboard dropdown (column C in the master sheet uses
@@ -154,6 +159,7 @@ export const GET = async (req: NextRequest) => {
     const assignees = assignedToRows
       .filter((r): r is { assignedTo: string; caseCount: number } => r.assignedTo != null)
       .map((r) => ({ name: r.assignedTo, count: r.caseCount }));
+    const unassignedCount = assignedToRows.find((r) => r.assignedTo == null)?.caseCount ?? 0;
 
     // Single aggregate for stats + count. Fee totals sum across the FULL
     // filtered set (not just the current page), so they stay accurate
@@ -255,6 +261,7 @@ export const GET = async (req: NextRequest) => {
       totalFeeRequested,
       totalFeesReceived,
       assignees,
+      unassignedCount,
     });
   } catch (error) {
     console.error("GET /api/fee-petitions error:", error);

--- a/src/app/api/overpaid-cases/route.ts
+++ b/src/app/api/overpaid-cases/route.ts
@@ -52,7 +52,11 @@ export const GET = async (req: NextRequest) => {
     const whereClause = sql`${overpaidCondition}
       ${searchClause}
       ${statusClause}
-      ${agent ? sql`AND ${feeRecords.assignedTo} = ${agent}` : sql``}
+      ${agent === "__unassigned__"
+        ? sql`AND ${feeRecords.assignedTo} IS NULL`
+        : agent
+          ? sql`AND ${feeRecords.assignedTo} = ${agent}`
+          : sql``}
       ${ltrClause}
       ${minClause}
       ${maxClause}
@@ -80,6 +84,7 @@ export const GET = async (req: NextRequest) => {
     const agents = agentRows
       .filter((r): r is { assignedTo: string; caseCount: number } => r.assignedTo != null)
       .map((r) => ({ name: r.assignedTo, count: r.caseCount }));
+    const unassignedCount = agentRows.find((r) => r.assignedTo == null)?.caseCount ?? 0;
 
     // Aggregate stats (respects all active filters including agent)
     const [agg] = await db
@@ -157,7 +162,7 @@ export const GET = async (req: NextRequest) => {
     const pageFeesReceived = pageFeesCents / 100;
     const pageOverpaid = pageOverpaidCents / 100;
 
-    return NextResponse.json({ data, page, limit, total, totalOverpaid, clearedCount, ltrCount, agents, pageFeesReceived, pageOverpaid });
+    return NextResponse.json({ data, page, limit, total, totalOverpaid, clearedCount, ltrCount, agents, unassignedCount, pageFeesReceived, pageOverpaid });
   } catch (error) {
     console.error("GET /api/overpaid-cases error:", error);
     return NextResponse.json(

--- a/src/components/fee-petitions/FeePetitions.tsx
+++ b/src/components/fee-petitions/FeePetitions.tsx
@@ -213,6 +213,7 @@ export const FeePetitions = () => {
   const [agingFilter, setAgingFilter] = useState<AgingFilter>(initialState.aging);
   const [assignedToFilter, setAssignedToFilter] = useState(initialState.assignedTo);
   const [assignees, setAssignees] = useState<Assignee[]>([]);
+  const [unassignedCount, setUnassignedCount] = useState(0);
   const [sortKey, setSortKey] = useState<SortKey>(initialState.sort);
   const [sortDir, setSortDir] = useState<SortDir>(initialState.dir);
 
@@ -416,6 +417,7 @@ export const FeePetitions = () => {
       setBulkConfirming(false);
       setTotal(typeof json.total === "number" ? json.total : data.length);
       if (Array.isArray(json.assignees)) setAssignees(json.assignees);
+      if (typeof json.unassignedCount === "number") setUnassignedCount(json.unassignedCount);
       noteSnapshot.current = new Map(data.map((r) => [r.id, r.updateNote]));
     } catch (err) {
       if ((err as Error).name === "AbortError") return;
@@ -989,6 +991,7 @@ export const FeePetitions = () => {
               className={`h-8 px-2 rounded-md border text-xs outline-none cursor-pointer ${t.inputBg}`}
             >
               <option value="">All Assigned</option>
+              <option value="__unassigned__">Unassigned ({unassignedCount})</option>
               {assignees.map((a) => (
                 <option key={a.name} value={a.name}>{a.name} ({a.count})</option>
               ))}
@@ -1089,7 +1092,7 @@ export const FeePetitions = () => {
             )}
             {assignedToFilter && (
               <span className={chipBase}>
-                Assigned: {assignedToFilter}
+                Assigned: {assignedToFilter === "__unassigned__" ? "Unassigned" : assignedToFilter}
                 <button aria-label="Clear assigned to filter" onClick={() => { urlMethodRef.current = "push"; setAssignedToFilter(""); setPage(1); }} className="ml-0.5 hover:opacity-70">
                   <X aria-hidden="true" className="h-3 w-3" />
                 </button>

--- a/src/components/overpaid-cases/OverpaidCases.tsx
+++ b/src/components/overpaid-cases/OverpaidCases.tsx
@@ -121,6 +121,7 @@ export const OverpaidCases = () => {
   const [stats, setStats] = useState({ totalOverpaid: 0, ltrCount: 0 });
   const [pageTotals, setPageTotals] = useState({ pageFeesReceived: 0, pageOverpaid: 0 });
   const [agents, setAgents] = useState<{ name: string; count: number }[]>([]);
+  const [unassignedCount, setUnassignedCount] = useState(0);
 
   const [search, setSearch] = useState(initialState.search);
   const [appliedSearch, setAppliedSearch] = useState(initialState.search);
@@ -294,6 +295,7 @@ export const OverpaidCases = () => {
         pageOverpaid: typeof json.pageOverpaid === "number" ? json.pageOverpaid : 0,
       });
       if (Array.isArray(json.agents)) setAgents(json.agents);
+      if (typeof json.unassignedCount === "number") setUnassignedCount(json.unassignedCount);
       noteSnapshot.current = new Map(data.map((r) => [r.id, r.updateNote]));
       ltrSnapshot.current = new Map(data.map((r) => [r.id, r.opLtrReceived]));
       opLtrDateSnapshot.current = new Map(data.map((r) => [r.id, r.opLtrDate]));
@@ -997,6 +999,7 @@ export const OverpaidCases = () => {
               className={`h-8 px-2 rounded-md border text-xs outline-none cursor-pointer ${t.inputBg}`}
             >
               <option value="">All Agents</option>
+              <option value="__unassigned__">Unassigned ({unassignedCount})</option>
               {agents.map((a) => (
                 <option key={a.name} value={a.name}>{a.name} ({a.count})</option>
               ))}
@@ -1102,7 +1105,7 @@ export const OverpaidCases = () => {
             )}
             {agentFilter && (
               <span className={chipBase}>
-                Agent: {agentFilter}
+                Agent: {agentFilter === "__unassigned__" ? "Unassigned" : agentFilter}
                 <button aria-label="Clear agent filter" onClick={() => { urlMethodRef.current = "push"; setAgentFilter(""); setPage(1); }} className="ml-0.5 hover:opacity-70">
                   <X aria-hidden="true" className="h-3 w-3" />
                 </button>


### PR DESCRIPTION
## Summary
- The "All Assigned"/"All Agents" dropdown on Fee Petitions and Overpaid Cases had no way to filter to cases with no agent assigned (rows with a null `assignedTo` were silently excluded from the dropdown's option list).
- Adds an "Unassigned (N)" option to both dropdowns, backed by a `__unassigned__` sentinel that the API routes translate into an `IS NULL` clause (mirroring the existing pattern in `FeeRecordsTable.tsx`).
- Active-filter chip now reads "Unassigned" instead of the raw sentinel value.

## Test plan
- [x] Manually verified in browser: selecting "Unassigned" on Fee Petitions filters to unassigned rows, chip shows correctly, dismissable
- [x] Manually verified in browser: same on Overpaid Cases
- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (62/62)