### PR TITLE
Show $0.00 amounts instead of collapsing them to a dash

### DIFF
--- a/src/components/cases/FeePaymentPanel.tsx
+++ b/src/components/cases/FeePaymentPanel.tsx
@@ -155,7 +155,7 @@ export function FeePaymentPanel({
           {feeType.toUpperCase()} Payment History
         </span>
         <span className={`text-[13px] font-medium ${t.textSub}`}>
-          Total: {currentTotal > 0 ? fmtFull(currentTotal) : "—"}
+          Total: {fmtFull(currentTotal)}
         </span>
       </div>
 

--- a/src/components/fee-petitions/CompletedPetitions.tsx
+++ b/src/components/fee-petitions/CompletedPetitions.tsx
@@ -476,7 +476,7 @@ export const CompletedPetitions = ({ dark }: Props) => {
                           {row.feeAmount != null ? fmt(row.feeAmount) : "—"}
                         </td>
                         <td className={`${tdBase} w-24 text-right font-medium tabular-nums ${row.feesReceived != null && row.feesReceived > 0 ? (dark ? "text-emerald-400" : "text-emerald-600") : t.textMuted}`}>
-                          {row.feesReceived != null && row.feesReceived > 0 ? fmt(row.feesReceived) : "—"}
+                          {row.feesReceived != null ? fmt(row.feesReceived) : "—"}
                         </td>
                         <td className={`${tdBase} ${t.textMuted}`}>{fmtDate(row.approvalDate)}</td>
                         <td className={`${tdBase} ${t.textMuted}`}>{fmtDate(row.updatedAt)}</td>

--- a/src/components/modals/ImportCasesModal.tsx
+++ b/src/components/modals/ImportCasesModal.tsx
@@ -757,7 +757,7 @@ const PreviewTable = ({
                 )}
               </td>
               <td className={`${t.text} px-3 py-1.5 text-right tabular-nums font-medium`}>
-                {r.totalExpected > 0 ? fmtFull(r.totalExpected) : "—"}
+                {fmtFull(r.totalExpected)}
               </td>
               <td className="px-3 py-1.5 text-center">
                 {r.hasNotes ? (

--- a/src/components/modals/MyCaseSyncModal.tsx
+++ b/src/components/modals/MyCaseSyncModal.tsx
@@ -845,7 +845,7 @@ const SourceRowsTable = ({
                 </span>
               </td>
               <td className={`${t.text} px-3 py-1.5 text-right tabular-nums font-medium`}>
-                {r.totalExpected > 0 ? fmtFull(r.totalExpected) : "—"}
+                {fmtFull(r.totalExpected)}
               </td>
               <td className="px-3 py-1.5 text-center">
                 {r.hasNotes ? (

--- a/src/components/modals/SheetSyncModal.tsx
+++ b/src/components/modals/SheetSyncModal.tsx
@@ -1344,7 +1344,7 @@ const SheetRowsTable = ({
                 )}
               </td>
               <td className={`${t.text} px-3 py-1.5 text-right tabular-nums font-medium`}>
-                {r.totalExpected > 0 ? fmtFull(r.totalExpected) : "—"}
+                {fmtFull(r.totalExpected)}
               </td>
               <td className="px-3 py-1.5 text-center">
                 {r.hasNotes ? (

--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -882,7 +882,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                       {showCol("opennofees")  && <td className={`${tdBase} text-right ${a.openNoFees  > 0 ? (dark ? "text-amber-400"   : "text-amber-600")   : t.textMuted}`}>{a.openNoFees}</td>}
                       {showCol("collected") && (
                         <td className={`${tdBase} text-right font-semibold ${a.feesCollectedInWindow > 0 ? "text-emerald-500" : t.textMuted}`}>
-                          {a.feesCollectedInWindow > 0 ? fmt(a.feesCollectedInWindow) : "—"}
+                          {fmt(a.feesCollectedInWindow)}
                         </td>
                       )}
                       {showCol("ssacalls")    && <td className={`${tdBase} text-right border-l ${t.borderLight} ${dark ? "text-sky-400" : "text-sky-600"}`}>{a.weekSsaCalls}</td>}


### PR DESCRIPTION
## Summary
- `CompletedPetitions.tsx`, `FeePaymentPanel.tsx`, `MyCaseSyncModal.tsx`, `ImportCasesModal.tsx`, `SheetSyncModal.tsx`, and `ScoreboardTracker.tsx` all used a truthy/`>0` check on a money field to decide between showing the formatted amount or "—", which hid a genuine $0.00 as if it were missing data.
- Confirmed via each file's own sibling code (e.g. `Reports.tsx`'s totals row, `CompletedPetitions.tsx`'s header stats) that displaying zero plainly is already the intended pattern elsewhere in the same files — these per-row cells just hadn't caught up.
- Where a field is genuinely nullable (`CompletedPetitions.tsx`'s `feesReceived`), kept the `!= null` check and only dropped the erroneous `> 0`. Where a field is always a number (the other five), the conditional was removed entirely.