### PR TITLE
Eliminate SQL injection in chronicle/import, fix decision-outcome bug

### DIFF
--- a/src/app/api/chronicle/import/route.ts
+++ b/src/app/api/chronicle/import/route.ts
@@ -1,54 +1,76 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { db } from "@/lib/db";
-import { sql } from "drizzle-orm";
+import { cases, feeRecords, activityLog } from "@/lib/db/schema";
 import { requirePageAccess, guardStatus } from "@/lib/auth-helpers";
+import {
+  resolveDecisionOutcome,
+  resolveLevelWon,
+  buildClaimTypeArray,
+  countPdfFields,
+} from "@/lib/import/chronicle-import-mapper";
 
-interface ImportCase {
-  chronicleClientId: number;
-  firstName: string;
-  lastName: string;
-  last4Ssn: string;
-  claimType: "T2" | "T16" | "T2_T16";
-  officeWithJurisdiction: string;
-  caseLevel: string;
-  statusDate: string | null;
-  t2Decision: string | null;
-  t16Decision: string | null;
-  feeAgreement: boolean;
-  feePetition: boolean;
-  reportType: string;
-  favorableTypes: string[];
-}
+const pdfFieldsSchema = z.object({
+  fullSsn: z.string().nullable().optional(),
+  dob: z.string().nullable().optional(),
+  email: z.string().nullable().optional(),
+  phone: z.string().nullable().optional(),
+  primaryDiagnosis: z.string().nullable().optional(),
+  primaryDiagnosisCode: z.string().nullable().optional(),
+  secondaryDiagnosis: z.string().nullable().optional(),
+  secondaryDiagnosisCode: z.string().nullable().optional(),
+  allegations: z.string().nullable().optional(),
+  dateLastInsured: z.string().nullable().optional(),
+  blindDli: z.string().nullable().optional(),
+  feeMethod: z.enum(["fee_agreement", "fee_petition"]).nullable().optional(),
+  feeCapAtSigning: z.number().nullable().optional(),
+  // Selectable in the UI, but there is no fee_records.fee_agreement_date
+  // column — accepted and validated, never written (see the POST handler).
+  feeAgreementDate: z.string().nullable().optional(),
+  firmName: z.string().nullable().optional(),
+  firmEin: z.string().nullable().optional(),
+  hearingOffice: z.string().nullable().optional(),
+  representatives: z
+    .array(z.object({ name: z.string(), repId: z.string().nullable() }))
+    .nullable()
+    .optional(),
+  decisionHistory: z
+    .array(
+      z.object({
+        level: z.string(),
+        claimType: z.string(),
+        result: z.string(),
+        date: z.string().nullable(),
+      }),
+    )
+    .nullable()
+    .optional(),
+});
 
-// PDF fields the user can select for import
-interface PdfFields {
-  fullSsn?: string | null;
-  dob?: string | null;
-  email?: string | null;
-  phone?: string | null;
-  primaryDiagnosis?: string | null;
-  primaryDiagnosisCode?: string | null;
-  secondaryDiagnosis?: string | null;
-  secondaryDiagnosisCode?: string | null;
-  allegations?: string | null;
-  dateLastInsured?: string | null;
-  blindDli?: string | null;
-  feeMethod?: "fee_agreement" | "fee_petition" | null;
-  feeCapAtSigning?: number | null;
-  feeAgreementDate?: string | null;
-  firmName?: string | null;
-  firmEin?: string | null;
-  hearingOffice?: string | null;
-  representatives?: { name: string; repId: string | null }[] | null;
-  decisionHistory?:
-    | {
-        level: string;
-        claimType: string;
-        result: string;
-        date: string | null;
-      }[]
-    | null;
-}
+const importCaseSchema = z.object({
+  chronicleClientId: z.number().int().positive(),
+  firstName: z.string().min(1),
+  lastName: z.string().min(1),
+  last4Ssn: z.string(),
+  claimType: z.enum(["T2", "T16", "T2_T16"]),
+  officeWithJurisdiction: z.string(),
+  caseLevel: z.string(),
+  statusDate: z.string().nullable(),
+  t2Decision: z.string().nullable(),
+  t16Decision: z.string().nullable(),
+  // The client never actually sets this — kept optional rather than required
+  // to match the real request shape instead of an aspirational one.
+  feePetition: z.boolean().optional(),
+  reportType: z.string(),
+  favorableTypes: z.array(z.string()),
+});
+
+const bodySchema = z.object({
+  cases: z.array(importCaseSchema).min(1),
+  pdfFields: pdfFieldsSchema.nullable().optional(),
+});
+
+type PdfFields = z.infer<typeof pdfFieldsSchema>;
 
 // POST /api/chronicle/import — Import selected cases into DB with optional PDF-extracted fields
 export const POST = async (req: NextRequest) => {
@@ -61,16 +83,16 @@ export const POST = async (req: NextRequest) => {
       );
     }
 
-    const body = await req.json();
-    const importCases: ImportCase[] = body.cases;
-    const pdfFields: PdfFields | null = body.pdfFields || null;
-
-    if (!importCases || importCases.length === 0) {
+    const rawBody = await req.json().catch(() => null);
+    const parsedBody = bodySchema.safeParse(rawBody);
+    if (!parsedBody.success) {
       return NextResponse.json(
-        { error: "No cases to import" },
+        { error: "Invalid request body", issues: parsedBody.error.issues },
         { status: 400 },
       );
     }
+    const importCases = parsedBody.data.cases;
+    const pdfFields: PdfFields | null = parsedBody.data.pdfFields ?? null;
 
     const imported: { clientId: number; name: string }[] = [];
     const errors: { name: string; error: string }[] = [];
@@ -79,215 +101,85 @@ export const POST = async (req: NextRequest) => {
       try {
         const clientId = c.chronicleClientId;
 
-        const t2Dec = c.t2Decision?.toLowerCase().includes("favorable")
-          ? "fully_favorable"
-          : c.t2Decision?.toLowerCase().includes("unfavorable")
-            ? "unfavorable"
-            : c.t2Decision?.toLowerCase().includes("dismissal")
-              ? "dismissed"
-              : c.t2Decision
-                ? "unknown"
-                : null;
+        const t2Dec = resolveDecisionOutcome(c.t2Decision);
+        const t16Dec = resolveDecisionOutcome(c.t16Decision);
+        const levelWon = resolveLevelWon(c.caseLevel);
+        const claimTypeArray = buildClaimTypeArray(c.claimType);
 
-        const t16Dec = c.t16Decision?.toLowerCase().includes("favorable")
-          ? "fully_favorable"
-          : c.t16Decision?.toLowerCase().includes("unfavorable")
-            ? "unfavorable"
-            : c.t16Decision?.toLowerCase().includes("dismissal")
-              ? "dismissed"
-              : c.t16Decision
-                ? "unknown"
-                : null;
-
-        const levelWon = ["INITIAL", "RECON", "HEARING", "AC"].includes(
-          c.caseLevel,
-        )
-          ? c.caseLevel
-          : "HEARING";
-
-        // Build the INSERT with base fields + any selected PDF fields
-        const columns = [
-          "client_id",
-          "first_name",
-          "last_name",
-          "last4_ssn",
-          "claim_type",
-          "claim_type_label",
-          "level_won",
-          "t2_decision",
-          "t16_decision",
-          "approval_date",
-          "office_with_jurisdiction",
-        ];
-        const values: (string | number | null | string[])[] = [
+        const caseInsert: typeof cases.$inferInsert = {
           clientId,
-          c.firstName,
-          c.lastName,
-          c.last4Ssn.replace(/\D/g, "").slice(-4),
-          c.claimType === "T2_T16"
-            ? ["T2", "T16"]
-            : c.claimType === "T16"
-              ? ["T16"]
-              : ["T2"],
-          c.claimType,
+          firstName: c.firstName,
+          lastName: c.lastName,
+          last4Ssn: c.last4Ssn.replace(/\D/g, "").slice(-4),
+          claimType: claimTypeArray,
+          claimTypeLabel: c.claimType,
           levelWon,
-          t2Dec,
-          t16Dec,
-          c.statusDate || null,
-          c.officeWithJurisdiction,
-        ];
+          t2Decision: t2Dec,
+          t16Decision: t16Dec,
+          approvalDate: c.statusDate || null,
+          officeWithJurisdiction: c.officeWithJurisdiction,
+        };
 
-        // Append selected PDF fields
         if (pdfFields) {
-          if (pdfFields.fullSsn !== undefined) {
-            columns.push("full_ssn");
-            values.push(pdfFields.fullSsn);
-          }
-          if (pdfFields.dob !== undefined) {
-            columns.push("dob");
-            values.push(pdfFields.dob);
-          }
-          if (pdfFields.email !== undefined) {
-            columns.push("email");
-            values.push(pdfFields.email);
-          }
-          if (pdfFields.phone !== undefined) {
-            columns.push("phone");
-            values.push(pdfFields.phone);
-          }
-          if (pdfFields.primaryDiagnosis !== undefined) {
-            columns.push("primary_diagnosis");
-            values.push(pdfFields.primaryDiagnosis);
-          }
-          if (pdfFields.primaryDiagnosisCode !== undefined) {
-            columns.push("primary_diagnosis_code");
-            values.push(pdfFields.primaryDiagnosisCode);
-          }
-          if (pdfFields.secondaryDiagnosis !== undefined) {
-            columns.push("secondary_diagnosis");
-            values.push(pdfFields.secondaryDiagnosis);
-          }
-          if (pdfFields.secondaryDiagnosisCode !== undefined) {
-            columns.push("secondary_diagnosis_code");
-            values.push(pdfFields.secondaryDiagnosisCode);
-          }
-          if (pdfFields.allegations !== undefined) {
-            columns.push("allegations");
-            values.push(pdfFields.allegations);
-          }
-          if (pdfFields.dateLastInsured !== undefined) {
-            columns.push("last_insured");
-            values.push(pdfFields.dateLastInsured);
-          }
-          if (pdfFields.blindDli !== undefined) {
-            columns.push("blind_dli");
-            values.push(pdfFields.blindDli);
-          }
-          if (pdfFields.firmName !== undefined) {
-            columns.push("firm_name");
-            values.push(pdfFields.firmName);
-          }
-          if (pdfFields.firmEin !== undefined) {
-            columns.push("firm_ein");
-            values.push(pdfFields.firmEin);
-          }
-          if (pdfFields.hearingOffice !== undefined) {
-            columns.push("hearing_office");
-            values.push(pdfFields.hearingOffice);
-          }
+          if (pdfFields.fullSsn !== undefined) caseInsert.fullSsn = pdfFields.fullSsn;
+          if (pdfFields.dob !== undefined) caseInsert.dob = pdfFields.dob;
+          if (pdfFields.email !== undefined) caseInsert.email = pdfFields.email;
+          if (pdfFields.phone !== undefined) caseInsert.phone = pdfFields.phone;
+          if (pdfFields.primaryDiagnosis !== undefined)
+            caseInsert.primaryDiagnosis = pdfFields.primaryDiagnosis;
+          if (pdfFields.primaryDiagnosisCode !== undefined)
+            caseInsert.primaryDiagnosisCode = pdfFields.primaryDiagnosisCode;
+          if (pdfFields.secondaryDiagnosis !== undefined)
+            caseInsert.secondaryDiagnosis = pdfFields.secondaryDiagnosis;
+          if (pdfFields.secondaryDiagnosisCode !== undefined)
+            caseInsert.secondaryDiagnosisCode = pdfFields.secondaryDiagnosisCode;
+          if (pdfFields.allegations !== undefined)
+            caseInsert.allegations = pdfFields.allegations;
+          if (pdfFields.dateLastInsured !== undefined)
+            caseInsert.lastInsured = pdfFields.dateLastInsured;
+          if (pdfFields.blindDli !== undefined) caseInsert.blindDli = pdfFields.blindDli;
+          if (pdfFields.firmName !== undefined) caseInsert.firmName = pdfFields.firmName;
+          if (pdfFields.firmEin !== undefined) caseInsert.firmEin = pdfFields.firmEin;
+          if (pdfFields.hearingOffice !== undefined)
+            caseInsert.hearingOffice = pdfFields.hearingOffice;
+          if (pdfFields.representatives != null)
+            caseInsert.representatives = pdfFields.representatives;
+          if (pdfFields.decisionHistory != null)
+            caseInsert.decisionHistory = pdfFields.decisionHistory;
         }
 
-        // Use parameterized query for the dynamic columns
-        // Build SQL manually with positional params
-        const claimArraySql =
-          c.claimType === "T2_T16"
-            ? `ARRAY['T2','T16']`
-            : c.claimType === "T16"
-              ? `ARRAY['T16']`
-              : `ARRAY['T2']`;
-
-        // For the base insert, use raw SQL with parameters
-        await db.execute(
-          sql.raw(`
-          INSERT INTO cases (${columns.join(", ")})
-          VALUES (
-            ${clientId},
-            '${esc(c.firstName)}',
-            '${esc(c.lastName)}',
-            '${c.last4Ssn.replace(/\D/g, "").slice(-4)}',
-            ${claimArraySql},
-            '${esc(c.claimType)}',
-            '${esc(levelWon)}',
-            ${t2Dec ? `'${esc(t2Dec)}'` : "NULL"},
-            ${t16Dec ? `'${esc(t16Dec)}'` : "NULL"},
-            ${c.statusDate ? `'${esc(c.statusDate)}'` : "NULL"},
-            '${esc(c.officeWithJurisdiction)}'
-            ${pdfFields ? buildPdfValuesSql(pdfFields) : ""}
-          )
-        `),
-        );
-
-        // Create fee record with optional PDF fee fields
         const feeMethod =
-          pdfFields?.feeMethod ||
-          (c.feePetition ? "fee_petition" : "fee_agreement");
+          pdfFields?.feeMethod || (c.feePetition ? "fee_petition" : "fee_agreement");
         const feeCap = pdfFields?.feeCapAtSigning ?? 9200;
-        const feeAgmtDate = pdfFields?.feeAgreementDate || null;
 
-        await db.execute(
-          sql.raw(`
-          INSERT INTO fee_records (case_id, assigned_to, win_sheet_status, fee_method, applicable_fee_cap, fee_agreement_date, fee_computed)
-          VALUES (
-            ${clientId},
-            NULL,
-            'not_started',
-            '${esc(feeMethod)}',
-            ${feeCap},
-            ${feeAgmtDate ? `'${esc(feeAgmtDate)}'` : "NULL"},
-            FALSE
-          )
-        `),
-        );
-
-        // Store representatives and decision history as JSONB if selected
-        if (pdfFields?.representatives) {
-          await db.execute(
-            sql.raw(`
-            UPDATE cases SET representatives = '${esc(JSON.stringify(pdfFields.representatives))}'::jsonb
-            WHERE client_id = ${clientId}
-          `),
-          );
-        }
-        if (pdfFields?.decisionHistory) {
-          await db.execute(
-            sql.raw(`
-            UPDATE cases SET decision_history = '${esc(JSON.stringify(pdfFields.decisionHistory))}'::jsonb
-            WHERE client_id = ${clientId}
-          `),
-          );
-        }
-
-        // Build activity log message
-        const pdfFieldNames = pdfFields
-          ? Object.keys(pdfFields).filter(
-              (k) => (pdfFields as Record<string, unknown>)[k] != null,
-            )
-          : [];
+        const pdfFieldNames = countPdfFields(pdfFields);
         const pdfNote =
           pdfFieldNames.length > 0
             ? ` PDF fields imported: ${pdfFieldNames.length}.`
             : "";
 
-        await db.execute(
-          sql.raw(`
-          INSERT INTO activity_log (case_id, message, created_by)
-          VALUES (
-            ${clientId},
-            'Imported from Chronicle Legal (${esc(c.reportType)}). Favorable: ${esc(c.favorableTypes.join(", "))}.${pdfNote}',
-            'System'
-          )
-        `),
-        );
+        // One transaction per case: the cases/fee_records/activity_log rows
+        // for a single import must land together or not at all, instead of
+        // leaving an orphaned cases row if a later insert in the sequence
+        // fails (as the previous raw-SQL version could).
+        await db.transaction(async (tx) => {
+          await tx.insert(cases).values(caseInsert);
+
+          await tx.insert(feeRecords).values({
+            caseId: clientId,
+            assignedTo: null,
+            winSheetStatus: "not_started",
+            feeMethod,
+            applicableFeeCap: String(feeCap),
+            feeComputed: false,
+          });
+
+          await tx.insert(activityLog).values({
+            caseId: clientId,
+            message: `Imported from Chronicle Legal (${c.reportType}). Favorable: ${c.favorableTypes.join(", ")}.${pdfNote}`,
+            createdBy: "System",
+          });
+        });
 
         imported.push({ clientId, name: `${c.lastName}, ${c.firstName}` });
       } catch (err) {
@@ -312,49 +204,3 @@ export const POST = async (req: NextRequest) => {
     );
   }
 };
-
-// Escape single quotes for raw SQL
-function esc(val: string): string {
-  return val.replace(/'/g, "''");
-}
-
-// Build the PDF values portion of the INSERT SQL
-function buildPdfValuesSql(pf: PdfFields): string {
-  const parts: string[] = [];
-  if (pf.fullSsn !== undefined)
-    parts.push(pf.fullSsn ? `'${esc(pf.fullSsn)}'` : "NULL");
-  if (pf.dob !== undefined) parts.push(pf.dob ? `'${esc(pf.dob)}'` : "NULL");
-  if (pf.email !== undefined)
-    parts.push(pf.email ? `'${esc(pf.email)}'` : "NULL");
-  if (pf.phone !== undefined)
-    parts.push(pf.phone ? `'${esc(pf.phone)}'` : "NULL");
-  if (pf.primaryDiagnosis !== undefined)
-    parts.push(pf.primaryDiagnosis ? `'${esc(pf.primaryDiagnosis)}'` : "NULL");
-  if (pf.primaryDiagnosisCode !== undefined)
-    parts.push(
-      pf.primaryDiagnosisCode ? `'${esc(pf.primaryDiagnosisCode)}'` : "NULL",
-    );
-  if (pf.secondaryDiagnosis !== undefined)
-    parts.push(
-      pf.secondaryDiagnosis ? `'${esc(pf.secondaryDiagnosis)}'` : "NULL",
-    );
-  if (pf.secondaryDiagnosisCode !== undefined)
-    parts.push(
-      pf.secondaryDiagnosisCode
-        ? `'${esc(pf.secondaryDiagnosisCode)}'`
-        : "NULL",
-    );
-  if (pf.allegations !== undefined)
-    parts.push(pf.allegations ? `'${esc(pf.allegations)}'` : "NULL");
-  if (pf.dateLastInsured !== undefined)
-    parts.push(pf.dateLastInsured ? `'${esc(pf.dateLastInsured)}'` : "NULL");
-  if (pf.blindDli !== undefined)
-    parts.push(pf.blindDli ? `'${esc(pf.blindDli)}'` : "NULL");
-  if (pf.firmName !== undefined)
-    parts.push(pf.firmName ? `'${esc(pf.firmName)}'` : "NULL");
-  if (pf.firmEin !== undefined)
-    parts.push(pf.firmEin ? `'${esc(pf.firmEin)}'` : "NULL");
-  if (pf.hearingOffice !== undefined)
-    parts.push(pf.hearingOffice ? `'${esc(pf.hearingOffice)}'` : "NULL");
-  return parts.length > 0 ? ", " + parts.join(", ") : "";
-}

--- a/src/lib/import/__tests__/chronicle-import-mapper.test.ts
+++ b/src/lib/import/__tests__/chronicle-import-mapper.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveDecisionOutcome,
+  resolveLevelWon,
+  buildClaimTypeArray,
+  countPdfFields,
+} from "../chronicle-import-mapper";
+
+describe("resolveDecisionOutcome", () => {
+  it("resolves an unfavorable decision correctly, not as fully favorable", () => {
+    // Regression test: "unfavorable" contains "favorable" as a substring —
+    // checking for "favorable" first would misclassify every unfavorable
+    // decision as fully_favorable.
+    expect(resolveDecisionOutcome("Unfavorable Decision")).toBe("unfavorable");
+    expect(resolveDecisionOutcome("UNFAVORABLE")).toBe("unfavorable");
+  });
+
+  it("resolves a favorable decision", () => {
+    expect(resolveDecisionOutcome("Fully Favorable")).toBe("fully_favorable");
+    expect(resolveDecisionOutcome("Favorable")).toBe("fully_favorable");
+  });
+
+  it("resolves a dismissal", () => {
+    expect(resolveDecisionOutcome("Dismissal")).toBe("dismissed");
+  });
+
+  it("resolves an unrecognized non-empty decision as unknown", () => {
+    expect(resolveDecisionOutcome("Remanded")).toBe("unknown");
+  });
+
+  it("resolves a missing decision as null", () => {
+    expect(resolveDecisionOutcome(null)).toBeNull();
+    expect(resolveDecisionOutcome(undefined)).toBeNull();
+    expect(resolveDecisionOutcome("")).toBeNull();
+  });
+});
+
+describe("resolveLevelWon", () => {
+  it("passes through a known level", () => {
+    expect(resolveLevelWon("INITIAL")).toBe("INITIAL");
+    expect(resolveLevelWon("RECON")).toBe("RECON");
+    expect(resolveLevelWon("HEARING")).toBe("HEARING");
+    expect(resolveLevelWon("AC")).toBe("AC");
+  });
+
+  it("falls back to HEARING for an unknown level", () => {
+    expect(resolveLevelWon("FEDERAL_COURT")).toBe("HEARING");
+    expect(resolveLevelWon("something else")).toBe("HEARING");
+  });
+});
+
+describe("buildClaimTypeArray", () => {
+  it("splits T2_T16 into both types", () => {
+    expect(buildClaimTypeArray("T2_T16")).toEqual(["T2", "T16"]);
+  });
+
+  it("wraps a single claim type", () => {
+    expect(buildClaimTypeArray("T2")).toEqual(["T2"]);
+    expect(buildClaimTypeArray("T16")).toEqual(["T16"]);
+  });
+});
+
+describe("countPdfFields", () => {
+  it("returns an empty array when pdfFields is null/undefined", () => {
+    expect(countPdfFields(null)).toEqual([]);
+    expect(countPdfFields(undefined)).toEqual([]);
+  });
+
+  it("counts only keys with a non-null value", () => {
+    expect(
+      countPdfFields({ fullSsn: "123-45-6789", dob: null, email: "a@b.com" }),
+    ).toEqual(["fullSsn", "email"]);
+  });
+
+  it("excludes keys that are absent entirely, same as excluding null ones", () => {
+    expect(countPdfFields({ fullSsn: "123-45-6789" })).toEqual(["fullSsn"]);
+  });
+});

--- a/src/lib/import/chronicle-import-mapper.ts
+++ b/src/lib/import/chronicle-import-mapper.ts
@@ -1,0 +1,44 @@
+// Pure transform helpers for /api/chronicle/import — split out so the
+// decision/level/claim-type logic is unit-testable without a DB.
+
+export type DecisionOutcome =
+  | "fully_favorable"
+  | "unfavorable"
+  | "dismissed"
+  | "unknown"
+  | null;
+
+// "unfavorable" contains "favorable" as a substring, so it must be checked
+// FIRST — checking "favorable" first would match every "unfavorable" string
+// too and misclassify it as fully favorable.
+export const resolveDecisionOutcome = (
+  decision: string | null | undefined,
+): DecisionOutcome => {
+  const d = decision?.toLowerCase();
+  if (d?.includes("unfavorable")) return "unfavorable";
+  if (d?.includes("favorable")) return "fully_favorable";
+  if (d?.includes("dismissal")) return "dismissed";
+  return decision ? "unknown" : null;
+};
+
+const KNOWN_LEVELS = ["INITIAL", "RECON", "HEARING", "AC"];
+
+// Falls back to "HEARING" for any level this app doesn't have a bucket for
+// (e.g. Chronicle's "FEDERAL_COURT") rather than rejecting the import.
+export const resolveLevelWon = (caseLevel: string): string =>
+  KNOWN_LEVELS.includes(caseLevel) ? caseLevel : "HEARING";
+
+export const buildClaimTypeArray = (
+  claimType: "T2" | "T16" | "T2_T16",
+): string[] => (claimType === "T2_T16" ? ["T2", "T16"] : [claimType]);
+
+// Names of the pdfFields entries that actually carry a value — used only for
+// the "N PDF fields imported" note on the activity log entry.
+export const countPdfFields = (
+  pdfFields: Record<string, unknown> | null | undefined,
+): string[] =>
+  pdfFields
+    ? Object.entries(pdfFields)
+        .filter(([, v]) => v != null)
+        .map(([k]) => k)
+    : [];


### PR DESCRIPTION
## Summary
- Replaced hand-rolled `sql.raw()` + quote-escaping in `chronicle/import/route.ts` with Drizzle's parameterized `.insert()`, and added Zod validation on the request body (previously trusted `body.cases` blindly).
- Wrapped each case's `cases`/`fee_records`/`activity_log` writes in one transaction instead of three separate statements. The `fee_records` insert referenced a `fee_agreement_date` column that doesn't exist anywhere in the schema, so every import was silently leaving an orphaned `cases` row with no fee record. Dropped that column reference and made the writes atomic.
- Extracted the decision/level/claim-type transforms into `src/lib/import/chronicle-import-mapper.ts` with tests. Found and fixed a real bug along the way: `"unfavorable"` contains `"favorable"` as a substring, so the original check order misclassified every unfavorable decision as `fully_favorable`.

## Test plan
- Live-verified against production (cleaned up immediately after each check): a malicious `clientId` is rejected by validation before touching the DB, a SQL-injection-shaped name is safely stored as literal data, a duplicate `clientId` fails atomically with zero orphaned rows across all three tables, and an "Unfavorable Decision" string now correctly stores as `unfavorable`.