### PR TITLE
Master Fees UI tweaks and NOA checklist removal

### DIFF
--- a/src/app/(dashboard)/fee-petitions/actions.ts
+++ b/src/app/(dashboard)/fee-petitions/actions.ts
@@ -76,7 +76,6 @@ export async function bulkMarkComplete(input: {
     if (input.caseIds.length > 500) return { ok: false, error: "Too many cases (max 500)" };
     if (!input.caseIds.every((id) => Number.isFinite(id))) return { ok: false, error: "Invalid case IDs" };
     const allTrue = {
-      noa: true,
       timeDelineation: true,
       feePetitionDoc: true,
       ltrToClmt: true,
@@ -99,7 +98,6 @@ export async function bulkMarkComplete(input: {
 }
 
 type ChecklistFields = {
-  noa: boolean;
   timeDelineation: boolean;
   feePetitionDoc: boolean;
   ltrToClmt: boolean;

--- a/src/app/api/fee-petitions/route.ts
+++ b/src/app/api/fee-petitions/route.ts
@@ -33,7 +33,6 @@ const resolveActiveFeeType = (
 
 const getMissingClause = (key: string | null) => {
   switch (key) {
-    case "noa": return sql`AND COALESCE(${feePetitions.noa}, false) = false`;
     case "timeDelineation": return sql`AND COALESCE(${feePetitions.timeDelineation}, false) = false`;
     case "feePetitionDoc": return sql`AND COALESCE(${feePetitions.feePetitionDoc}, false) = false`;
     case "ltrToClmt": return sql`AND COALESCE(${feePetitions.ltrToClmt}, false) = false`;
@@ -66,10 +65,10 @@ export const GET = async (req: NextRequest) => {
     const limit = Number.isFinite(rawLimit) ? Math.min(Math.max(1, rawLimit), 10000) : 50;
     const offset = (page - 1) * limit;
 
-    // All 7 checklist fields true (NULLs from LEFT JOIN coalesce to false)
+    // All 6 checklist fields true (NULLs from LEFT JOIN coalesce to false).
+    // NOA dropped from the checklist — a petition can now be filed without it.
     const allChecked = sql`(
-      COALESCE(${feePetitions.noa}, false)
-      AND COALESCE(${feePetitions.timeDelineation}, false)
+      COALESCE(${feePetitions.timeDelineation}, false)
       AND COALESCE(${feePetitions.feePetitionDoc}, false)
       AND COALESCE(${feePetitions.ltrToClmt}, false)
       AND COALESCE(${feePetitions.ltrToClmtWithSignature}, false)
@@ -86,7 +85,6 @@ export const GET = async (req: NextRequest) => {
 
     // Sum of checked boxes — used for progress sort
     const progressExpr = sql`(
-      COALESCE(${feePetitions.noa}, false)::int +
       COALESCE(${feePetitions.timeDelineation}, false)::int +
       COALESCE(${feePetitions.feePetitionDoc}, false)::int +
       COALESCE(${feePetitions.ltrToClmt}, false)::int +

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -107,6 +107,7 @@ const CASE_STATUS_COLORS: Record<string, { badge: string; badgeDark: string }> =
   "Incomplete win sheet":          { badge: "bg-red-50 text-red-700 border-red-300",           badgeDark: "bg-red-900/40 text-red-300 border-red-700"          },
   "Missing fees":                  { badge: "bg-red-50 text-red-700 border-red-300",           badgeDark: "bg-red-900/40 text-red-300 border-red-700"          },
   "NEED AUX FEE":                  { badge: "bg-red-50 text-red-700 border-red-300",           badgeDark: "bg-red-900/40 text-red-300 border-red-700"          },
+  "FEE PETITION APPROVED":         { badge: "bg-red-50 text-red-700 border-red-300",           badgeDark: "bg-red-900/40 text-red-300 border-red-700"          },
 };
 const CASE_STATUS_FALLBACK = { badge: "bg-neutral-100 text-neutral-500 border-neutral-300", badgeDark: "bg-neutral-700 text-neutral-300 border-neutral-600" };
 
@@ -879,6 +880,11 @@ export const FeeRecordsTable = ({
   // needs to grow on desktop), so every other frozen offset below shifts
   // right by exactly that much when mode === "closed".
   const colClosedOnW = `w-28 min-w-28 max-w-28`;
+  // Refresh is a leading frozen column in every mode, sitting right after the
+  // checkbox — fixed 56px at every breakpoint, so every other frozen offset
+  // below (Closed On, Case Name, Assigned, Fees Conf) shifts right by that
+  // much regardless of mode.
+  const colRefreshW = `w-14 min-w-14 max-w-14`;
   const isClosedMode = mode === "closed";
 
   // Every header cell is sticky vertically by default — the column-header
@@ -898,53 +904,62 @@ export const FeeRecordsTable = ({
   // Frozen column headers (row 2). Case Name freezes left on all screens;
   // Assigned freezes left only at sm+ (on mobile it keeps thBase's sticky-top
   // but scrolls horizontally). Corner cells use z-30 to cover both single-axis
-  // sticky neighbors during scroll. In "closed" mode, Closed On sits in front
-  // of Case Name, so Case Name/Assigned/Fees Conf's left offsets all shift
-  // right by colClosedOnW's 112px (7rem) — 40+112=152px=9.5rem, etc.
+  // sticky neighbors during scroll. Refresh (56px) is now the leading frozen
+  // column in every mode, so every offset below already includes it —
+  // checkbox(40) + refresh(56) = 96px = left-24 as the new baseline. In
+  // "closed" mode, Closed On additionally sits in front of Case Name, adding
+  // colClosedOnW's 112px on top of that — 96+112=208px=13rem, etc.
   const stickyTh1 = isClosedMode
-    ? `left-[9.5rem] z-30 ${colNameW} ${nameDivider}`
-    : `left-10 z-30 ${colNameW} ${nameDivider}`;
+    ? `left-52 z-30 ${colNameW} ${nameDivider}`
+    : `left-24 z-30 ${colNameW} ${nameDivider}`;
   // z-30 only at sm+ (where Assigned is a frozen corner). On mobile Assigned
   // scrolls, so no sticky-left. Freeze boundary moved to Fees Conf, so no divider here.
   // scrolls, so it must stay at thBase's z-20 — BELOW the frozen Case Name
   // (z-30) — otherwise it paints over the frozen "front index" on scroll.
   // Assigned: no divider — freeze boundary now sits after Fees Conf.
   const stickyTh2 = isClosedMode
-    ? `sm:left-[21.5rem] sm:z-30 ${colAssignedW}`
-    : `sm:left-[14.5rem] sm:z-30 ${colAssignedW}`;
+    ? `sm:left-[25rem] sm:z-30 ${colAssignedW}`
+    : `sm:left-72 sm:z-30 ${colAssignedW}`;
   // "Case Info" group label is split into cells so each part's freeze matches
   // the column beneath it. Three frozen columns: Case Name, Assigned, Fees
   // Conf (four, with Closed On, in "closed" mode).
   const stickyGroup = isClosedMode
-    ? `top-0! left-[9.5rem] z-30 ${colNameW} ${nameDivider}`
-    : `top-0! left-10 z-30 ${colNameW} ${nameDivider}`;
+    ? `top-0! left-52 z-30 ${colNameW} ${nameDivider}`
+    : `top-0! left-24 z-30 ${colNameW} ${nameDivider}`;
   const stickyGroup2 = isClosedMode
-    ? `top-0! sm:left-[21.5rem] sm:z-30 ${colAssignedW}`
-    : `top-0! sm:left-[14.5rem] sm:z-30 ${colAssignedW}`;
-  // Fees Conf is the 3rd frozen column (left offset = 40 + 192 + 160 = 392px
-  // = 24.5rem; + colClosedOnW's 112px = 504px = 31.5rem in "closed" mode).
+    ? `top-0! sm:left-[25rem] sm:z-30 ${colAssignedW}`
+    : `top-0! sm:left-72 sm:z-30 ${colAssignedW}`;
+  // Fees Conf is the 3rd frozen column (left offset = 96 + 192 + 160 = 448px
+  // = 28rem; + colClosedOnW's 112px = 560px = 35rem in "closed" mode).
   const stickyGroup3 = isClosedMode
-    ? `top-0! sm:left-[31.5rem] sm:z-30 ${colFeesConfW} ${stickyDivider}`
-    : `top-0! sm:left-[24.5rem] sm:z-30 ${colFeesConfW} ${stickyDivider}`;
+    ? `top-0! sm:left-[35rem] sm:z-30 ${colFeesConfW} ${stickyDivider}`
+    : `top-0! sm:left-[28rem] sm:z-30 ${colFeesConfW} ${stickyDivider}`;
   const stickyTh3 = isClosedMode
-    ? `sm:left-[31.5rem] sm:z-30 ${colFeesConfW} ${stickyDivider}`
-    : `sm:left-[24.5rem] sm:z-30 ${colFeesConfW} ${stickyDivider}`;
+    ? `sm:left-[35rem] sm:z-30 ${colFeesConfW} ${stickyDivider}`
+    : `sm:left-[28rem] sm:z-30 ${colFeesConfW} ${stickyDivider}`;
   const stickyTd1 = isClosedMode
-    ? `sticky left-[9.5rem] z-10 ${colNameW} ${stickyBg} ${stickyHover} ${nameDivider}`
-    : `sticky left-10 z-10 ${colNameW} ${stickyBg} ${stickyHover} ${nameDivider}`;
+    ? `sticky left-52 z-10 ${colNameW} ${stickyBg} ${stickyHover} ${nameDivider}`
+    : `sticky left-24 z-10 ${colNameW} ${stickyBg} ${stickyHover} ${nameDivider}`;
   const stickyTd2 = isClosedMode
-    ? `sm:sticky sm:left-[21.5rem] sm:z-10 ${colAssignedW} ${stickyColBg}`
-    : `sm:sticky sm:left-[14.5rem] sm:z-10 ${colAssignedW} ${stickyColBg}`;
+    ? `sm:sticky sm:left-[25rem] sm:z-10 ${colAssignedW} ${stickyColBg}`
+    : `sm:sticky sm:left-72 sm:z-10 ${colAssignedW} ${stickyColBg}`;
   const stickyTd3 = isClosedMode
-    ? `sm:sticky sm:left-[31.5rem] sm:z-10 ${colFeesConfW} ${stickyColBg} ${stickyDivider}`
-    : `sm:sticky sm:left-[24.5rem] sm:z-10 ${colFeesConfW} ${stickyColBg} ${stickyDivider}`;
+    ? `sm:sticky sm:left-[35rem] sm:z-10 ${colFeesConfW} ${stickyColBg} ${stickyDivider}`
+    : `sm:sticky sm:left-[28rem] sm:z-10 ${colFeesConfW} ${stickyColBg} ${stickyDivider}`;
   const stickyCheckTh = `sticky top-0! left-0 z-30 w-10 min-w-10 ${stickyBg}`;
   const stickyCheckTd = `sticky left-0 z-10 w-10 min-w-10 ${stickyBg} ${stickyHover}`;
-  // Closed On — new frozen column, "closed" mode only, sitting exactly where
-  // Case Name used to (left-10) now that it's first.
-  const stickyGroupClosedOn = `top-0! left-10 z-30 ${colClosedOnW}`;
-  const stickyThClosedOn = `left-10 z-30 ${colClosedOnW}`;
-  const stickyTdClosedOn = `sticky left-10 z-10 ${colClosedOnW} ${stickyBg} ${stickyHover}`;
+  // Refresh — new leading frozen column (all modes), sitting right after the
+  // checkbox at left-10 (40px, the checkbox's own width). Spans both header
+  // rows like the checkbox, so (like stickyCheckTh) it's fully self-contained
+  // rather than combined with thBase — a rowSpan={2} cell needs top-0! for
+  // its whole height, not thBase's row-2-only top-8.
+  const stickyThRefresh = `h-8 px-3 text-[12px] font-semibold uppercase tracking-wider whitespace-nowrap sticky top-0! left-10 z-30 ${colRefreshW} ${stickyBg} ${t.textSub} text-center`;
+  const stickyTdRefresh = `sticky left-10 z-10 ${colRefreshW} ${stickyBg} ${stickyHover}`;
+  // Closed On — frozen, "closed" mode only, sitting right after Refresh
+  // (checkbox 40px + refresh 56px = 96px = left-24).
+  const stickyGroupClosedOn = `top-0! left-24 z-30 ${colClosedOnW}`;
+  const stickyThClosedOn = `left-24 z-30 ${colClosedOnW}`;
+  const stickyTdClosedOn = `sticky left-24 z-10 ${colClosedOnW} ${stickyBg} ${stickyHover}`;
 
   return (
     <div className={`relative rounded-xl border ${t.card}`}>
@@ -1138,6 +1153,16 @@ export const FeeRecordsTable = ({
                     className="h-3.5 w-3.5 cursor-pointer accent-indigo-500"
                   />
                 </th>
+                {/* Refresh — moved to the front (frozen), before Case Name, so
+                    it's usable without scrolling right. Spans both header
+                    rows like the checkbox, since it has no group label.
+                    Icon-only (like the checkbox column) — the column is too
+                    narrow at this frozen width for the word "Refresh" to fit
+                    without colliding with "Case Info" next to it. */}
+                <th rowSpan={2} className={stickyThRefresh} title="Refresh">
+                  <RefreshCw className="h-3.5 w-3.5 inline" aria-hidden="true" />
+                  <span className="sr-only">Refresh</span>
+                </th>
                 {/* Closed On sits in front of Case Info's group, "closed" mode
                     only — same blank-spacer pattern as the Assigned/Fees Conf
                     cells below, just with nothing to label. */}
@@ -1196,7 +1221,7 @@ export const FeeRecordsTable = ({
                   Totals
                 </th>
                 <th
-                  colSpan={isClosedMode ? 6 : 7}
+                  colSpan={isClosedMode ? 5 : 6}
                   className={`${thBase} text-center ${groupBorder} ${stickyThRow1} ${t.textSub}`}
                 >
                   Workflow
@@ -1335,7 +1360,6 @@ export const FeeRecordsTable = ({
                   Recent Update
                 </th>
                 <th className={`${thBase} ${t.textSub} text-center`}>Logs</th>
-                <th className={`${thBase} ${t.textSub} text-center`}>Refresh</th>
                 {/* Closed On moved to the front (frozen) in "closed" mode —
                     this trailing slot is Active-mode-only now. */}
                 {!isClosedMode && (
@@ -1373,6 +1397,26 @@ export const FeeRecordsTable = ({
                         aria-label={`Select ${c.name}`}
                         className="h-3.5 w-3.5 cursor-pointer accent-indigo-500"
                       />
+                    </td>
+                    {/* Refresh — moved to the front (frozen), before Case
+                        Name, so it's usable without scrolling right. */}
+                    <td
+                      className={`${tdBase} text-center ${stickyTdRefresh}`}
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <button
+                        type="button"
+                        onClick={() => handleRowRefresh(c)}
+                        disabled={rowRefreshing.has(c.id)}
+                        aria-label={`Refresh ${c.name}`}
+                        title="Refresh this case's fee data from the server"
+                        className={`inline-flex items-center justify-center h-6 w-6 rounded ${t.hover} ${t.textSub} disabled:opacity-50`}
+                      >
+                        <RefreshCw
+                          className={`h-3.5 w-3.5 ${rowRefreshing.has(c.id) ? "animate-spin" : ""}`}
+                          aria-hidden="true"
+                        />
+                      </button>
                     </td>
                     {/* Closed On — frozen, "closed" mode only, first data
                         column so it's visible without scrolling. */}
@@ -2247,21 +2291,6 @@ export const FeeRecordsTable = ({
                       >
                         <MessageSquare className="h-3 w-3" aria-hidden="true" />
                         {c.notesCount}
-                      </button>
-                    </td>
-                    <td className={`${tdBase} text-center`} onClick={(e) => e.stopPropagation()}>
-                      <button
-                        type="button"
-                        onClick={() => handleRowRefresh(c)}
-                        disabled={rowRefreshing.has(c.id)}
-                        aria-label={`Refresh ${c.name}`}
-                        title="Refresh this case's fee data from the server"
-                        className={`inline-flex items-center justify-center h-6 w-6 rounded ${t.hover} ${t.textSub} disabled:opacity-50`}
-                      >
-                        <RefreshCw
-                          className={`h-3.5 w-3.5 ${rowRefreshing.has(c.id) ? "animate-spin" : ""}`}
-                          aria-hidden="true"
-                        />
                       </button>
                     </td>
                     {/* Closed On moved to the front (frozen) in "closed" mode —

--- a/src/components/fee-petitions/FeePetitions.tsx
+++ b/src/components/fee-petitions/FeePetitions.tsx
@@ -58,7 +58,6 @@ interface FeePetitionRow {
 }
 
 type CheckboxKey =
-  | "noa"
   | "timeDelineation"
   | "feePetitionDoc"
   | "ltrToClmt"
@@ -75,7 +74,7 @@ type Assignee = { name: string; count: number };
 // ---------- helpers ----------
 const PAGE_SIZE_OPTIONS = [25, 50, 100, 200];
 const SORT_KEYS: SortKey[] = ["claimant", "approvalDate", "updatedAt", "progress"];
-const CHECKBOX_KEYS = ["noa", "timeDelineation", "feePetitionDoc", "ltrToClmt", "ltrToClmtWithSignature", "ltrToAlj", "faxConfFeePet"] as const;
+const CHECKBOX_KEYS = ["timeDelineation", "feePetitionDoc", "ltrToClmt", "ltrToClmtWithSignature", "ltrToAlj", "faxConfFeePet"] as const;
 
 const daysSince = (dateStr: string | null): number | null => {
   if (!dateStr) return null;
@@ -103,7 +102,6 @@ const DEFAULTS = {
 };
 
 const CHECKBOX_COLUMNS: { key: CheckboxKey; label: string }[] = [
-  { key: "noa", label: "NOA" },
   { key: "timeDelineation", label: "Time Delineation" },
   { key: "feePetitionDoc", label: "Fee Petition Doc" },
   { key: "ltrToClmt", label: "Ltr to Clmt" },
@@ -573,7 +571,7 @@ export const FeePetitions = () => {
           ids.includes(r.id)
             ? {
                 ...r,
-                noa: true, timeDelineation: true, feePetitionDoc: true,
+                timeDelineation: true, feePetitionDoc: true,
                 ltrToClmt: true, ltrToClmtWithSignature: true, ltrToAlj: true,
                 faxConfFeePet: true, updatedAt: today,
               }
@@ -735,7 +733,7 @@ export const FeePetitions = () => {
       }
       const headers = [
         "Case", "Approval Date", "Last Updated", "Progress",
-        "NOA", "Time Delineation", "Fee Petition Doc", "Ltr to Clmt",
+        "Time Delineation", "Fee Petition Doc", "Ltr to Clmt",
         "Ltr to Clmt w/ Signature", "Ltr to ALJ", "Fax Conf Fee Pet", "Notes",
       ];
       const escape = (v: string) => {
@@ -751,7 +749,6 @@ export const FeePetitions = () => {
             r.approvalDate ?? "",
             r.updatedAt ?? "",
             `${completedCount}/${CHECKBOX_COLUMNS.length}`,
-            r.noa ? "Yes" : "No",
             r.timeDelineation ? "Yes" : "No",
             r.feePetitionDoc ? "Yes" : "No",
             r.ltrToClmt ? "Yes" : "No",

--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -811,8 +811,8 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                     {showCol("closedcases") && <th className={`${thBase} ${t.textSub} text-right`}>Closed</th>}
                     {showCol("opennofees")  && <th className={`${thBase} text-right ${dark ? "text-amber-400" : "text-amber-600"}`}>No Fees</th>}
                     {showCol("collected")   && <th className={`${thBase} ${t.textSub} text-right`}>Collected</th>}
-                    {showCol("ssacalls")    && <th className={`${thBase} ${t.textSub} text-right border-l ${t.borderLight}`}>SSA Calls</th>}
-                    {showCol("clientcalls") && <th className={`${thBase} ${t.textSub} text-right`}>Client Calls</th>}
+                    {showCol("ssacalls")    && <th className={`${thBase} text-right border-l ${t.borderLight} ${dark ? "text-sky-400" : "text-sky-600"}`}>SSA Calls</th>}
+                    {showCol("clientcalls") && <th className={`${thBase} text-right ${dark ? "text-indigo-400" : "text-indigo-600"}`}>Client Calls</th>}
                     {showCol("faxsent")     && <th className={`${thBase} ${t.textSub} text-right`}>Fax Sent</th>}
                     {showCol("winsheets")   && <th className={`${thBase} ${t.textSub} text-right`}>Win Sheets</th>}
                   </tr>
@@ -842,8 +842,8 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                           {a.totalCollected > 0 ? fmt(a.totalCollected) : "—"}
                         </td>
                       )}
-                      {showCol("ssacalls")    && <td className={`${tdBase} text-right ${t.textSub} border-l ${t.borderLight}`}>{a.weekSsaCalls}</td>}
-                      {showCol("clientcalls") && <td className={`${tdBase} text-right ${t.textSub}`}>{a.weekClientCalls}</td>}
+                      {showCol("ssacalls")    && <td className={`${tdBase} text-right border-l ${t.borderLight} ${dark ? "text-sky-400" : "text-sky-600"}`}>{a.weekSsaCalls}</td>}
+                      {showCol("clientcalls") && <td className={`${tdBase} text-right ${dark ? "text-indigo-400" : "text-indigo-600"}`}>{a.weekClientCalls}</td>}
                       {showCol("faxsent")     && <td className={`${tdBase} text-right ${t.textSub}`}>{a.weekFaxSent}</td>}
                       {showCol("winsheets")   && <td className={`${tdBase} text-right ${t.text}`}>{a.completedWinSheets}</td>}
                     </tr>
@@ -856,8 +856,8 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                     {showCol("closedcases") && <td className={`${tdBase} text-right font-bold ${t.textSub}`}>{filteredTotals.casesClosed}</td>}
                     {showCol("opennofees")  && <td className={`${tdBase} text-right font-bold ${dark ? "text-amber-400"   : "text-amber-600"}`}>{filteredTotals.openNoFees}</td>}
                     {showCol("collected")   && <td className={`${tdBase} text-right font-bold text-emerald-500`}>{fmt(filteredTotals.totalCollected)}</td>}
-                    {showCol("ssacalls")    && <td className={`${tdBase} text-right font-bold ${t.textSub} border-l ${t.borderLight}`}>{filteredTotals.weekSsaCalls}</td>}
-                    {showCol("clientcalls") && <td className={`${tdBase} text-right font-bold ${t.textSub}`}>{filteredTotals.weekClientCalls}</td>}
+                    {showCol("ssacalls")    && <td className={`${tdBase} text-right font-bold border-l ${t.borderLight} ${dark ? "text-sky-400" : "text-sky-600"}`}>{filteredTotals.weekSsaCalls}</td>}
+                    {showCol("clientcalls") && <td className={`${tdBase} text-right font-bold ${dark ? "text-indigo-400" : "text-indigo-600"}`}>{filteredTotals.weekClientCalls}</td>}
                     {showCol("faxsent")     && <td className={`${tdBase} text-right font-bold ${t.textSub}`}>{filteredTotals.weekFaxSent}</td>}
                     {showCol("winsheets")   && <td className={`${tdBase} text-right font-bold ${t.text}`}>{filteredTotals.completedWinSheets}</td>}
                   </tr>


### PR DESCRIPTION
## Summary
- Move the Refresh button on Master Fees into a new frozen column right before Case Name, so it no longer requires scrolling right
- Color "FEE PETITION APPROVED" red in the Remarks dropdown badge
- Add colors to the SSA Calls / Client Calls columns on Reports
- Remove the NOA checkbox from the Fee Petitions checklist (cases can be filed without it)

## Test plan
- [ ] Confirm Refresh button appears frozen before Case Name on Master Fees and still refreshes the row
- [ ] Confirm FEE PETITION APPROVED renders red in the Remarks dropdown
- [ ] Confirm SSA Calls / Client Calls columns are colored on Reports
- [ ] Confirm NOA checkbox is gone from Fee Petitions checklist and checklist completion no longer requires it