### PR TITLE
Merge develop into main

### DIFF
--- a/src/app/(dashboard)/fee-petitions/actions.ts
+++ b/src/app/(dashboard)/fee-petitions/actions.ts
@@ -76,7 +76,6 @@ export async function bulkMarkComplete(input: {
     if (input.caseIds.length > 500) return { ok: false, error: "Too many cases (max 500)" };
     if (!input.caseIds.every((id) => Number.isFinite(id))) return { ok: false, error: "Invalid case IDs" };
     const allTrue = {
-      noa: true,
       timeDelineation: true,
       feePetitionDoc: true,
       ltrToClmt: true,
@@ -99,7 +98,6 @@ export async function bulkMarkComplete(input: {
 }
 
 type ChecklistFields = {
-  noa: boolean;
   timeDelineation: boolean;
   feePetitionDoc: boolean;
   ltrToClmt: boolean;

--- a/src/app/api/fee-petitions/route.ts
+++ b/src/app/api/fee-petitions/route.ts
@@ -33,7 +33,6 @@ const resolveActiveFeeType = (
 
 const getMissingClause = (key: string | null) => {
   switch (key) {
-    case "noa": return sql`AND COALESCE(${feePetitions.noa}, false) = false`;
     case "timeDelineation": return sql`AND COALESCE(${feePetitions.timeDelineation}, false) = false`;
     case "feePetitionDoc": return sql`AND COALESCE(${feePetitions.feePetitionDoc}, false) = false`;
     case "ltrToClmt": return sql`AND COALESCE(${feePetitions.ltrToClmt}, false) = false`;
@@ -66,10 +65,10 @@ export const GET = async (req: NextRequest) => {
     const limit = Number.isFinite(rawLimit) ? Math.min(Math.max(1, rawLimit), 10000) : 50;
     const offset = (page - 1) * limit;
 
-    // All 7 checklist fields true (NULLs from LEFT JOIN coalesce to false)
+    // All 6 checklist fields true (NULLs from LEFT JOIN coalesce to false).
+    // NOA dropped from the checklist — a petition can now be filed without it.
     const allChecked = sql`(
-      COALESCE(${feePetitions.noa}, false)
-      AND COALESCE(${feePetitions.timeDelineation}, false)
+      COALESCE(${feePetitions.timeDelineation}, false)
       AND COALESCE(${feePetitions.feePetitionDoc}, false)
       AND COALESCE(${feePetitions.ltrToClmt}, false)
       AND COALESCE(${feePetitions.ltrToClmtWithSignature}, false)
@@ -86,7 +85,6 @@ export const GET = async (req: NextRequest) => {
 
     // Sum of checked boxes — used for progress sort
     const progressExpr = sql`(
-      COALESCE(${feePetitions.noa}, false)::int +
       COALESCE(${feePetitions.timeDelineation}, false)::int +
       COALESCE(${feePetitions.feePetitionDoc}, false)::int +
       COALESCE(${feePetitions.ltrToClmt}, false)::int +

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -18,6 +18,8 @@ import {
   X,
   Archive,
   RefreshCw,
+  Minimize2,
+  Maximize2,
 } from "lucide-react";
 
 import { themeClasses } from "@/lib/theme-classes";
@@ -281,6 +283,19 @@ export const FeeRecordsTable = ({
   const [feesConfFilter, setFeesConfFilter] = useState("all");
   const [claimFilter, setClaimFilter] = useState("all");
   const [caseStatusFilter, setCaseStatusFilter] = useState("all");
+  // Minimized T16/T2/AUX column groups — collapses a claim type's 5 editable
+  // columns down to a single read-only Fee Due glance, so staff working a
+  // single claim type can't mistakenly enter Retro/Fee Due on the wrong one.
+  // Session-only (not persisted), same as this table's other view toggles.
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<"t16" | "t2" | "aux">>(new Set());
+  const toggleGroupCollapse = (group: "t16" | "t2" | "aux") => {
+    setCollapsedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(group)) next.delete(group);
+      else next.add(group);
+      return next;
+    });
+  };
   const [sortKey, setSortKey] = useState<SortKey>("date");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
   // Client-side pagination over the filtered+sorted set. Page size is
@@ -1172,22 +1187,55 @@ export const FeeRecordsTable = ({
                 />
 
                 <th
-                  colSpan={5}
+                  colSpan={collapsedGroups.has("t16") ? 1 : 5}
                   className={`${thBase} text-center ${groupBorder} ${stickyThRow1} ${dark ? "text-indigo-400" : "text-indigo-600"}`}
                 >
-                  T16
+                  <button
+                    type="button"
+                    onClick={() => toggleGroupCollapse("t16")}
+                    className="inline-flex items-center gap-1 cursor-pointer"
+                    aria-label={collapsedGroups.has("t16") ? "Expand T16 columns" : "Minimize T16 columns"}
+                    title={collapsedGroups.has("t16") ? "Expand T16 columns" : "Minimize T16 columns"}
+                  >
+                    T16
+                    {collapsedGroups.has("t16")
+                      ? <Maximize2 className="h-3 w-3" aria-hidden="true" />
+                      : <Minimize2 className="h-3 w-3" aria-hidden="true" />}
+                  </button>
                 </th>
                 <th
-                  colSpan={5}
+                  colSpan={collapsedGroups.has("t2") ? 1 : 5}
                   className={`${thBase} text-center ${groupBorder} ${stickyThRow1} ${dark ? "text-blue-400" : "text-blue-600"}`}
                 >
-                  T2
+                  <button
+                    type="button"
+                    onClick={() => toggleGroupCollapse("t2")}
+                    className="inline-flex items-center gap-1 cursor-pointer"
+                    aria-label={collapsedGroups.has("t2") ? "Expand T2 columns" : "Minimize T2 columns"}
+                    title={collapsedGroups.has("t2") ? "Expand T2 columns" : "Minimize T2 columns"}
+                  >
+                    T2
+                    {collapsedGroups.has("t2")
+                      ? <Maximize2 className="h-3 w-3" aria-hidden="true" />
+                      : <Minimize2 className="h-3 w-3" aria-hidden="true" />}
+                  </button>
                 </th>
                 <th
-                  colSpan={5}
+                  colSpan={collapsedGroups.has("aux") ? 1 : 5}
                   className={`${thBase} text-center ${groupBorder} ${stickyThRow1} ${dark ? "text-violet-400" : "text-violet-600"}`}
                 >
-                  AUX
+                  <button
+                    type="button"
+                    onClick={() => toggleGroupCollapse("aux")}
+                    className="inline-flex items-center gap-1 cursor-pointer"
+                    aria-label={collapsedGroups.has("aux") ? "Expand AUX columns" : "Minimize AUX columns"}
+                    title={collapsedGroups.has("aux") ? "Expand AUX columns" : "Minimize AUX columns"}
+                  >
+                    AUX
+                    {collapsedGroups.has("aux")
+                      ? <Maximize2 className="h-3 w-3" aria-hidden="true" />
+                      : <Minimize2 className="h-3 w-3" aria-hidden="true" />}
+                  </button>
                 </th>
                 <th
                   colSpan={3}
@@ -1254,49 +1302,73 @@ export const FeeRecordsTable = ({
                 )}
 
                 {/* T16 */}
-                <th
-                  className={`${thBase} ${t.textSub} text-right ${groupBorder}`}
-                >
-                  Retro
-                </th>
-                <th className={`${thBase} ${t.textSub} text-right`}>Fee Due</th>
-                <th className={`${thBase} ${t.textSub} text-right`}>
-                  Rec&apos;d
-                </th>
-                <th className={`${thBase} ${t.textSub} text-right`}>Pending</th>
-                <th className={`${thBase} ${t.textSub} text-left`}>
-                  Date Rec&apos;d
-                </th>
+                {collapsedGroups.has("t16") ? (
+                  <th className={`${thBase} ${t.textSub} text-right ${groupBorder}`}>
+                    Fee Due
+                  </th>
+                ) : (
+                  <>
+                    <th
+                      className={`${thBase} ${t.textSub} text-right ${groupBorder}`}
+                    >
+                      Retro
+                    </th>
+                    <th className={`${thBase} ${t.textSub} text-right`}>Fee Due</th>
+                    <th className={`${thBase} ${t.textSub} text-right`}>
+                      Rec&apos;d
+                    </th>
+                    <th className={`${thBase} ${t.textSub} text-right`}>Pending</th>
+                    <th className={`${thBase} ${t.textSub} text-left`}>
+                      Date Rec&apos;d
+                    </th>
+                  </>
+                )}
 
                 {/* T2 */}
-                <th
-                  className={`${thBase} ${t.textSub} text-right ${groupBorder}`}
-                >
-                  Retro
-                </th>
-                <th className={`${thBase} ${t.textSub} text-right`}>Fee Due</th>
-                <th className={`${thBase} ${t.textSub} text-right`}>
-                  Rec&apos;d
-                </th>
-                <th className={`${thBase} ${t.textSub} text-right`}>Pending</th>
-                <th className={`${thBase} ${t.textSub} text-left`}>
-                  Date Rec&apos;d
-                </th>
+                {collapsedGroups.has("t2") ? (
+                  <th className={`${thBase} ${t.textSub} text-right ${groupBorder}`}>
+                    Fee Due
+                  </th>
+                ) : (
+                  <>
+                    <th
+                      className={`${thBase} ${t.textSub} text-right ${groupBorder}`}
+                    >
+                      Retro
+                    </th>
+                    <th className={`${thBase} ${t.textSub} text-right`}>Fee Due</th>
+                    <th className={`${thBase} ${t.textSub} text-right`}>
+                      Rec&apos;d
+                    </th>
+                    <th className={`${thBase} ${t.textSub} text-right`}>Pending</th>
+                    <th className={`${thBase} ${t.textSub} text-left`}>
+                      Date Rec&apos;d
+                    </th>
+                  </>
+                )}
 
                 {/* AUX */}
-                <th
-                  className={`${thBase} ${t.textSub} text-right ${groupBorder}`}
-                >
-                  Retro
-                </th>
-                <th className={`${thBase} ${t.textSub} text-right`}>Fee Due</th>
-                <th className={`${thBase} ${t.textSub} text-right`}>
-                  Rec&apos;d
-                </th>
-                <th className={`${thBase} ${t.textSub} text-right`}>Pending</th>
-                <th className={`${thBase} ${t.textSub} text-left`}>
-                  Date Rec&apos;d
-                </th>
+                {collapsedGroups.has("aux") ? (
+                  <th className={`${thBase} ${t.textSub} text-right ${groupBorder}`}>
+                    Fee Due
+                  </th>
+                ) : (
+                  <>
+                    <th
+                      className={`${thBase} ${t.textSub} text-right ${groupBorder}`}
+                    >
+                      Retro
+                    </th>
+                    <th className={`${thBase} ${t.textSub} text-right`}>Fee Due</th>
+                    <th className={`${thBase} ${t.textSub} text-right`}>
+                      Rec&apos;d
+                    </th>
+                    <th className={`${thBase} ${t.textSub} text-right`}>Pending</th>
+                    <th className={`${thBase} ${t.textSub} text-left`}>
+                      Date Rec&apos;d
+                    </th>
+                  </>
+                )}
 
                 {/* Totals */}
                 <th
@@ -1875,193 +1947,226 @@ export const FeeRecordsTable = ({
                     )}
 
                     {/* T16 */}
-                    <td
-                      className={`${tdBase} text-right tabular-nums ${t.text} ${groupBorder}`}
-                      onClick={canEditFeeDue ? (e) => e.stopPropagation() : undefined}
-                    >
-                      <FeeAmountCell
-                        active={canEditFeeDue && feeAmountEdit?.caseId === c.id && feeAmountEdit.field === "t16Retro"}
-                        value={c.t16Retro} draft={feeAmountEdit?.draft ?? ""} saving={feeAmountSaving} error={feeAmountError}
-                        canEdit={canEditFeeDue} saveLabel="T16 retro" inputBg={t.inputBg} hoverCls={t.hover} textMuted={t.textMuted}
-                        onEdit={() => { setFeeAmountEdit({ caseId: c.id, field: "t16Retro", draft: String(c.t16Retro) }); setFeeAmountError(null); }}
-                        onDraftChange={(v) => setFeeAmountEdit((p) => p ? { ...p, draft: v } : p)}
-                        onSave={handleFeeAmountSave}
-                        onCancel={() => { setFeeAmountEdit(null); setFeeAmountError(null); }}
-                      />
-                    </td>
-                    <td
-                      className={`${tdBase} text-right tabular-nums ${t.text}`}
-                      onClick={canEditFeeDue ? (e) => e.stopPropagation() : undefined}
-                    >
-                      <FeeAmountCell
-                        active={canEditFeeDue && feeAmountEdit?.caseId === c.id && feeAmountEdit.field === "t16FeeDue"}
-                        value={c.t16FeeDue} draft={feeAmountEdit?.draft ?? ""} saving={feeAmountSaving} error={feeAmountError}
-                        canEdit={canEditFeeDue} saveLabel="T16 fee due" inputBg={t.inputBg} hoverCls={t.hover} textMuted={t.textMuted} allowExplicitZero
-                        onEdit={() => { setFeeAmountEdit({ caseId: c.id, field: "t16FeeDue", draft: c.t16FeeDue != null ? String(c.t16FeeDue) : "" }); setFeeAmountError(null); }}
-                        onDraftChange={(v) => setFeeAmountEdit((p) => p ? { ...p, draft: v } : p)}
-                        onSave={handleFeeAmountSave}
-                        onCancel={() => { setFeeAmountEdit(null); setFeeAmountError(null); }}
-                      />
-                    </td>
-                    <td
-                      className={`${tdBase} text-right tabular-nums ${c.t16FeeReceived > 0 ? "text-emerald-500 font-medium" : t.textMuted}`}
-                    >
-                      {currency(c.t16FeeReceived)}
-                    </td>
-                    <td
-                      className={`${tdBase} text-right tabular-nums ${c.t16Pending > 0 ? (dark ? "text-amber-400" : "text-amber-600") : c.t16Pending < 0 ? (dark ? "text-red-400" : "text-red-600") : t.textMuted}`}
-                      title="Auto-calculated: Fee Due − Rec'd"
-                    >
-                      {pendingDisplay(c.t16Pending)}
-                    </td>
-                    <td className={`${tdBase} ${t.textSub}`} onClick={(e) => e.stopPropagation()}>
-                      <FeePaymentPanel
-                        caseId={c.id}
-                        feeType="t16"
-                        currentTotal={c.t16FeeReceived}
-                        mostRecentDate={c.t16FeeReceivedDate}
-                        canEdit={canEditFees}
-                        dark={dark}
-                        onAdded={(amount, receivedDate) =>
-                          setFeeOverrides((prev) => ({
-                            ...prev,
-                            [c.id]: { ...prev[c.id], t16FeeReceived: (prev[c.id]?.t16FeeReceived ?? c.t16FeeReceived) + amount, t16FeeReceivedDate: receivedDate },
-                          }))
-                        }
-                        onDeleted={(amount) =>
-                          setFeeOverrides((prev) => ({
-                            ...prev,
-                            [c.id]: { ...prev[c.id], t16FeeReceived: Math.max(0, (prev[c.id]?.t16FeeReceived ?? c.t16FeeReceived) - amount) },
-                          }))
-                        }
-                      />
-                    </td>
+                    {collapsedGroups.has("t16") ? (
+                      <td
+                        className={`${tdBase} text-right tabular-nums ${t.textMuted} ${groupBorder}`}
+                        title="Minimized — expand T16 to edit"
+                      >
+                        {c.t16FeeDue != null ? currency(c.t16FeeDue) : "—"}
+                      </td>
+                    ) : (
+                      <>
+                        <td
+                          className={`${tdBase} text-right tabular-nums ${t.text} ${groupBorder}`}
+                          onClick={canEditFeeDue ? (e) => e.stopPropagation() : undefined}
+                        >
+                          <FeeAmountCell
+                            active={canEditFeeDue && feeAmountEdit?.caseId === c.id && feeAmountEdit.field === "t16Retro"}
+                            value={c.t16Retro} draft={feeAmountEdit?.draft ?? ""} saving={feeAmountSaving} error={feeAmountError}
+                            canEdit={canEditFeeDue} saveLabel="T16 retro" inputBg={t.inputBg} hoverCls={t.hover} textMuted={t.textMuted}
+                            onEdit={() => { setFeeAmountEdit({ caseId: c.id, field: "t16Retro", draft: String(c.t16Retro) }); setFeeAmountError(null); }}
+                            onDraftChange={(v) => setFeeAmountEdit((p) => p ? { ...p, draft: v } : p)}
+                            onSave={handleFeeAmountSave}
+                            onCancel={() => { setFeeAmountEdit(null); setFeeAmountError(null); }}
+                          />
+                        </td>
+                        <td
+                          className={`${tdBase} text-right tabular-nums ${t.text}`}
+                          onClick={canEditFeeDue ? (e) => e.stopPropagation() : undefined}
+                        >
+                          <FeeAmountCell
+                            active={canEditFeeDue && feeAmountEdit?.caseId === c.id && feeAmountEdit.field === "t16FeeDue"}
+                            value={c.t16FeeDue} draft={feeAmountEdit?.draft ?? ""} saving={feeAmountSaving} error={feeAmountError}
+                            canEdit={canEditFeeDue} saveLabel="T16 fee due" inputBg={t.inputBg} hoverCls={t.hover} textMuted={t.textMuted} allowExplicitZero
+                            onEdit={() => { setFeeAmountEdit({ caseId: c.id, field: "t16FeeDue", draft: c.t16FeeDue != null ? String(c.t16FeeDue) : "" }); setFeeAmountError(null); }}
+                            onDraftChange={(v) => setFeeAmountEdit((p) => p ? { ...p, draft: v } : p)}
+                            onSave={handleFeeAmountSave}
+                            onCancel={() => { setFeeAmountEdit(null); setFeeAmountError(null); }}
+                          />
+                        </td>
+                        <td
+                          className={`${tdBase} text-right tabular-nums ${c.t16FeeReceived > 0 ? "text-emerald-500 font-medium" : t.textMuted}`}
+                        >
+                          {currency(c.t16FeeReceived)}
+                        </td>
+                        <td
+                          className={`${tdBase} text-right tabular-nums ${c.t16Pending > 0 ? (dark ? "text-amber-400" : "text-amber-600") : c.t16Pending < 0 ? (dark ? "text-red-400" : "text-red-600") : t.textMuted}`}
+                          title="Auto-calculated: Fee Due − Rec'd"
+                        >
+                          {pendingDisplay(c.t16Pending)}
+                        </td>
+                        <td className={`${tdBase} ${t.textSub}`} onClick={(e) => e.stopPropagation()}>
+                          <FeePaymentPanel
+                            caseId={c.id}
+                            feeType="t16"
+                            currentTotal={c.t16FeeReceived}
+                            mostRecentDate={c.t16FeeReceivedDate}
+                            canEdit={canEditFees}
+                            dark={dark}
+                            onAdded={(amount, receivedDate) =>
+                              setFeeOverrides((prev) => ({
+                                ...prev,
+                                [c.id]: { ...prev[c.id], t16FeeReceived: (prev[c.id]?.t16FeeReceived ?? c.t16FeeReceived) + amount, t16FeeReceivedDate: receivedDate },
+                              }))
+                            }
+                            onDeleted={(amount) =>
+                              setFeeOverrides((prev) => ({
+                                ...prev,
+                                [c.id]: { ...prev[c.id], t16FeeReceived: Math.max(0, (prev[c.id]?.t16FeeReceived ?? c.t16FeeReceived) - amount) },
+                              }))
+                            }
+                          />
+                        </td>
+                      </>
+                    )}
 
                     {/* T2 */}
-                    <td
-                      className={`${tdBase} text-right tabular-nums ${t.text} ${groupBorder}`}
-                      onClick={canEditFeeDue ? (e) => e.stopPropagation() : undefined}
-                    >
-                      <FeeAmountCell
-                        active={canEditFeeDue && feeAmountEdit?.caseId === c.id && feeAmountEdit.field === "t2Retro"}
-                        value={c.t2Retro} draft={feeAmountEdit?.draft ?? ""} saving={feeAmountSaving} error={feeAmountError}
-                        canEdit={canEditFeeDue} saveLabel="T2 retro" inputBg={t.inputBg} hoverCls={t.hover} textMuted={t.textMuted}
-                        onEdit={() => { setFeeAmountEdit({ caseId: c.id, field: "t2Retro", draft: String(c.t2Retro) }); setFeeAmountError(null); }}
-                        onDraftChange={(v) => setFeeAmountEdit((p) => p ? { ...p, draft: v } : p)}
-                        onSave={handleFeeAmountSave}
-                        onCancel={() => { setFeeAmountEdit(null); setFeeAmountError(null); }}
-                      />
-                    </td>
-                    <td
-                      className={`${tdBase} text-right tabular-nums ${t.text}`}
-                      onClick={canEditFeeDue ? (e) => e.stopPropagation() : undefined}
-                    >
-                      <FeeAmountCell
-                        active={canEditFeeDue && feeAmountEdit?.caseId === c.id && feeAmountEdit.field === "t2FeeDue"}
-                        value={c.t2FeeDue} draft={feeAmountEdit?.draft ?? ""} saving={feeAmountSaving} error={feeAmountError}
-                        canEdit={canEditFeeDue} saveLabel="T2 fee due" inputBg={t.inputBg} hoverCls={t.hover} textMuted={t.textMuted} allowExplicitZero
-                        onEdit={() => { setFeeAmountEdit({ caseId: c.id, field: "t2FeeDue", draft: c.t2FeeDue != null ? String(c.t2FeeDue) : "" }); setFeeAmountError(null); }}
-                        onDraftChange={(v) => setFeeAmountEdit((p) => p ? { ...p, draft: v } : p)}
-                        onSave={handleFeeAmountSave}
-                        onCancel={() => { setFeeAmountEdit(null); setFeeAmountError(null); }}
-                      />
-                    </td>
-                    <td
-                      className={`${tdBase} text-right tabular-nums ${c.t2FeeReceived > 0 ? "text-emerald-500 font-medium" : t.textMuted}`}
-                    >
-                      {currency(c.t2FeeReceived)}
-                    </td>
-                    <td
-                      className={`${tdBase} text-right tabular-nums ${c.t2Pending > 0 ? (dark ? "text-amber-400" : "text-amber-600") : c.t2Pending < 0 ? (dark ? "text-red-400" : "text-red-600") : t.textMuted}`}
-                      title="Auto-calculated: Fee Due − Rec'd"
-                    >
-                      {pendingDisplay(c.t2Pending)}
-                    </td>
-                    <td className={`${tdBase} ${t.textSub}`} onClick={(e) => e.stopPropagation()}>
-                      <FeePaymentPanel
-                        caseId={c.id}
-                        feeType="t2"
-                        currentTotal={c.t2FeeReceived}
-                        mostRecentDate={c.t2FeeReceivedDate}
-                        canEdit={canEditFees}
-                        dark={dark}
-                        onAdded={(amount, receivedDate) =>
-                          setFeeOverrides((prev) => ({
-                            ...prev,
-                            [c.id]: { ...prev[c.id], t2FeeReceived: (prev[c.id]?.t2FeeReceived ?? c.t2FeeReceived) + amount, t2FeeReceivedDate: receivedDate },
-                          }))
-                        }
-                        onDeleted={(amount) =>
-                          setFeeOverrides((prev) => ({
-                            ...prev,
-                            [c.id]: { ...prev[c.id], t2FeeReceived: Math.max(0, (prev[c.id]?.t2FeeReceived ?? c.t2FeeReceived) - amount) },
-                          }))
-                        }
-                      />
-                    </td>
+                    {collapsedGroups.has("t2") ? (
+                      <td
+                        className={`${tdBase} text-right tabular-nums ${t.textMuted} ${groupBorder}`}
+                        title="Minimized — expand T2 to edit"
+                      >
+                        {c.t2FeeDue != null ? currency(c.t2FeeDue) : "—"}
+                      </td>
+                    ) : (
+                      <>
+                        <td
+                          className={`${tdBase} text-right tabular-nums ${t.text} ${groupBorder}`}
+                          onClick={canEditFeeDue ? (e) => e.stopPropagation() : undefined}
+                        >
+                          <FeeAmountCell
+                            active={canEditFeeDue && feeAmountEdit?.caseId === c.id && feeAmountEdit.field === "t2Retro"}
+                            value={c.t2Retro} draft={feeAmountEdit?.draft ?? ""} saving={feeAmountSaving} error={feeAmountError}
+                            canEdit={canEditFeeDue} saveLabel="T2 retro" inputBg={t.inputBg} hoverCls={t.hover} textMuted={t.textMuted}
+                            onEdit={() => { setFeeAmountEdit({ caseId: c.id, field: "t2Retro", draft: String(c.t2Retro) }); setFeeAmountError(null); }}
+                            onDraftChange={(v) => setFeeAmountEdit((p) => p ? { ...p, draft: v } : p)}
+                            onSave={handleFeeAmountSave}
+                            onCancel={() => { setFeeAmountEdit(null); setFeeAmountError(null); }}
+                          />
+                        </td>
+                        <td
+                          className={`${tdBase} text-right tabular-nums ${t.text}`}
+                          onClick={canEditFeeDue ? (e) => e.stopPropagation() : undefined}
+                        >
+                          <FeeAmountCell
+                            active={canEditFeeDue && feeAmountEdit?.caseId === c.id && feeAmountEdit.field === "t2FeeDue"}
+                            value={c.t2FeeDue} draft={feeAmountEdit?.draft ?? ""} saving={feeAmountSaving} error={feeAmountError}
+                            canEdit={canEditFeeDue} saveLabel="T2 fee due" inputBg={t.inputBg} hoverCls={t.hover} textMuted={t.textMuted} allowExplicitZero
+                            onEdit={() => { setFeeAmountEdit({ caseId: c.id, field: "t2FeeDue", draft: c.t2FeeDue != null ? String(c.t2FeeDue) : "" }); setFeeAmountError(null); }}
+                            onDraftChange={(v) => setFeeAmountEdit((p) => p ? { ...p, draft: v } : p)}
+                            onSave={handleFeeAmountSave}
+                            onCancel={() => { setFeeAmountEdit(null); setFeeAmountError(null); }}
+                          />
+                        </td>
+                        <td
+                          className={`${tdBase} text-right tabular-nums ${c.t2FeeReceived > 0 ? "text-emerald-500 font-medium" : t.textMuted}`}
+                        >
+                          {currency(c.t2FeeReceived)}
+                        </td>
+                        <td
+                          className={`${tdBase} text-right tabular-nums ${c.t2Pending > 0 ? (dark ? "text-amber-400" : "text-amber-600") : c.t2Pending < 0 ? (dark ? "text-red-400" : "text-red-600") : t.textMuted}`}
+                          title="Auto-calculated: Fee Due − Rec'd"
+                        >
+                          {pendingDisplay(c.t2Pending)}
+                        </td>
+                        <td className={`${tdBase} ${t.textSub}`} onClick={(e) => e.stopPropagation()}>
+                          <FeePaymentPanel
+                            caseId={c.id}
+                            feeType="t2"
+                            currentTotal={c.t2FeeReceived}
+                            mostRecentDate={c.t2FeeReceivedDate}
+                            canEdit={canEditFees}
+                            dark={dark}
+                            onAdded={(amount, receivedDate) =>
+                              setFeeOverrides((prev) => ({
+                                ...prev,
+                                [c.id]: { ...prev[c.id], t2FeeReceived: (prev[c.id]?.t2FeeReceived ?? c.t2FeeReceived) + amount, t2FeeReceivedDate: receivedDate },
+                              }))
+                            }
+                            onDeleted={(amount) =>
+                              setFeeOverrides((prev) => ({
+                                ...prev,
+                                [c.id]: { ...prev[c.id], t2FeeReceived: Math.max(0, (prev[c.id]?.t2FeeReceived ?? c.t2FeeReceived) - amount) },
+                              }))
+                            }
+                          />
+                        </td>
+                      </>
+                    )}
 
                     {/* AUX */}
-                    <td
-                      className={`${tdBase} text-right tabular-nums ${t.text} ${groupBorder}`}
-                      onClick={canEditFeeDue ? (e) => e.stopPropagation() : undefined}
-                    >
-                      <FeeAmountCell
-                        active={canEditFeeDue && feeAmountEdit?.caseId === c.id && feeAmountEdit.field === "auxRetro"}
-                        value={c.auxRetro} draft={feeAmountEdit?.draft ?? ""} saving={feeAmountSaving} error={feeAmountError}
-                        canEdit={canEditFeeDue} saveLabel="AUX retro" inputBg={t.inputBg} hoverCls={t.hover} textMuted={t.textMuted}
-                        onEdit={() => { setFeeAmountEdit({ caseId: c.id, field: "auxRetro", draft: String(c.auxRetro) }); setFeeAmountError(null); }}
-                        onDraftChange={(v) => setFeeAmountEdit((p) => p ? { ...p, draft: v } : p)}
-                        onSave={handleFeeAmountSave}
-                        onCancel={() => { setFeeAmountEdit(null); setFeeAmountError(null); }}
-                      />
-                    </td>
-                    <td
-                      className={`${tdBase} text-right tabular-nums ${t.text}`}
-                      onClick={canEditFeeDue ? (e) => e.stopPropagation() : undefined}
-                    >
-                      <FeeAmountCell
-                        active={canEditFeeDue && feeAmountEdit?.caseId === c.id && feeAmountEdit.field === "auxFeeDue"}
-                        value={c.auxFeeDue} draft={feeAmountEdit?.draft ?? ""} saving={feeAmountSaving} error={feeAmountError}
-                        canEdit={canEditFeeDue} saveLabel="AUX fee due" inputBg={t.inputBg} hoverCls={t.hover} textMuted={t.textMuted} allowExplicitZero
-                        onEdit={() => { setFeeAmountEdit({ caseId: c.id, field: "auxFeeDue", draft: c.auxFeeDue != null ? String(c.auxFeeDue) : "" }); setFeeAmountError(null); }}
-                        onDraftChange={(v) => setFeeAmountEdit((p) => p ? { ...p, draft: v } : p)}
-                        onSave={handleFeeAmountSave}
-                        onCancel={() => { setFeeAmountEdit(null); setFeeAmountError(null); }}
-                      />
-                    </td>
-                    <td
-                      className={`${tdBase} text-right tabular-nums ${c.auxFeeReceived > 0 ? "text-emerald-500 font-medium" : t.textMuted}`}
-                    >
-                      {currency(c.auxFeeReceived)}
-                    </td>
-                    <td
-                      className={`${tdBase} text-right tabular-nums ${c.auxPending > 0 ? (dark ? "text-amber-400" : "text-amber-600") : c.auxPending < 0 ? (dark ? "text-red-400" : "text-red-600") : t.textMuted}`}
-                      title="Auto-calculated: Fee Due − Rec'd"
-                    >
-                      {pendingDisplay(c.auxPending)}
-                    </td>
-                    <td className={`${tdBase} ${t.textSub}`} onClick={(e) => e.stopPropagation()}>
-                      <FeePaymentPanel
-                        caseId={c.id}
-                        feeType="aux"
-                        currentTotal={c.auxFeeReceived}
-                        mostRecentDate={c.auxFeeReceivedDate}
-                        canEdit={canEditFees}
-                        dark={dark}
-                        onAdded={(amount, receivedDate) =>
-                          setFeeOverrides((prev) => ({
-                            ...prev,
-                            [c.id]: { ...prev[c.id], auxFeeReceived: (prev[c.id]?.auxFeeReceived ?? c.auxFeeReceived) + amount, auxFeeReceivedDate: receivedDate },
-                          }))
-                        }
-                        onDeleted={(amount) =>
-                          setFeeOverrides((prev) => ({
-                            ...prev,
-                            [c.id]: { ...prev[c.id], auxFeeReceived: Math.max(0, (prev[c.id]?.auxFeeReceived ?? c.auxFeeReceived) - amount) },
-                          }))
-                        }
-                      />
-                    </td>
+                    {collapsedGroups.has("aux") ? (
+                      <td
+                        className={`${tdBase} text-right tabular-nums ${t.textMuted} ${groupBorder}`}
+                        title="Minimized — expand AUX to edit"
+                      >
+                        {c.auxFeeDue != null ? currency(c.auxFeeDue) : "—"}
+                      </td>
+                    ) : (
+                      <>
+                        <td
+                          className={`${tdBase} text-right tabular-nums ${t.text} ${groupBorder}`}
+                          onClick={canEditFeeDue ? (e) => e.stopPropagation() : undefined}
+                        >
+                          <FeeAmountCell
+                            active={canEditFeeDue && feeAmountEdit?.caseId === c.id && feeAmountEdit.field === "auxRetro"}
+                            value={c.auxRetro} draft={feeAmountEdit?.draft ?? ""} saving={feeAmountSaving} error={feeAmountError}
+                            canEdit={canEditFeeDue} saveLabel="AUX retro" inputBg={t.inputBg} hoverCls={t.hover} textMuted={t.textMuted}
+                            onEdit={() => { setFeeAmountEdit({ caseId: c.id, field: "auxRetro", draft: String(c.auxRetro) }); setFeeAmountError(null); }}
+                            onDraftChange={(v) => setFeeAmountEdit((p) => p ? { ...p, draft: v } : p)}
+                            onSave={handleFeeAmountSave}
+                            onCancel={() => { setFeeAmountEdit(null); setFeeAmountError(null); }}
+                          />
+                        </td>
+                        <td
+                          className={`${tdBase} text-right tabular-nums ${t.text}`}
+                          onClick={canEditFeeDue ? (e) => e.stopPropagation() : undefined}
+                        >
+                          <FeeAmountCell
+                            active={canEditFeeDue && feeAmountEdit?.caseId === c.id && feeAmountEdit.field === "auxFeeDue"}
+                            value={c.auxFeeDue} draft={feeAmountEdit?.draft ?? ""} saving={feeAmountSaving} error={feeAmountError}
+                            canEdit={canEditFeeDue} saveLabel="AUX fee due" inputBg={t.inputBg} hoverCls={t.hover} textMuted={t.textMuted} allowExplicitZero
+                            onEdit={() => { setFeeAmountEdit({ caseId: c.id, field: "auxFeeDue", draft: c.auxFeeDue != null ? String(c.auxFeeDue) : "" }); setFeeAmountError(null); }}
+                            onDraftChange={(v) => setFeeAmountEdit((p) => p ? { ...p, draft: v } : p)}
+                            onSave={handleFeeAmountSave}
+                            onCancel={() => { setFeeAmountEdit(null); setFeeAmountError(null); }}
+                          />
+                        </td>
+                        <td
+                          className={`${tdBase} text-right tabular-nums ${c.auxFeeReceived > 0 ? "text-emerald-500 font-medium" : t.textMuted}`}
+                        >
+                          {currency(c.auxFeeReceived)}
+                        </td>
+                        <td
+                          className={`${tdBase} text-right tabular-nums ${c.auxPending > 0 ? (dark ? "text-amber-400" : "text-amber-600") : c.auxPending < 0 ? (dark ? "text-red-400" : "text-red-600") : t.textMuted}`}
+                          title="Auto-calculated: Fee Due − Rec'd"
+                        >
+                          {pendingDisplay(c.auxPending)}
+                        </td>
+                        <td className={`${tdBase} ${t.textSub}`} onClick={(e) => e.stopPropagation()}>
+                          <FeePaymentPanel
+                            caseId={c.id}
+                            feeType="aux"
+                            currentTotal={c.auxFeeReceived}
+                            mostRecentDate={c.auxFeeReceivedDate}
+                            canEdit={canEditFees}
+                            dark={dark}
+                            onAdded={(amount, receivedDate) =>
+                              setFeeOverrides((prev) => ({
+                                ...prev,
+                                [c.id]: { ...prev[c.id], auxFeeReceived: (prev[c.id]?.auxFeeReceived ?? c.auxFeeReceived) + amount, auxFeeReceivedDate: receivedDate },
+                              }))
+                            }
+                            onDeleted={(amount) =>
+                              setFeeOverrides((prev) => ({
+                                ...prev,
+                                [c.id]: { ...prev[c.id], auxFeeReceived: Math.max(0, (prev[c.id]?.auxFeeReceived ?? c.auxFeeReceived) - amount) },
+                              }))
+                            }
+                          />
+                        </td>
+                      </>
+                    )}
 
                     {/* Totals */}
                     <td

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -1187,7 +1187,7 @@ export const FeeRecordsTable = ({
                 />
 
                 <th
-                  colSpan={collapsedGroups.has("t16") ? 1 : 5}
+                  colSpan={collapsedGroups.has("t16") ? 2 : 5}
                   className={`${thBase} text-center ${groupBorder} ${stickyThRow1} ${dark ? "text-indigo-400" : "text-indigo-600"}`}
                 >
                   <button
@@ -1204,7 +1204,7 @@ export const FeeRecordsTable = ({
                   </button>
                 </th>
                 <th
-                  colSpan={collapsedGroups.has("t2") ? 1 : 5}
+                  colSpan={collapsedGroups.has("t2") ? 2 : 5}
                   className={`${thBase} text-center ${groupBorder} ${stickyThRow1} ${dark ? "text-blue-400" : "text-blue-600"}`}
                 >
                   <button
@@ -1221,7 +1221,7 @@ export const FeeRecordsTable = ({
                   </button>
                 </th>
                 <th
-                  colSpan={collapsedGroups.has("aux") ? 1 : 5}
+                  colSpan={collapsedGroups.has("aux") ? 2 : 5}
                   className={`${thBase} text-center ${groupBorder} ${stickyThRow1} ${dark ? "text-violet-400" : "text-violet-600"}`}
                 >
                   <button
@@ -1318,11 +1318,11 @@ export const FeeRecordsTable = ({
                       Rec&apos;d
                     </th>
                     <th className={`${thBase} ${t.textSub} text-right`}>Pending</th>
-                    <th className={`${thBase} ${t.textSub} text-left`}>
-                      Date Rec&apos;d
-                    </th>
                   </>
                 )}
+                <th className={`${thBase} ${t.textSub} text-left`}>
+                  Date Rec&apos;d
+                </th>
 
                 {/* T2 */}
                 {collapsedGroups.has("t2") ? (
@@ -1341,11 +1341,11 @@ export const FeeRecordsTable = ({
                       Rec&apos;d
                     </th>
                     <th className={`${thBase} ${t.textSub} text-right`}>Pending</th>
-                    <th className={`${thBase} ${t.textSub} text-left`}>
-                      Date Rec&apos;d
-                    </th>
                   </>
                 )}
+                <th className={`${thBase} ${t.textSub} text-left`}>
+                  Date Rec&apos;d
+                </th>
 
                 {/* AUX */}
                 {collapsedGroups.has("aux") ? (
@@ -1364,11 +1364,11 @@ export const FeeRecordsTable = ({
                       Rec&apos;d
                     </th>
                     <th className={`${thBase} ${t.textSub} text-right`}>Pending</th>
-                    <th className={`${thBase} ${t.textSub} text-left`}>
-                      Date Rec&apos;d
-                    </th>
                   </>
                 )}
+                <th className={`${thBase} ${t.textSub} text-left`}>
+                  Date Rec&apos;d
+                </th>
 
                 {/* Totals */}
                 <th
@@ -1995,30 +1995,30 @@ export const FeeRecordsTable = ({
                         >
                           {pendingDisplay(c.t16Pending)}
                         </td>
-                        <td className={`${tdBase} ${t.textSub}`} onClick={(e) => e.stopPropagation()}>
-                          <FeePaymentPanel
-                            caseId={c.id}
-                            feeType="t16"
-                            currentTotal={c.t16FeeReceived}
-                            mostRecentDate={c.t16FeeReceivedDate}
-                            canEdit={canEditFees}
-                            dark={dark}
-                            onAdded={(amount, receivedDate) =>
-                              setFeeOverrides((prev) => ({
-                                ...prev,
-                                [c.id]: { ...prev[c.id], t16FeeReceived: (prev[c.id]?.t16FeeReceived ?? c.t16FeeReceived) + amount, t16FeeReceivedDate: receivedDate },
-                              }))
-                            }
-                            onDeleted={(amount) =>
-                              setFeeOverrides((prev) => ({
-                                ...prev,
-                                [c.id]: { ...prev[c.id], t16FeeReceived: Math.max(0, (prev[c.id]?.t16FeeReceived ?? c.t16FeeReceived) - amount) },
-                              }))
-                            }
-                          />
-                        </td>
                       </>
                     )}
+                    <td className={`${tdBase} ${t.textSub}`} onClick={(e) => e.stopPropagation()}>
+                      <FeePaymentPanel
+                        caseId={c.id}
+                        feeType="t16"
+                        currentTotal={c.t16FeeReceived}
+                        mostRecentDate={c.t16FeeReceivedDate}
+                        canEdit={canEditFees}
+                        dark={dark}
+                        onAdded={(amount, receivedDate) =>
+                          setFeeOverrides((prev) => ({
+                            ...prev,
+                            [c.id]: { ...prev[c.id], t16FeeReceived: (prev[c.id]?.t16FeeReceived ?? c.t16FeeReceived) + amount, t16FeeReceivedDate: receivedDate },
+                          }))
+                        }
+                        onDeleted={(amount) =>
+                          setFeeOverrides((prev) => ({
+                            ...prev,
+                            [c.id]: { ...prev[c.id], t16FeeReceived: Math.max(0, (prev[c.id]?.t16FeeReceived ?? c.t16FeeReceived) - amount) },
+                          }))
+                        }
+                      />
+                    </td>
 
                     {/* T2 */}
                     {collapsedGroups.has("t2") ? (
@@ -2069,30 +2069,30 @@ export const FeeRecordsTable = ({
                         >
                           {pendingDisplay(c.t2Pending)}
                         </td>
-                        <td className={`${tdBase} ${t.textSub}`} onClick={(e) => e.stopPropagation()}>
-                          <FeePaymentPanel
-                            caseId={c.id}
-                            feeType="t2"
-                            currentTotal={c.t2FeeReceived}
-                            mostRecentDate={c.t2FeeReceivedDate}
-                            canEdit={canEditFees}
-                            dark={dark}
-                            onAdded={(amount, receivedDate) =>
-                              setFeeOverrides((prev) => ({
-                                ...prev,
-                                [c.id]: { ...prev[c.id], t2FeeReceived: (prev[c.id]?.t2FeeReceived ?? c.t2FeeReceived) + amount, t2FeeReceivedDate: receivedDate },
-                              }))
-                            }
-                            onDeleted={(amount) =>
-                              setFeeOverrides((prev) => ({
-                                ...prev,
-                                [c.id]: { ...prev[c.id], t2FeeReceived: Math.max(0, (prev[c.id]?.t2FeeReceived ?? c.t2FeeReceived) - amount) },
-                              }))
-                            }
-                          />
-                        </td>
                       </>
                     )}
+                    <td className={`${tdBase} ${t.textSub}`} onClick={(e) => e.stopPropagation()}>
+                      <FeePaymentPanel
+                        caseId={c.id}
+                        feeType="t2"
+                        currentTotal={c.t2FeeReceived}
+                        mostRecentDate={c.t2FeeReceivedDate}
+                        canEdit={canEditFees}
+                        dark={dark}
+                        onAdded={(amount, receivedDate) =>
+                          setFeeOverrides((prev) => ({
+                            ...prev,
+                            [c.id]: { ...prev[c.id], t2FeeReceived: (prev[c.id]?.t2FeeReceived ?? c.t2FeeReceived) + amount, t2FeeReceivedDate: receivedDate },
+                          }))
+                        }
+                        onDeleted={(amount) =>
+                          setFeeOverrides((prev) => ({
+                            ...prev,
+                            [c.id]: { ...prev[c.id], t2FeeReceived: Math.max(0, (prev[c.id]?.t2FeeReceived ?? c.t2FeeReceived) - amount) },
+                          }))
+                        }
+                      />
+                    </td>
 
                     {/* AUX */}
                     {collapsedGroups.has("aux") ? (
@@ -2143,30 +2143,30 @@ export const FeeRecordsTable = ({
                         >
                           {pendingDisplay(c.auxPending)}
                         </td>
-                        <td className={`${tdBase} ${t.textSub}`} onClick={(e) => e.stopPropagation()}>
-                          <FeePaymentPanel
-                            caseId={c.id}
-                            feeType="aux"
-                            currentTotal={c.auxFeeReceived}
-                            mostRecentDate={c.auxFeeReceivedDate}
-                            canEdit={canEditFees}
-                            dark={dark}
-                            onAdded={(amount, receivedDate) =>
-                              setFeeOverrides((prev) => ({
-                                ...prev,
-                                [c.id]: { ...prev[c.id], auxFeeReceived: (prev[c.id]?.auxFeeReceived ?? c.auxFeeReceived) + amount, auxFeeReceivedDate: receivedDate },
-                              }))
-                            }
-                            onDeleted={(amount) =>
-                              setFeeOverrides((prev) => ({
-                                ...prev,
-                                [c.id]: { ...prev[c.id], auxFeeReceived: Math.max(0, (prev[c.id]?.auxFeeReceived ?? c.auxFeeReceived) - amount) },
-                              }))
-                            }
-                          />
-                        </td>
                       </>
                     )}
+                    <td className={`${tdBase} ${t.textSub}`} onClick={(e) => e.stopPropagation()}>
+                      <FeePaymentPanel
+                        caseId={c.id}
+                        feeType="aux"
+                        currentTotal={c.auxFeeReceived}
+                        mostRecentDate={c.auxFeeReceivedDate}
+                        canEdit={canEditFees}
+                        dark={dark}
+                        onAdded={(amount, receivedDate) =>
+                          setFeeOverrides((prev) => ({
+                            ...prev,
+                            [c.id]: { ...prev[c.id], auxFeeReceived: (prev[c.id]?.auxFeeReceived ?? c.auxFeeReceived) + amount, auxFeeReceivedDate: receivedDate },
+                          }))
+                        }
+                        onDeleted={(amount) =>
+                          setFeeOverrides((prev) => ({
+                            ...prev,
+                            [c.id]: { ...prev[c.id], auxFeeReceived: Math.max(0, (prev[c.id]?.auxFeeReceived ?? c.auxFeeReceived) - amount) },
+                          }))
+                        }
+                      />
+                    </td>
 
                     {/* Totals */}
                     <td

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -107,6 +107,7 @@ const CASE_STATUS_COLORS: Record<string, { badge: string; badgeDark: string }> =
   "Incomplete win sheet":          { badge: "bg-red-50 text-red-700 border-red-300",           badgeDark: "bg-red-900/40 text-red-300 border-red-700"          },
   "Missing fees":                  { badge: "bg-red-50 text-red-700 border-red-300",           badgeDark: "bg-red-900/40 text-red-300 border-red-700"          },
   "NEED AUX FEE":                  { badge: "bg-red-50 text-red-700 border-red-300",           badgeDark: "bg-red-900/40 text-red-300 border-red-700"          },
+  "FEE PETITION APPROVED":         { badge: "bg-red-50 text-red-700 border-red-300",           badgeDark: "bg-red-900/40 text-red-300 border-red-700"          },
 };
 const CASE_STATUS_FALLBACK = { badge: "bg-neutral-100 text-neutral-500 border-neutral-300", badgeDark: "bg-neutral-700 text-neutral-300 border-neutral-600" };
 
@@ -879,6 +880,11 @@ export const FeeRecordsTable = ({
   // needs to grow on desktop), so every other frozen offset below shifts
   // right by exactly that much when mode === "closed".
   const colClosedOnW = `w-28 min-w-28 max-w-28`;
+  // Refresh is a leading frozen column in every mode, sitting right after the
+  // checkbox — fixed 56px at every breakpoint, so every other frozen offset
+  // below (Closed On, Case Name, Assigned, Fees Conf) shifts right by that
+  // much regardless of mode.
+  const colRefreshW = `w-14 min-w-14 max-w-14`;
   const isClosedMode = mode === "closed";
 
   // Every header cell is sticky vertically by default — the column-header
@@ -898,53 +904,62 @@ export const FeeRecordsTable = ({
   // Frozen column headers (row 2). Case Name freezes left on all screens;
   // Assigned freezes left only at sm+ (on mobile it keeps thBase's sticky-top
   // but scrolls horizontally). Corner cells use z-30 to cover both single-axis
-  // sticky neighbors during scroll. In "closed" mode, Closed On sits in front
-  // of Case Name, so Case Name/Assigned/Fees Conf's left offsets all shift
-  // right by colClosedOnW's 112px (7rem) — 40+112=152px=9.5rem, etc.
+  // sticky neighbors during scroll. Refresh (56px) is now the leading frozen
+  // column in every mode, so every offset below already includes it —
+  // checkbox(40) + refresh(56) = 96px = left-24 as the new baseline. In
+  // "closed" mode, Closed On additionally sits in front of Case Name, adding
+  // colClosedOnW's 112px on top of that — 96+112=208px=13rem, etc.
   const stickyTh1 = isClosedMode
-    ? `left-[9.5rem] z-30 ${colNameW} ${nameDivider}`
-    : `left-10 z-30 ${colNameW} ${nameDivider}`;
+    ? `left-52 z-30 ${colNameW} ${nameDivider}`
+    : `left-24 z-30 ${colNameW} ${nameDivider}`;
   // z-30 only at sm+ (where Assigned is a frozen corner). On mobile Assigned
   // scrolls, so no sticky-left. Freeze boundary moved to Fees Conf, so no divider here.
   // scrolls, so it must stay at thBase's z-20 — BELOW the frozen Case Name
   // (z-30) — otherwise it paints over the frozen "front index" on scroll.
   // Assigned: no divider — freeze boundary now sits after Fees Conf.
   const stickyTh2 = isClosedMode
-    ? `sm:left-[21.5rem] sm:z-30 ${colAssignedW}`
-    : `sm:left-[14.5rem] sm:z-30 ${colAssignedW}`;
+    ? `sm:left-[25rem] sm:z-30 ${colAssignedW}`
+    : `sm:left-72 sm:z-30 ${colAssignedW}`;
   // "Case Info" group label is split into cells so each part's freeze matches
   // the column beneath it. Three frozen columns: Case Name, Assigned, Fees
   // Conf (four, with Closed On, in "closed" mode).
   const stickyGroup = isClosedMode
-    ? `top-0! left-[9.5rem] z-30 ${colNameW} ${nameDivider}`
-    : `top-0! left-10 z-30 ${colNameW} ${nameDivider}`;
+    ? `top-0! left-52 z-30 ${colNameW} ${nameDivider}`
+    : `top-0! left-24 z-30 ${colNameW} ${nameDivider}`;
   const stickyGroup2 = isClosedMode
-    ? `top-0! sm:left-[21.5rem] sm:z-30 ${colAssignedW}`
-    : `top-0! sm:left-[14.5rem] sm:z-30 ${colAssignedW}`;
-  // Fees Conf is the 3rd frozen column (left offset = 40 + 192 + 160 = 392px
-  // = 24.5rem; + colClosedOnW's 112px = 504px = 31.5rem in "closed" mode).
+    ? `top-0! sm:left-[25rem] sm:z-30 ${colAssignedW}`
+    : `top-0! sm:left-72 sm:z-30 ${colAssignedW}`;
+  // Fees Conf is the 3rd frozen column (left offset = 96 + 192 + 160 = 448px
+  // = 28rem; + colClosedOnW's 112px = 560px = 35rem in "closed" mode).
   const stickyGroup3 = isClosedMode
-    ? `top-0! sm:left-[31.5rem] sm:z-30 ${colFeesConfW} ${stickyDivider}`
-    : `top-0! sm:left-[24.5rem] sm:z-30 ${colFeesConfW} ${stickyDivider}`;
+    ? `top-0! sm:left-[35rem] sm:z-30 ${colFeesConfW} ${stickyDivider}`
+    : `top-0! sm:left-[28rem] sm:z-30 ${colFeesConfW} ${stickyDivider}`;
   const stickyTh3 = isClosedMode
-    ? `sm:left-[31.5rem] sm:z-30 ${colFeesConfW} ${stickyDivider}`
-    : `sm:left-[24.5rem] sm:z-30 ${colFeesConfW} ${stickyDivider}`;
+    ? `sm:left-[35rem] sm:z-30 ${colFeesConfW} ${stickyDivider}`
+    : `sm:left-[28rem] sm:z-30 ${colFeesConfW} ${stickyDivider}`;
   const stickyTd1 = isClosedMode
-    ? `sticky left-[9.5rem] z-10 ${colNameW} ${stickyBg} ${stickyHover} ${nameDivider}`
-    : `sticky left-10 z-10 ${colNameW} ${stickyBg} ${stickyHover} ${nameDivider}`;
+    ? `sticky left-52 z-10 ${colNameW} ${stickyBg} ${stickyHover} ${nameDivider}`
+    : `sticky left-24 z-10 ${colNameW} ${stickyBg} ${stickyHover} ${nameDivider}`;
   const stickyTd2 = isClosedMode
-    ? `sm:sticky sm:left-[21.5rem] sm:z-10 ${colAssignedW} ${stickyColBg}`
-    : `sm:sticky sm:left-[14.5rem] sm:z-10 ${colAssignedW} ${stickyColBg}`;
+    ? `sm:sticky sm:left-[25rem] sm:z-10 ${colAssignedW} ${stickyColBg}`
+    : `sm:sticky sm:left-72 sm:z-10 ${colAssignedW} ${stickyColBg}`;
   const stickyTd3 = isClosedMode
-    ? `sm:sticky sm:left-[31.5rem] sm:z-10 ${colFeesConfW} ${stickyColBg} ${stickyDivider}`
-    : `sm:sticky sm:left-[24.5rem] sm:z-10 ${colFeesConfW} ${stickyColBg} ${stickyDivider}`;
+    ? `sm:sticky sm:left-[35rem] sm:z-10 ${colFeesConfW} ${stickyColBg} ${stickyDivider}`
+    : `sm:sticky sm:left-[28rem] sm:z-10 ${colFeesConfW} ${stickyColBg} ${stickyDivider}`;
   const stickyCheckTh = `sticky top-0! left-0 z-30 w-10 min-w-10 ${stickyBg}`;
   const stickyCheckTd = `sticky left-0 z-10 w-10 min-w-10 ${stickyBg} ${stickyHover}`;
-  // Closed On — new frozen column, "closed" mode only, sitting exactly where
-  // Case Name used to (left-10) now that it's first.
-  const stickyGroupClosedOn = `top-0! left-10 z-30 ${colClosedOnW}`;
-  const stickyThClosedOn = `left-10 z-30 ${colClosedOnW}`;
-  const stickyTdClosedOn = `sticky left-10 z-10 ${colClosedOnW} ${stickyBg} ${stickyHover}`;
+  // Refresh — new leading frozen column (all modes), sitting right after the
+  // checkbox at left-10 (40px, the checkbox's own width). Spans both header
+  // rows like the checkbox, so (like stickyCheckTh) it's fully self-contained
+  // rather than combined with thBase — a rowSpan={2} cell needs top-0! for
+  // its whole height, not thBase's row-2-only top-8.
+  const stickyThRefresh = `h-8 px-3 text-[12px] font-semibold uppercase tracking-wider whitespace-nowrap sticky top-0! left-10 z-30 ${colRefreshW} ${stickyBg} ${t.textSub} text-center`;
+  const stickyTdRefresh = `sticky left-10 z-10 ${colRefreshW} ${stickyBg} ${stickyHover}`;
+  // Closed On — frozen, "closed" mode only, sitting right after Refresh
+  // (checkbox 40px + refresh 56px = 96px = left-24).
+  const stickyGroupClosedOn = `top-0! left-24 z-30 ${colClosedOnW}`;
+  const stickyThClosedOn = `left-24 z-30 ${colClosedOnW}`;
+  const stickyTdClosedOn = `sticky left-24 z-10 ${colClosedOnW} ${stickyBg} ${stickyHover}`;
 
   return (
     <div className={`relative rounded-xl border ${t.card}`}>
@@ -1138,6 +1153,16 @@ export const FeeRecordsTable = ({
                     className="h-3.5 w-3.5 cursor-pointer accent-indigo-500"
                   />
                 </th>
+                {/* Refresh — moved to the front (frozen), before Case Name, so
+                    it's usable without scrolling right. Spans both header
+                    rows like the checkbox, since it has no group label.
+                    Icon-only (like the checkbox column) — the column is too
+                    narrow at this frozen width for the word "Refresh" to fit
+                    without colliding with "Case Info" next to it. */}
+                <th rowSpan={2} className={stickyThRefresh} title="Refresh">
+                  <RefreshCw className="h-3.5 w-3.5 inline" aria-hidden="true" />
+                  <span className="sr-only">Refresh</span>
+                </th>
                 {/* Closed On sits in front of Case Info's group, "closed" mode
                     only — same blank-spacer pattern as the Assigned/Fees Conf
                     cells below, just with nothing to label. */}
@@ -1196,7 +1221,7 @@ export const FeeRecordsTable = ({
                   Totals
                 </th>
                 <th
-                  colSpan={isClosedMode ? 6 : 7}
+                  colSpan={isClosedMode ? 5 : 6}
                   className={`${thBase} text-center ${groupBorder} ${stickyThRow1} ${t.textSub}`}
                 >
                   Workflow
@@ -1335,7 +1360,6 @@ export const FeeRecordsTable = ({
                   Recent Update
                 </th>
                 <th className={`${thBase} ${t.textSub} text-center`}>Logs</th>
-                <th className={`${thBase} ${t.textSub} text-center`}>Refresh</th>
                 {/* Closed On moved to the front (frozen) in "closed" mode —
                     this trailing slot is Active-mode-only now. */}
                 {!isClosedMode && (
@@ -1373,6 +1397,26 @@ export const FeeRecordsTable = ({
                         aria-label={`Select ${c.name}`}
                         className="h-3.5 w-3.5 cursor-pointer accent-indigo-500"
                       />
+                    </td>
+                    {/* Refresh — moved to the front (frozen), before Case
+                        Name, so it's usable without scrolling right. */}
+                    <td
+                      className={`${tdBase} text-center ${stickyTdRefresh}`}
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <button
+                        type="button"
+                        onClick={() => handleRowRefresh(c)}
+                        disabled={rowRefreshing.has(c.id)}
+                        aria-label={`Refresh ${c.name}`}
+                        title="Refresh this case's fee data from the server"
+                        className={`inline-flex items-center justify-center h-6 w-6 rounded ${t.hover} ${t.textSub} disabled:opacity-50`}
+                      >
+                        <RefreshCw
+                          className={`h-3.5 w-3.5 ${rowRefreshing.has(c.id) ? "animate-spin" : ""}`}
+                          aria-hidden="true"
+                        />
+                      </button>
                     </td>
                     {/* Closed On — frozen, "closed" mode only, first data
                         column so it's visible without scrolling. */}
@@ -2247,21 +2291,6 @@ export const FeeRecordsTable = ({
                       >
                         <MessageSquare className="h-3 w-3" aria-hidden="true" />
                         {c.notesCount}
-                      </button>
-                    </td>
-                    <td className={`${tdBase} text-center`} onClick={(e) => e.stopPropagation()}>
-                      <button
-                        type="button"
-                        onClick={() => handleRowRefresh(c)}
-                        disabled={rowRefreshing.has(c.id)}
-                        aria-label={`Refresh ${c.name}`}
-                        title="Refresh this case's fee data from the server"
-                        className={`inline-flex items-center justify-center h-6 w-6 rounded ${t.hover} ${t.textSub} disabled:opacity-50`}
-                      >
-                        <RefreshCw
-                          className={`h-3.5 w-3.5 ${rowRefreshing.has(c.id) ? "animate-spin" : ""}`}
-                          aria-hidden="true"
-                        />
                       </button>
                     </td>
                     {/* Closed On moved to the front (frozen) in "closed" mode —

--- a/src/components/fee-petitions/FeePetitions.tsx
+++ b/src/components/fee-petitions/FeePetitions.tsx
@@ -58,7 +58,6 @@ interface FeePetitionRow {
 }
 
 type CheckboxKey =
-  | "noa"
   | "timeDelineation"
   | "feePetitionDoc"
   | "ltrToClmt"
@@ -75,7 +74,7 @@ type Assignee = { name: string; count: number };
 // ---------- helpers ----------
 const PAGE_SIZE_OPTIONS = [25, 50, 100, 200];
 const SORT_KEYS: SortKey[] = ["claimant", "approvalDate", "updatedAt", "progress"];
-const CHECKBOX_KEYS = ["noa", "timeDelineation", "feePetitionDoc", "ltrToClmt", "ltrToClmtWithSignature", "ltrToAlj", "faxConfFeePet"] as const;
+const CHECKBOX_KEYS = ["timeDelineation", "feePetitionDoc", "ltrToClmt", "ltrToClmtWithSignature", "ltrToAlj", "faxConfFeePet"] as const;
 
 const daysSince = (dateStr: string | null): number | null => {
   if (!dateStr) return null;
@@ -103,7 +102,6 @@ const DEFAULTS = {
 };
 
 const CHECKBOX_COLUMNS: { key: CheckboxKey; label: string }[] = [
-  { key: "noa", label: "NOA" },
   { key: "timeDelineation", label: "Time Delineation" },
   { key: "feePetitionDoc", label: "Fee Petition Doc" },
   { key: "ltrToClmt", label: "Ltr to Clmt" },
@@ -573,7 +571,7 @@ export const FeePetitions = () => {
           ids.includes(r.id)
             ? {
                 ...r,
-                noa: true, timeDelineation: true, feePetitionDoc: true,
+                timeDelineation: true, feePetitionDoc: true,
                 ltrToClmt: true, ltrToClmtWithSignature: true, ltrToAlj: true,
                 faxConfFeePet: true, updatedAt: today,
               }
@@ -735,7 +733,7 @@ export const FeePetitions = () => {
       }
       const headers = [
         "Case", "Approval Date", "Last Updated", "Progress",
-        "NOA", "Time Delineation", "Fee Petition Doc", "Ltr to Clmt",
+        "Time Delineation", "Fee Petition Doc", "Ltr to Clmt",
         "Ltr to Clmt w/ Signature", "Ltr to ALJ", "Fax Conf Fee Pet", "Notes",
       ];
       const escape = (v: string) => {
@@ -751,7 +749,6 @@ export const FeePetitions = () => {
             r.approvalDate ?? "",
             r.updatedAt ?? "",
             `${completedCount}/${CHECKBOX_COLUMNS.length}`,
-            r.noa ? "Yes" : "No",
             r.timeDelineation ? "Yes" : "No",
             r.feePetitionDoc ? "Yes" : "No",
             r.ltrToClmt ? "Yes" : "No",

--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -811,8 +811,8 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                     {showCol("closedcases") && <th className={`${thBase} ${t.textSub} text-right`}>Closed</th>}
                     {showCol("opennofees")  && <th className={`${thBase} text-right ${dark ? "text-amber-400" : "text-amber-600"}`}>No Fees</th>}
                     {showCol("collected")   && <th className={`${thBase} ${t.textSub} text-right`}>Collected</th>}
-                    {showCol("ssacalls")    && <th className={`${thBase} ${t.textSub} text-right border-l ${t.borderLight}`}>SSA Calls</th>}
-                    {showCol("clientcalls") && <th className={`${thBase} ${t.textSub} text-right`}>Client Calls</th>}
+                    {showCol("ssacalls")    && <th className={`${thBase} text-right border-l ${t.borderLight} ${dark ? "text-sky-400" : "text-sky-600"}`}>SSA Calls</th>}
+                    {showCol("clientcalls") && <th className={`${thBase} text-right ${dark ? "text-indigo-400" : "text-indigo-600"}`}>Client Calls</th>}
                     {showCol("faxsent")     && <th className={`${thBase} ${t.textSub} text-right`}>Fax Sent</th>}
                     {showCol("winsheets")   && <th className={`${thBase} ${t.textSub} text-right`}>Win Sheets</th>}
                   </tr>
@@ -842,8 +842,8 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                           {a.totalCollected > 0 ? fmt(a.totalCollected) : "—"}
                         </td>
                       )}
-                      {showCol("ssacalls")    && <td className={`${tdBase} text-right ${t.textSub} border-l ${t.borderLight}`}>{a.weekSsaCalls}</td>}
-                      {showCol("clientcalls") && <td className={`${tdBase} text-right ${t.textSub}`}>{a.weekClientCalls}</td>}
+                      {showCol("ssacalls")    && <td className={`${tdBase} text-right border-l ${t.borderLight} ${dark ? "text-sky-400" : "text-sky-600"}`}>{a.weekSsaCalls}</td>}
+                      {showCol("clientcalls") && <td className={`${tdBase} text-right ${dark ? "text-indigo-400" : "text-indigo-600"}`}>{a.weekClientCalls}</td>}
                       {showCol("faxsent")     && <td className={`${tdBase} text-right ${t.textSub}`}>{a.weekFaxSent}</td>}
                       {showCol("winsheets")   && <td className={`${tdBase} text-right ${t.text}`}>{a.completedWinSheets}</td>}
                     </tr>
@@ -856,8 +856,8 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                     {showCol("closedcases") && <td className={`${tdBase} text-right font-bold ${t.textSub}`}>{filteredTotals.casesClosed}</td>}
                     {showCol("opennofees")  && <td className={`${tdBase} text-right font-bold ${dark ? "text-amber-400"   : "text-amber-600"}`}>{filteredTotals.openNoFees}</td>}
                     {showCol("collected")   && <td className={`${tdBase} text-right font-bold text-emerald-500`}>{fmt(filteredTotals.totalCollected)}</td>}
-                    {showCol("ssacalls")    && <td className={`${tdBase} text-right font-bold ${t.textSub} border-l ${t.borderLight}`}>{filteredTotals.weekSsaCalls}</td>}
-                    {showCol("clientcalls") && <td className={`${tdBase} text-right font-bold ${t.textSub}`}>{filteredTotals.weekClientCalls}</td>}
+                    {showCol("ssacalls")    && <td className={`${tdBase} text-right font-bold border-l ${t.borderLight} ${dark ? "text-sky-400" : "text-sky-600"}`}>{filteredTotals.weekSsaCalls}</td>}
+                    {showCol("clientcalls") && <td className={`${tdBase} text-right font-bold ${dark ? "text-indigo-400" : "text-indigo-600"}`}>{filteredTotals.weekClientCalls}</td>}
                     {showCol("faxsent")     && <td className={`${tdBase} text-right font-bold ${t.textSub}`}>{filteredTotals.weekFaxSent}</td>}
                     {showCol("winsheets")   && <td className={`${tdBase} text-right font-bold ${t.text}`}>{filteredTotals.completedWinSheets}</td>}
                   </tr>


### PR DESCRIPTION
## Summary
- Add minimize/expand toggle for T16, T2, AUX column groups on Master Fees (PR #209), including a fix keeping the payment-history panel mounted so in-progress drafts survive a minimize/expand cycle
- Move the Refresh button into a frozen column before Case Name, color FEE PETITION APPROVED red in Remarks, color SSA/Client Calls on Reports, and remove the NOA checklist item from Fee Petitions (PR #210)