### PR TITLE
Close authorization gaps on several API routes

### DIFF
--- a/src/app/api/chronicle/import/route.ts
+++ b/src/app/api/chronicle/import/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { sql } from "drizzle-orm";
+import { requirePageAccess, guardStatus } from "@/lib/auth-helpers";
 
 interface ImportCase {
   chronicleClientId: number;
@@ -52,6 +53,14 @@ interface PdfFields {
 // POST /api/chronicle/import — Import selected cases into DB with optional PDF-extracted fields
 export const POST = async (req: NextRequest) => {
   try {
+    const guard = await requirePageAccess("chronicle");
+    if (!guard.ok) {
+      return NextResponse.json(
+        { error: guard.error },
+        { status: guardStatus(guard.error) },
+      );
+    }
+
     const body = await req.json();
     const importCases: ImportCase[] = body.cases;
     const pdfFields: PdfFields | null = body.pdfFields || null;

--- a/src/app/api/chronicle/pdf-parse/route.ts
+++ b/src/app/api/chronicle/pdf-parse/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { parseChronicleAllFile } from "@/lib/chronicle-pdf-parser";
+import { requirePageAccess, guardStatus } from "@/lib/auth-helpers";
 
 // pdf-parse v1 tries to load a test PDF on require() — import from lib directly to avoid this
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -9,6 +10,14 @@ export const maxDuration = 60;
 
 export async function POST(request: NextRequest) {
   try {
+    const guard = await requirePageAccess("chronicle");
+    if (!guard.ok) {
+      return NextResponse.json(
+        { error: guard.error },
+        { status: guardStatus(guard.error) },
+      );
+    }
+
     const body = await request.json();
     const { allFileLink } = body;
 

--- a/src/app/api/chronicle/pull/route.ts
+++ b/src/app/api/chronicle/pull/route.ts
@@ -6,6 +6,7 @@ import {
   parseChronicleResponse,
   type ChronicleApiResponse,
 } from "@/lib/chronicle-client";
+import { requirePageAccess, guardStatus } from "@/lib/auth-helpers";
 
 // ============================================================================
 // MOCK DATA — 4 sample clients for development
@@ -233,6 +234,14 @@ const MOCK: Record<string, ChronicleApiResponse> = {
 
 export const POST = async (req: NextRequest) => {
   try {
+    const guard = await requirePageAccess("chronicle");
+    if (!guard.ok) {
+      return NextResponse.json(
+        { error: guard.error },
+        { status: guardStatus(guard.error) },
+      );
+    }
+
     const { clientId } = await req.json();
     if (!clientId) {
       return NextResponse.json(

--- a/src/app/api/fee-petitions/route.ts
+++ b/src/app/api/fee-petitions/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { cases, feePetitions, feeRecords } from "@/lib/db/schema";
 import { eq, ilike, sql } from "drizzle-orm";
+import { requirePageAccess, guardStatus } from "@/lib/auth-helpers";
 
 const SORT_KEYS = ["claimant", "approvalDate", "updatedAt", "progress"] as const;
 type SortKey = (typeof SORT_KEYS)[number];
@@ -47,6 +48,14 @@ const getMissingClause = (key: string | null) => {
 // Lists cases at FEE_PETITION level with checklist state and aggregate stats
 export const GET = async (req: NextRequest) => {
   try {
+    const guard = await requirePageAccess("fee_petitions");
+    if (!guard.ok) {
+      return NextResponse.json(
+        { error: guard.error },
+        { status: guardStatus(guard.error) },
+      );
+    }
+
     const { searchParams } = new URL(req.url);
     const search = searchParams.get("search");
     const status = searchParams.get("status"); // "complete" | "incomplete"

--- a/src/app/api/import/cases/route.ts
+++ b/src/app/api/import/cases/route.ts
@@ -4,6 +4,7 @@ import { sql, inArray } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { cases, feeRecords, activityLog } from "@/lib/db/schema";
 import { parseWorksheet, type ParsedCaseRow } from "@/lib/import/xlsx-mapper";
+import { requireAdmin } from "@/lib/auth-helpers";
 
 export const runtime = "nodejs";
 export const maxDuration = 60;
@@ -69,6 +70,14 @@ const toFeeInsert = (r: ParsedCaseRow) => ({
 //     mode=replace  → TRUNCATE cases then insert everything (subject to selectedClientIds filter)
 export const POST = async (req: NextRequest) => {
   try {
+    const guard = await requireAdmin();
+    if (!guard.ok) {
+      return NextResponse.json(
+        { error: guard.error },
+        { status: guard.error === "Unauthenticated" ? 401 : 403 },
+      );
+    }
+
     const { searchParams } = new URL(req.url);
     const mode = (searchParams.get("mode") ?? "preview") as
       | "preview"

--- a/src/app/api/overpaid-cases/route.ts
+++ b/src/app/api/overpaid-cases/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { cases, feeRecords, overpaidCases } from "@/lib/db/schema";
 import { eq, ilike, sql } from "drizzle-orm";
+import { requirePageAccess, guardStatus } from "@/lib/auth-helpers";
 
 const SORT_KEYS = ["claimant", "feesReceived", "overpaidAmount", "opLtrDate", "assignedTo"] as const;
 type SortKey = (typeof SORT_KEYS)[number];
@@ -10,6 +11,14 @@ type SortKey = (typeof SORT_KEYS)[number];
 // Returns cases where total_fees_paid > total_fees_expected
 export const GET = async (req: NextRequest) => {
   try {
+    const guard = await requirePageAccess("overpaid_cases");
+    if (!guard.ok) {
+      return NextResponse.json(
+        { error: guard.error },
+        { status: guardStatus(guard.error) },
+      );
+    }
+
     const { searchParams } = new URL(req.url);
     const search = searchParams.get("search");
     const status = searchParams.get("status");

--- a/src/app/api/scoreboard/route.ts
+++ b/src/app/api/scoreboard/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { sql } from "drizzle-orm";
+import { requirePageAccess, guardStatus } from "@/lib/auth-helpers";
 
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 // Add days to a YYYY-MM-DD (UTC math, returns YYYY-MM-DD) — used for the
@@ -18,6 +19,14 @@ const addDays = (iso: string, days: number): string => {
 // metrics are current-state snapshots and ignore the window.
 export const GET = async (req: NextRequest) => {
   try {
+    const guard = await requirePageAccess("scoreboard");
+    if (!guard.ok) {
+      return NextResponse.json(
+        { error: guard.error },
+        { status: guardStatus(guard.error) },
+      );
+    }
+
     const { searchParams } = new URL(req.url);
     const weekParam = searchParams.get("week");
     const fromParam = searchParams.get("from");

--- a/src/app/api/settings/connections/route.ts
+++ b/src/app/api/settings/connections/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/auth-helpers";
 
 interface ConnectionStatus {
   service: string;
@@ -12,6 +13,14 @@ interface ConnectionStatus {
 // GET /api/settings/connections?test=true
 export const GET = async (req: NextRequest) => {
   try {
+    const guard = await requireAdmin();
+    if (!guard.ok) {
+      return NextResponse.json(
+        { error: guard.error },
+        { status: guard.error === "Unauthenticated" ? 401 : 403 },
+      );
+    }
+
     const shouldTest = new URL(req.url).searchParams.get("test") === "true";
     const connections: ConnectionStatus[] = [];
 

--- a/src/app/api/settings/dropdown-options/[id]/route.ts
+++ b/src/app/api/settings/dropdown-options/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { dropdownOptions } from "@/lib/db/schema";
+import { requireAdmin } from "@/lib/auth-helpers";
 
 const resolveId = async (context: {
   params: { id: string } | Promise<{ id: string }>;
@@ -26,6 +27,14 @@ export const PATCH = async (
   context: { params: { id: string } | Promise<{ id: string }> },
 ) => {
   try {
+    const guard = await requireAdmin();
+    if (!guard.ok) {
+      return NextResponse.json(
+        { error: guard.error },
+        { status: guard.error === "Unauthenticated" ? 401 : 403 },
+      );
+    }
+
     const id = await resolveId(context);
     if (!Number.isFinite(id)) {
       return NextResponse.json({ error: "Invalid id" }, { status: 400 });
@@ -85,6 +94,14 @@ export const DELETE = async (
   context: { params: { id: string } | Promise<{ id: string }> },
 ) => {
   try {
+    const guard = await requireAdmin();
+    if (!guard.ok) {
+      return NextResponse.json(
+        { error: guard.error },
+        { status: guard.error === "Unauthenticated" ? 401 : 403 },
+      );
+    }
+
     const id = await resolveId(context);
     if (!Number.isFinite(id)) {
       return NextResponse.json({ error: "Invalid id" }, { status: 400 });

--- a/src/app/api/settings/dropdown-options/route.ts
+++ b/src/app/api/settings/dropdown-options/route.ts
@@ -3,6 +3,7 @@ import { and, eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { dropdownOptions } from "@/lib/db/schema";
 import { isDropdownCategory } from "@/lib/dropdown-categories";
+import { requireAdmin } from "@/lib/auth-helpers";
 
 // GET /api/settings/dropdown-options?category=<key>
 // Returns rows ordered by (sortOrder, name). When no category is provided,
@@ -41,6 +42,14 @@ export const GET = async (req: NextRequest) => {
 // POST /api/settings/dropdown-options — create a new option within a category.
 export const POST = async (req: NextRequest) => {
   try {
+    const guard = await requireAdmin();
+    if (!guard.ok) {
+      return NextResponse.json(
+        { error: guard.error },
+        { status: guard.error === "Unauthenticated" ? 401 : 403 },
+      );
+    }
+
     const body = await req.json().catch(() => ({}));
     const category = String(body?.category ?? "").trim();
     const name = String(body?.name ?? "").trim();

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { appSettings, feeCapHistory } from "@/lib/db/schema";
 import { eq, sql, desc } from "drizzle-orm";
+import { requireAdmin } from "@/lib/auth-helpers";
 
 // ============================================================================
 // GET /api/settings
@@ -9,6 +10,14 @@ import { eq, sql, desc } from "drizzle-orm";
 // ============================================================================
 export const GET = async () => {
   try {
+    const guard = await requireAdmin();
+    if (!guard.ok) {
+      return NextResponse.json(
+        { error: guard.error },
+        { status: guard.error === "Unauthenticated" ? 401 : 403 },
+      );
+    }
+
     const settings = await db
       .select()
       .from(appSettings)
@@ -56,6 +65,14 @@ export const GET = async () => {
 // ============================================================================
 export const PATCH = async (req: NextRequest) => {
   try {
+    const guard = await requireAdmin();
+    if (!guard.ok) {
+      return NextResponse.json(
+        { error: guard.error },
+        { status: guard.error === "Unauthenticated" ? 401 : 403 },
+      );
+    }
+
     const body = await req.json();
 
     // Update settings

--- a/src/app/api/team-members/route.ts
+++ b/src/app/api/team-members/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { teamMembers, feeRecords } from "@/lib/db/schema";
 import { eq, sql, count, sum, and } from "drizzle-orm";
+import { requirePageAccess, guardStatus } from "@/lib/auth-helpers";
 
 // GET /api/team-members — list all team members with case stats
 export const GET = async () => {
@@ -61,6 +62,14 @@ export const GET = async () => {
 // POST /api/team-members — create new team member
 export const POST = async (req: NextRequest) => {
   try {
+    const guard = await requirePageAccess("team");
+    if (!guard.ok) {
+      return NextResponse.json(
+        { error: guard.error },
+        { status: guardStatus(guard.error) },
+      );
+    }
+
     const body = await req.json();
     const { name, role, team } = body;
 
@@ -104,6 +113,14 @@ export const POST = async (req: NextRequest) => {
 // PATCH /api/team-members — update team member
 export const PATCH = async (req: NextRequest) => {
   try {
+    const guard = await requirePageAccess("team");
+    if (!guard.ok) {
+      return NextResponse.json(
+        { error: guard.error },
+        { status: guardStatus(guard.error) },
+      );
+    }
+
     const body = await req.json();
     const { id, name, role, team, isActive } = body;
 
@@ -195,6 +212,14 @@ export const PATCH = async (req: NextRequest) => {
 // DELETE /api/team-members?id=X — soft-delete (deactivate)
 export const DELETE = async (req: NextRequest) => {
   try {
+    const guard = await requirePageAccess("team");
+    if (!guard.ok) {
+      return NextResponse.json(
+        { error: guard.error },
+        { status: guardStatus(guard.error) },
+      );
+    }
+
     const { searchParams } = new URL(req.url);
     const id = Number(searchParams.get("id"));
 

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -1122,12 +1122,14 @@ export const FeeRecordsTable = ({
               <Plus className="h-3.5 w-3.5" aria-hidden="true" /> Add Case
             </button>
           )}
-          <button
-            onClick={() => setImportOpen(true)}
-            className={`h-8 px-3 rounded-md text-xs font-semibold flex items-center gap-1.5 ${t.outlineBtn}`}
-          >
-            <Upload className="h-3.5 w-3.5" aria-hidden="true" /> Import
-          </button>
+          {isAdmin && (
+            <button
+              onClick={() => setImportOpen(true)}
+              className={`h-8 px-3 rounded-md text-xs font-semibold flex items-center gap-1.5 ${t.outlineBtn}`}
+            >
+              <Upload className="h-3.5 w-3.5" aria-hidden="true" /> Import
+            </button>
+          )}
         </div>
       </div>
 

--- a/src/components/team/TeamManagement.tsx
+++ b/src/components/team/TeamManagement.tsx
@@ -92,6 +92,7 @@ export const TeamManagement = () => {
     null,
   );
   const [deactivating, setDeactivating] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
 
   /* ---- Fetch ---- */
   const fetchMembers = useCallback(async () => {
@@ -204,26 +205,40 @@ export const TeamManagement = () => {
       return;
     }
     // Reactivate directly
+    setActionError(null);
     try {
-      await fetch("/api/team-members", {
+      const res = await fetch("/api/team-members", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ id: m.id, isActive: true }),
       });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? `Failed to reactivate (${res.status})`);
+      }
       await fetchMembers();
-    } catch {}
+    } catch (err) {
+      setActionError((err as Error).message);
+    }
   };
 
   const confirmDeactivate = async () => {
     if (!confirmMember) return;
     setDeactivating(true);
+    setActionError(null);
     try {
-      await fetch(`/api/team-members?id=${confirmMember.id}`, {
+      const res = await fetch(`/api/team-members?id=${confirmMember.id}`, {
         method: "DELETE",
       });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? `Failed to deactivate (${res.status})`);
+      }
       setConfirmMember(null);
       await fetchMembers();
-    } catch {}
+    } catch (err) {
+      setActionError((err as Error).message);
+    }
     setDeactivating(false);
   };
 
@@ -278,6 +293,16 @@ export const TeamManagement = () => {
           Add Member
         </button>
       </div>
+
+      {actionError && (
+        <div
+          role="alert"
+          className={`rounded-xl border p-3 flex items-center gap-2 text-sm ${dark ? "bg-red-900/20 border-red-800 text-red-400" : "bg-red-50 border-red-200 text-red-700"}`}
+        >
+          <AlertCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
+          {actionError}
+        </div>
+      )}
 
       {/* ---- Stat Cards ---- */}
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">

--- a/src/lib/access/__tests__/resolve.test.ts
+++ b/src/lib/access/__tests__/resolve.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { hasPageAccess, effectivePagesForSession } from "../resolve";
+
+describe("hasPageAccess", () => {
+  it("checks membership and tolerates null/undefined", () => {
+    expect(hasPageAccess(["scoreboard"], "scoreboard")).toBe(true);
+    expect(hasPageAccess(["scoreboard"], "settings")).toBe(false);
+    expect(hasPageAccess(null, "scoreboard")).toBe(false);
+    expect(hasPageAccess(undefined, "scoreboard")).toBe(false);
+  });
+});
+
+describe("effectivePagesForSession", () => {
+  it("uses the session's own pages when present", () => {
+    expect(effectivePagesForSession(["scoreboard", "team"], "member")).toEqual([
+      "scoreboard",
+      "team",
+    ]);
+  });
+
+  it("falls back to the role's defaults for a stale token with no pages", () => {
+    expect(effectivePagesForSession(undefined, "member")).toContain("scoreboard");
+    expect(effectivePagesForSession(undefined, "member")).not.toContain("settings");
+    expect(effectivePagesForSession([], "admin")).toContain("settings");
+  });
+
+  it("falls back to member defaults for an unknown/missing role", () => {
+    expect(effectivePagesForSession(undefined, undefined)).toEqual(
+      effectivePagesForSession(undefined, "member"),
+    );
+  });
+});

--- a/src/lib/access/resolve.ts
+++ b/src/lib/access/resolve.ts
@@ -41,6 +41,17 @@ export const hasPageAccess = (
   key: PageKey,
 ): boolean => (pages ?? []).includes(key);
 
+/**
+ * The pages array to check against for a guard, given a session's baked-in
+ * `pages` (possibly empty/missing on a token minted before per-page access
+ * existed) and the user's role. Falls back to the role's defaults for a
+ * stale token, mirroring `sessionHasCapability`'s identical handling.
+ */
+export const effectivePagesForSession = (
+  pages: readonly PageKey[] | null | undefined,
+  role: string | null | undefined,
+): PageKey[] => (pages && pages.length > 0 ? [...pages] : rolePageDefaults(role));
+
 /** Effective set of capabilities a user has: role default ⊕ overrides. */
 export const effectiveCapabilities = (
   role: string | null | undefined,

--- a/src/lib/auth-helpers.ts
+++ b/src/lib/auth-helpers.ts
@@ -3,7 +3,9 @@ import { auth } from "@/auth";
 import type { Session } from "next-auth";
 import type { CapabilityKey } from "@/lib/access/capabilities";
 import { roleCapabilityDefaults } from "@/lib/access/capabilities";
-import { hasCapability } from "@/lib/access/resolve";
+import type { PageKey } from "@/lib/access/pages";
+import { rolePageDefaults } from "@/lib/access/role-defaults";
+import { hasCapability, hasPageAccess } from "@/lib/access/resolve";
 
 type AdminRole = "admin" | "system_admin";
 
@@ -72,6 +74,34 @@ export async function requireCapability(
   const session = await auth();
   if (!session?.user) return { ok: false, error: "Unauthenticated" };
   if (!sessionHasCapability(session, capability)) {
+    return { ok: false, error: "Forbidden" };
+  }
+  return { ok: true, session };
+}
+
+export type PageAccessGuard =
+  | { ok: true; session: Session }
+  | { ok: false; error: "Unauthenticated" | "Forbidden" };
+
+/**
+ * Server-side guard mirroring the page a route's data actually belongs to
+ * (e.g. an /api/scoreboard route guarded by the "scoreboard" page). Several
+ * routes only enforced "is logged in" via the edge middleware and nothing
+ * else — this closes that gap by reusing the same effective-pages logic the
+ * middleware and sidebar already use, so a route's access always matches
+ * what the UI shows. Tokens minted before per-page access existed have no
+ * `pages` array — fall back to the role's defaults for those, matching
+ * `sessionHasCapability`'s identical stale-token handling.
+ */
+export async function requirePageAccess(
+  pageKey: PageKey,
+): Promise<PageAccessGuard> {
+  const session = await auth();
+  if (!session?.user) return { ok: false, error: "Unauthenticated" };
+  const pages = session.user.pages;
+  const effectivePages =
+    pages && pages.length > 0 ? pages : rolePageDefaults(session.user.role);
+  if (!hasPageAccess(effectivePages, pageKey)) {
     return { ok: false, error: "Forbidden" };
   }
   return { ok: true, session };

--- a/src/lib/auth-helpers.ts
+++ b/src/lib/auth-helpers.ts
@@ -4,8 +4,7 @@ import type { Session } from "next-auth";
 import type { CapabilityKey } from "@/lib/access/capabilities";
 import { roleCapabilityDefaults } from "@/lib/access/capabilities";
 import type { PageKey } from "@/lib/access/pages";
-import { rolePageDefaults } from "@/lib/access/role-defaults";
-import { hasCapability, hasPageAccess } from "@/lib/access/resolve";
+import { hasCapability, hasPageAccess, effectivePagesForSession } from "@/lib/access/resolve";
 
 type AdminRole = "admin" | "system_admin";
 
@@ -84,24 +83,38 @@ export type PageAccessGuard =
   | { ok: false; error: "Unauthenticated" | "Forbidden" };
 
 /**
+ * True iff an already-fetched session has access to the given page. Mirrors
+ * `sessionHasCapability`'s identical stale-token fallback: tokens minted
+ * before per-page access existed have no `pages` array — fall back to the
+ * role's defaults for those so existing sessions behave correctly until next
+ * login.
+ */
+export const sessionHasPageAccess = (
+  session: Session | null | undefined,
+  pageKey: PageKey,
+): boolean => {
+  if (!session?.user) return false;
+  const effectivePages = effectivePagesForSession(
+    session.user.pages,
+    session.user.role,
+  );
+  return hasPageAccess(effectivePages, pageKey);
+};
+
+/**
  * Server-side guard mirroring the page a route's data actually belongs to
  * (e.g. an /api/scoreboard route guarded by the "scoreboard" page). Several
  * routes only enforced "is logged in" via the edge middleware and nothing
  * else — this closes that gap by reusing the same effective-pages logic the
  * middleware and sidebar already use, so a route's access always matches
- * what the UI shows. Tokens minted before per-page access existed have no
- * `pages` array — fall back to the role's defaults for those, matching
- * `sessionHasCapability`'s identical stale-token handling.
+ * what the UI shows.
  */
 export async function requirePageAccess(
   pageKey: PageKey,
 ): Promise<PageAccessGuard> {
   const session = await auth();
   if (!session?.user) return { ok: false, error: "Unauthenticated" };
-  const pages = session.user.pages;
-  const effectivePages =
-    pages && pages.length > 0 ? pages : rolePageDefaults(session.user.role);
-  if (!hasPageAccess(effectivePages, pageKey)) {
+  if (!sessionHasPageAccess(session, pageKey)) {
     return { ok: false, error: "Forbidden" };
   }
   return { ok: true, session };


### PR DESCRIPTION
## Summary
- `fee-petitions`, `overpaid-cases`, `scoreboard`: added a new `requirePageAccess()` helper (mirrors the existing per-page access system, including per-user overrides) so these routes enforce the same access as the pages they back, instead of relying solely on the edge middleware's "is logged in" check.
- `team-members` and `chronicle/*` mutations: gated to their respective pages (`team`, `chronicle`) via `requirePageAccess` — lead and above.
- `settings`, `settings/connections`, `settings/dropdown-options` mutations, and `import/cases` (including its destructive `mode=replace`, which truncates the `cases` table): gated to `requireAdmin()`.
- GET endpoints used broadly for dropdown population (`team-members`, `dropdown-options`) intentionally stay open — restricting those would break normal usage across Master Fees, Case Detail, etc.
- Hid the Master Fees "Import" button (can trigger `mode=replace`) from non-admins — it previously had no role gate in the UI at all.

## Test plan
- Verified live across member/lead/admin test accounts: correct 200/403 on every affected route, all pages render without errors, Import button visibility matches role.