### PR TITLE
Fix All PIF and All Remarks filters ignoring Settings sort order

### DIFF
--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -394,24 +394,38 @@ export const FeeRecordsTable = ({
 
   // All PIF statuses for the filter dropdown — the full admin-configured
   // catalog (so every status is filterable even if no currently-loaded case
-  // has it yet), unioned with whatever's actually present on records so an
-  // inactive-but-still-set value remains filterable too.
+  // has it yet), in the admin-configured order, followed by any values
+  // actually present on records that aren't in the catalog (e.g. an
+  // inactive-but-still-set value), alphabetized since those have no defined
+  // order of their own.
   const feesConfValues = useMemo(() => {
-    const set = new Set((dropdownOptions.fees_confirmation ?? []).map((o) => o.name));
-    for (const c of cases) if (c.feesConfirmation != null) set.add(c.feesConfirmation);
-    return Array.from(set).sort();
+    const catalog = (dropdownOptions.fees_confirmation ?? []).map((o) => o.name);
+    const catalogSet = new Set(catalog);
+    const extras = Array.from(
+      new Set(
+        cases
+          .map((c) => c.feesConfirmation)
+          .filter((v): v is string => v != null && !catalogSet.has(v)),
+      ),
+    ).sort();
+    return [...catalog, ...extras];
   }, [cases, dropdownOptions.fees_confirmation]);
 
-  // Unique Remarks values present in the data for the quick-filter dropdown.
-  // Remarks predates the case_status dropdown catalog, so this includes
-  // whatever free-text values are actually on records today, not just the
-  // admin-configured options.
+  // Remarks values for the quick-filter dropdown — admin-configured catalog
+  // first (in its configured order), then any free-text values actually
+  // present on records that predate/aren't in the catalog, alphabetized.
   const caseStatusValues = useMemo(() => {
-    const set = new Set(
-      cases.map((c) => c.caseStatus).filter((v): v is string => v != null),
-    );
-    return Array.from(set).sort();
-  }, [cases]);
+    const catalog = (dropdownOptions.case_status ?? []).map((o) => o.name);
+    const catalogSet = new Set(catalog);
+    const extras = Array.from(
+      new Set(
+        cases
+          .map((c) => c.caseStatus)
+          .filter((v): v is string => v != null && !catalogSet.has(v)),
+      ),
+    ).sort();
+    return [...catalog, ...extras];
+  }, [cases, dropdownOptions.case_status]);
 
   const filtered = useMemo(() => {
     let d = [...cases];


### PR DESCRIPTION
## Summary
- Reported: reordering options for "All PIF" and "All Remarks" in Settings had no visible effect on the Master Fees filter dropdowns.
- Root cause: `FeeRecordsTable.tsx` built both dropdowns' option lists by dumping names into a `Set` and calling `.sort()` — alphabetizing everything and discarding the admin-configured order entirely. The Settings page and its API (`ORDER BY sortOrder, name`) were never broken.
- Fix: both dropdowns now start from the admin-configured catalog in its actual configured order, then append any legacy/free-text values not in the catalog (alphabetized) at the end.

## Test plan
- [x] Verified in-browser against the live Settings-configured order for both dropdowns — output matches exactly (PIF: Yes, No, Pending, No Fees Due, Overpaid; Remarks: Ready for Review (Specialist), Reviewing (Management), For follow up, Not ready to close, Incomplete win sheet, Missing fees, Overpaid but ready to close, FEE PETITION APPROVED, plus one legacy value correctly appended at the end)
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` — no new issues (5 pre-existing findings unrelated to this diff)
- [x] `npm test` passes (62/62)