### PR TITLE
Default-sort Fees Closed by Closed On, Master Fees by date added

### DIFF
--- a/src/app/api/cases/route.ts
+++ b/src/app/api/cases/route.ts
@@ -62,6 +62,7 @@ export const GET = async (req: NextRequest) => {
         t16Decision: cases.t16Decision,
         approvalDate: cases.approvalDate,
         officeWithJurisdiction: cases.officeWithJurisdiction,
+        createdAt: cases.createdAt,
 
         // Fee record fields
         assignedTo: feeRecords.assignedTo,
@@ -216,6 +217,7 @@ export const GET = async (req: NextRequest) => {
         claim: r.claimTypeLabel === "T2_T16" || r.claimTypeLabel === "CONCURRENT" ? "CONC" : r.claimTypeLabel || "—",
         date: r.approvalDate || null,
         status: r.winSheetStatus || "not_started",
+        createdAt: r.createdAt.toISOString(),
 
         // T16
         t16Retro: Number(r.t16Retro) || 0,

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -212,7 +212,8 @@ type SortKey =
   | "expected"
   | "paid"
   | "daysAfterApproval"
-  | "closedAt";
+  | "closedAt"
+  | "createdAt";
 type SortDir = "asc" | "desc";
 
 export const FeeRecordsTable = ({
@@ -297,7 +298,9 @@ export const FeeRecordsTable = ({
       return next;
     });
   };
-  const [sortKey, setSortKey] = useState<SortKey>("date");
+  // Fees Closed defaults to most-recently-closed on top; Master Fees
+  // defaults to most-recently-added on top (both requested by Ms. Jazz).
+  const [sortKey, setSortKey] = useState<SortKey>(mode === "closed" ? "closedAt" : "createdAt");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
   // Client-side pagination over the filtered+sorted set. Page size is
   // user-selectable; "all" renders the whole filtered set on one page.
@@ -536,6 +539,10 @@ export const FeeRecordsTable = ({
         case "closedAt":
           av = a.closedAt || "";
           bv = b.closedAt || "";
+          break;
+        case "createdAt":
+          av = a.createdAt || "";
+          bv = b.createdAt || "";
           break;
       }
       if (av < bv) return sortDir === "asc" ? -1 : 1;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -37,6 +37,9 @@ export interface CaseRow {
   claim: string;
   date: string | null;
   status: WinSheetStatus;
+  // When the case itself was first added to the dashboard — powers Master
+  // Fees' "most recently added on top" default sort.
+  createdAt: string;
 
   // T16 section
   t16Retro: number;


### PR DESCRIPTION
## Summary
- Ms. Jazz: "Can we have the Fees Closed automatically in order based on the Closed On date and the top should be the most recent ones?" and "As well as the Master Fees page where the most recent added ones could be on top"
- Fees Closed now defaults to sorting by Closed On, most recent first — reuses the existing `closedAt` sort key, just changes the default.
- Master Fees now defaults to most-recently-added on top. Added a `createdAt` field end-to-end (schema column already existed, just never selected by `/api/cases` before) since nothing else represented "date added."
- Both pages stay fully re-sortable by clicking any other column header, exactly as before — only the default on page load changed.

## Test plan
- [x] `npx tsc --noEmit`, `npm run lint`, `npm test`, `npm run build` — all clean
- [x] Live-verified against the database: Master Fees' top rows match `cases.created_at` descending exactly; Fees Closed's top rows match `fee_records.closed_at` descending exactly