### PR TITLE
fix: close accessibility gaps from full-branch audit

### DIFF
--- a/src/app/(dashboard)/notifications/page.tsx
+++ b/src/app/(dashboard)/notifications/page.tsx
@@ -318,19 +318,21 @@ export default function NotificationsPage() {
               className={`h-8 px-3 rounded-md text-xs font-medium flex items-center gap-1.5 border ${t.outlineBtn} disabled:opacity-40`}
             >
               {markingAll ? (
-                <RefreshCw className="h-3 w-3 animate-spin" />
+                <RefreshCw className="h-3 w-3 animate-spin" aria-hidden="true" />
               ) : (
-                <CheckCheck className="h-3 w-3" />
+                <CheckCheck className="h-3 w-3" aria-hidden="true" />
               )}
               Mark all read
             </button>
             <button
               onClick={fetchNotifications}
               disabled={loading}
+              aria-label="Refresh notifications"
               className={`h-8 w-8 rounded-md flex items-center justify-center border ${t.outlineBtn}`}
             >
               <RefreshCw
                 className={`h-3.5 w-3.5 ${loading ? "animate-spin" : ""}`}
+                aria-hidden="true"
               />
             </button>
           </div>
@@ -380,9 +382,10 @@ export default function NotificationsPage() {
       {/* Error */}
       {error && (
         <div
+          role="alert"
           className={`rounded-xl border p-3 flex items-center gap-2 ${dark ? "bg-red-900/20 border-red-800 text-red-400" : "bg-red-50 border-red-200 text-red-700"}`}
         >
-          <AlertTriangle className="h-4 w-4 shrink-0" />
+          <AlertTriangle className="h-4 w-4 shrink-0" aria-hidden="true" />
           <span className="text-xs">{error}</span>
         </div>
       )}
@@ -392,7 +395,7 @@ export default function NotificationsPage() {
         <div
           className={`rounded-xl border ${t.card} flex items-center justify-center py-16`}
         >
-          <RefreshCw className={`h-5 w-5 animate-spin ${t.textMuted}`} />
+          <RefreshCw className={`h-5 w-5 animate-spin ${t.textMuted}`} aria-hidden="true" />
           <span className={`ml-2 text-sm ${t.textSub}`}>
             Loading notifications...
           </span>

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -379,9 +379,10 @@ export default function SettingsPage() {
       {/* Error */}
       {error && (
         <div
+          role="alert"
           className={`rounded-xl border p-3 flex items-center gap-2 ${dark ? "bg-red-900/20 border-red-800 text-red-400" : "bg-red-50 border-red-200 text-red-700"}`}
         >
-          <AlertCircle className="h-4 w-4 shrink-0" />
+          <AlertCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
           <span className="text-xs">{error}</span>
         </div>
       )}
@@ -389,6 +390,7 @@ export default function SettingsPage() {
       {/* Save message */}
       {saveMsg && (
         <div
+          role="alert"
           className={`rounded-xl border p-3 flex items-center gap-2 ${
             saveMsg.startsWith("Error")
               ? dark
@@ -400,9 +402,9 @@ export default function SettingsPage() {
           }`}
         >
           {saveMsg.startsWith("Error") ? (
-            <AlertCircle className="h-4 w-4" />
+            <AlertCircle className="h-4 w-4" aria-hidden="true" />
           ) : (
-            <Check className="h-4 w-4" />
+            <Check className="h-4 w-4" aria-hidden="true" />
           )}
           <span className="text-xs font-medium">{saveMsg}</span>
         </div>
@@ -594,9 +596,10 @@ export default function SettingsPage() {
                         </div>
                         <button
                           onClick={() => handleDeleteCap(fc.id)}
+                          aria-label="Delete fee cap"
                           className={`h-7 w-7 rounded-md flex items-center justify-center ${dark ? "hover:bg-red-900/30 text-red-400" : "hover:bg-red-50 text-red-500"} opacity-50 hover:opacity-100 transition-opacity`}
                         >
-                          <Trash2 className="h-3 w-3" />
+                          <Trash2 className="h-3 w-3" aria-hidden="true" />
                         </button>
                       </div>
                     ))}

--- a/src/app/cases/[id]/page.tsx
+++ b/src/app/cases/[id]/page.tsx
@@ -291,7 +291,7 @@ const FeeSection = memo(
               onClick={startEdit}
               className={`text-[12px] font-medium ${t.textMuted} flex items-center gap-1`}
             >
-              <Pencil className="h-2.5 w-2.5" /> Edit
+              <Pencil className="h-2.5 w-2.5" aria-hidden="true" /> Edit
             </button>
           ) : (
             <div className="flex gap-1.5">
@@ -299,7 +299,7 @@ const FeeSection = memo(
                 onClick={cancelInlineEdit}
                 className={`text-[12px] font-medium ${t.textMuted} flex items-center gap-0.5`}
               >
-                <X className="h-2.5 w-2.5" /> Cancel
+                <X className="h-2.5 w-2.5" aria-hidden="true" /> Cancel
               </button>
               <button
                 onClick={saveInline}
@@ -307,9 +307,9 @@ const FeeSection = memo(
                 className="text-[12px] font-semibold text-emerald-500 flex items-center gap-0.5 disabled:opacity-50"
               >
                 {localSaving ? (
-                  <RefreshCw className="h-2.5 w-2.5 animate-spin" />
+                  <RefreshCw className="h-2.5 w-2.5 animate-spin" aria-hidden="true" />
                 ) : (
-                  <Save className="h-2.5 w-2.5" />
+                  <Save className="h-2.5 w-2.5" aria-hidden="true" />
                 )}{" "}
                 Save
               </button>
@@ -773,6 +773,7 @@ const CaseDetailPage = () => {
               >
                 <Trash2
                   className={`h-5 w-5 ${dark ? "text-red-400" : "text-red-600"}`}
+                  aria-hidden="true"
                 />
               </div>
               <div>
@@ -801,9 +802,9 @@ const CaseDetailPage = () => {
                 className="h-8 px-4 rounded-md bg-red-600 hover:bg-red-700 text-white text-xs font-semibold flex items-center gap-1.5 disabled:opacity-50"
               >
                 {deleting ? (
-                  <RefreshCw className="h-3 w-3 animate-spin" />
+                  <RefreshCw className="h-3 w-3 animate-spin" aria-hidden="true" />
                 ) : (
-                  <Trash2 className="h-3 w-3" />
+                  <Trash2 className="h-3 w-3" aria-hidden="true" />
                 )}
                 {deleting ? "Deleting..." : "Delete Case"}
               </button>
@@ -858,20 +859,20 @@ const CaseDetailPage = () => {
                       onClick={() => setEditing(true)}
                       className={`h-8 px-3 rounded-md border text-xs font-medium flex items-center gap-1.5 ${t.outlineBtn}`}
                     >
-                      <Pencil className="h-3 w-3" /> Edit
+                      <Pencil className="h-3 w-3" aria-hidden="true" /> Edit
                     </button>
                     <button
                       onClick={() => setFeeModalOpen(true)}
                       className={`h-8 px-3 rounded-md border text-xs font-medium flex items-center gap-1.5 ${t.outlineBtn}`}
                     >
-                      <DollarSign className="h-3 w-3" /> Edit Fees
+                      <DollarSign className="h-3 w-3" aria-hidden="true" /> Edit Fees
                     </button>
                     {canDelete && (
                       <button
                         onClick={() => setDeleteConfirm(true)}
                         className={`h-8 px-3 rounded-md border text-xs font-medium flex items-center gap-1.5 ${dark ? "border-red-800 text-red-400 hover:bg-red-900/30" : "border-red-200 text-red-600 hover:bg-red-50"}`}
                       >
-                        <Trash2 className="h-3 w-3" /> Delete
+                        <Trash2 className="h-3 w-3" aria-hidden="true" /> Delete
                       </button>
                     )}
                   </>
@@ -881,7 +882,7 @@ const CaseDetailPage = () => {
                       onClick={cancelEdit}
                       className={`h-8 px-3 rounded-md border text-xs font-medium flex items-center gap-1.5 ${t.outlineBtn}`}
                     >
-                      <X className="h-3 w-3" /> Cancel
+                      <X className="h-3 w-3" aria-hidden="true" /> Cancel
                     </button>
                     <button
                       onClick={handleSave}
@@ -889,9 +890,9 @@ const CaseDetailPage = () => {
                       className={`h-8 px-3 rounded-md text-xs font-semibold flex items-center gap-1.5 ${t.ctaBtn} disabled:opacity-50`}
                     >
                       {saving ? (
-                        <RefreshCw className="h-3 w-3 animate-spin" />
+                        <RefreshCw className="h-3 w-3 animate-spin" aria-hidden="true" />
                       ) : (
-                        <Save className="h-3 w-3" />
+                        <Save className="h-3 w-3" aria-hidden="true" />
                       )}{" "}
                       Save
                     </button>
@@ -907,7 +908,7 @@ const CaseDetailPage = () => {
                       disabled={saving}
                       className="h-8 px-3 rounded-md bg-emerald-600 text-white text-xs font-semibold flex items-center gap-1.5 hover:bg-emerald-700 disabled:opacity-50"
                     >
-                      <CheckCircle2 className="h-3 w-3" /> Mark PIF
+                      <CheckCircle2 className="h-3 w-3" aria-hidden="true" /> Mark PIF
                     </button>
                   )}
               </div>
@@ -919,9 +920,10 @@ const CaseDetailPage = () => {
       <div className="max-w-6xl mx-auto px-4 md:px-6 py-6 space-y-4">
         {error && (
           <div
+            role="alert"
             className={`rounded-xl border p-4 flex items-center gap-3 ${dark ? "bg-red-900/20 border-red-800 text-red-400" : "bg-red-50 border-red-200 text-red-700"}`}
           >
-            <AlertCircle className="h-4 w-4 shrink-0" />
+            <AlertCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
             <span className="text-sm">{error}</span>
             <button
               onClick={() => router.back()}
@@ -934,7 +936,7 @@ const CaseDetailPage = () => {
 
         {loading && (
           <div className="flex items-center justify-center py-20">
-            <RefreshCw className={`h-6 w-6 animate-spin ${t.textMuted}`} />
+            <RefreshCw className={`h-6 w-6 animate-spin ${t.textMuted}`} aria-hidden="true" />
           </div>
         )}
 
@@ -946,7 +948,7 @@ const CaseDetailPage = () => {
                 <h4
                   className={`text-xs font-bold ${t.text} mb-3 flex items-center gap-2`}
                 >
-                  <FileText className="h-3.5 w-3.5" /> Case Information
+                  <FileText className="h-3.5 w-3.5" aria-hidden="true" /> Case Information
                 </h4>
                 <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
                   <div>
@@ -979,7 +981,7 @@ const CaseDetailPage = () => {
                   </div>
                   <div>
                     <p className={lbl}>
-                      <Shield className="h-3 w-3 inline mr-1" />
+                      <Shield className="h-3 w-3 inline mr-1" aria-hidden="true" />
                       SSN
                     </p>
                     <p className={val}>
@@ -991,14 +993,14 @@ const CaseDetailPage = () => {
                   </div>
                   <div>
                     <p className={lbl}>
-                      <Phone className="h-3 w-3 inline mr-1" />
+                      <Phone className="h-3 w-3 inline mr-1" aria-hidden="true" />
                       Phone
                     </p>
                     <p className={val}>{caseData.phone || "—"}</p>
                   </div>
                   <div>
                     <p className={lbl}>
-                      <Mail className="h-3 w-3 inline mr-1" />
+                      <Mail className="h-3 w-3 inline mr-1" aria-hidden="true" />
                       Email
                     </p>
                     <p className={val}>{caseData.email || "—"}</p>
@@ -1020,7 +1022,7 @@ const CaseDetailPage = () => {
                       </select>
                     ) : (
                       <p className={`${val} flex items-center gap-1`}>
-                        <User className="h-3 w-3" /> {caseData.assigned}
+                        <User className="h-3 w-3" aria-hidden="true" /> {caseData.assigned}
                       </p>
                     )}
                   </div>
@@ -1047,7 +1049,7 @@ const CaseDetailPage = () => {
                       />
                     ) : (
                       <p className={`${val} flex items-center gap-1`}>
-                        <CalendarDays className="h-3 w-3" />{" "}
+                        <CalendarDays className="h-3 w-3" aria-hidden="true" />{" "}
                         {caseData.approvalDate
                           ? fmtDate(caseData.approvalDate)
                           : "—"}
@@ -1206,7 +1208,7 @@ const CaseDetailPage = () => {
                 <h4
                   className={`text-xs font-bold ${t.text} mb-3 flex items-center gap-2`}
                 >
-                  <DollarSign className="h-3.5 w-3.5" /> Financial Summary
+                  <DollarSign className="h-3.5 w-3.5" aria-hidden="true" /> Financial Summary
                   <span className={`text-[11px] font-normal ${t.textMuted}`}>
                     (computed)
                   </span>
@@ -1242,7 +1244,7 @@ const CaseDetailPage = () => {
                         className={`h-2 rounded-full ${dark ? "bg-neutral-800" : "bg-neutral-200"}`}
                       >
                         <div
-                          className="h-2 rounded-full bg-emerald-500 transition-all"
+                          className="h-2 rounded-full bg-emerald-500 transition-[width]"
                           style={{
                             width: `${Math.min(100, (caseData.paid / caseData.expected) * 100)}%`,
                           }}
@@ -1264,7 +1266,7 @@ const CaseDetailPage = () => {
                       <span
                         className={`text-[14px] font-semibold ${caseData.approvalCategory === ">60" ? (dark ? "text-red-400" : "text-red-600") : dark ? "text-emerald-400" : "text-emerald-600"}`}
                       >
-                        <Clock className="h-3 w-3 inline mr-1" />
+                        <Clock className="h-3 w-3 inline mr-1" aria-hidden="true" />
                         {caseData.daysAfterApproval}d (
                         {caseData.approvalCategory})
                       </span>
@@ -1287,7 +1289,7 @@ const CaseDetailPage = () => {
                 <h4
                   className={`text-xs font-bold ${t.text} mb-3 flex items-center gap-2`}
                 >
-                  <Shield className="h-3.5 w-3.5" /> PDF-Extracted Data
+                  <Shield className="h-3.5 w-3.5" aria-hidden="true" /> PDF-Extracted Data
                   <span className={`text-[11px] font-normal ${t.textMuted}`}>
                     (from Chronicle file)
                   </span>
@@ -1302,7 +1304,7 @@ const CaseDetailPage = () => {
                   {caseData.primaryDiagnosis && (
                     <div>
                       <p className={lbl}>
-                        <Stethoscope className="h-3 w-3 inline mr-1" />
+                        <Stethoscope className="h-3 w-3 inline mr-1" aria-hidden="true" />
                         Primary Dx
                       </p>
                       <p className={val}>
@@ -1316,7 +1318,7 @@ const CaseDetailPage = () => {
                   {caseData.secondaryDiagnosis && (
                     <div>
                       <p className={lbl}>
-                        <Stethoscope className="h-3 w-3 inline mr-1" />
+                        <Stethoscope className="h-3 w-3 inline mr-1" aria-hidden="true" />
                         Secondary Dx
                       </p>
                       <p className={val}>
@@ -1330,7 +1332,7 @@ const CaseDetailPage = () => {
                   {caseData.lastInsured && (
                     <div>
                       <p className={lbl}>
-                        <CalendarDays className="h-3 w-3 inline mr-1" />
+                        <CalendarDays className="h-3 w-3 inline mr-1" aria-hidden="true" />
                         DLI
                       </p>
                       <p className={val}>{caseData.lastInsured}</p>
@@ -1339,7 +1341,7 @@ const CaseDetailPage = () => {
                   {caseData.blindDli && (
                     <div>
                       <p className={lbl}>
-                        <CalendarDays className="h-3 w-3 inline mr-1" />
+                        <CalendarDays className="h-3 w-3 inline mr-1" aria-hidden="true" />
                         Blind DLI
                       </p>
                       <p className={val}>{caseData.blindDli}</p>
@@ -1348,7 +1350,7 @@ const CaseDetailPage = () => {
                   {caseData.firmName && (
                     <div>
                       <p className={lbl}>
-                        <Building2 className="h-3 w-3 inline mr-1" />
+                        <Building2 className="h-3 w-3 inline mr-1" aria-hidden="true" />
                         Firm
                       </p>
                       <p className={val}>{caseData.firmName}</p>
@@ -1357,7 +1359,7 @@ const CaseDetailPage = () => {
                   {caseData.firmEin && (
                     <div>
                       <p className={lbl}>
-                        <Building2 className="h-3 w-3 inline mr-1" />
+                        <Building2 className="h-3 w-3 inline mr-1" aria-hidden="true" />
                         Firm EIN
                       </p>
                       <p className={val}>{caseData.firmEin}</p>
@@ -1366,7 +1368,7 @@ const CaseDetailPage = () => {
                   {caseData.hearingOffice && (
                     <div>
                       <p className={lbl}>
-                        <MapPin className="h-3 w-3 inline mr-1" />
+                        <MapPin className="h-3 w-3 inline mr-1" aria-hidden="true" />
                         Hearing Office
                       </p>
                       <p className={val}>{caseData.hearingOffice}</p>
@@ -1395,7 +1397,7 @@ const CaseDetailPage = () => {
                             key={i}
                             className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-lg text-[13px] font-medium ${dark ? "bg-neutral-800/60 text-neutral-300" : "bg-neutral-100 text-neutral-700"}`}
                           >
-                            <User className="h-3 w-3" /> {rep.name}
+                            <User className="h-3 w-3" aria-hidden="true" /> {rep.name}
                             {rep.repId ? ` (${rep.repId})` : ""}
                           </span>
                         ))}
@@ -1407,7 +1409,7 @@ const CaseDetailPage = () => {
                   caseData.decisionHistory.length > 0 && (
                     <div className="mt-3">
                       <p className={`${lbl} mb-1.5`}>
-                        <Gavel className="h-3 w-3 inline mr-1" />
+                        <Gavel className="h-3 w-3 inline mr-1" aria-hidden="true" />
                         Decision History
                       </p>
                       <div className="flex flex-wrap gap-2">
@@ -1427,9 +1429,9 @@ const CaseDetailPage = () => {
                               }`}
                             >
                               {denied ? (
-                                <XCircle className="h-3 w-3" />
+                                <XCircle className="h-3 w-3" aria-hidden="true" />
                               ) : (
-                                <CheckCircle2 className="h-3 w-3" />
+                                <CheckCircle2 className="h-3 w-3" aria-hidden="true" />
                               )}
                               {dec.level} • {dec.claimType} • {dec.result}
                               {dec.date ? ` (${dec.date})` : ""}
@@ -1490,7 +1492,7 @@ const CaseDetailPage = () => {
               <h4
                 className={`text-xs font-bold ${t.text} mb-4 flex items-center gap-2`}
               >
-                <MessageSquare className="h-3.5 w-3.5" /> Activity Log
+                <MessageSquare className="h-3.5 w-3.5" aria-hidden="true" /> Activity Log
                 <span className={`ml-1 text-[12px] font-normal ${t.textMuted}`}>
                   ({caseData.activities?.length ?? 0}{" "}
                   {caseData.activities?.length === 1 ? "entry" : "entries"})
@@ -1519,9 +1521,9 @@ const CaseDetailPage = () => {
                     className={`h-8 px-3 rounded-md text-xs font-semibold flex items-center gap-1.5 ${t.ctaBtn} disabled:opacity-40`}
                   >
                     {postingNote ? (
-                      <RefreshCw className="h-3 w-3 animate-spin" />
+                      <RefreshCw className="h-3 w-3 animate-spin" aria-hidden="true" />
                     ) : (
-                      <Send className="h-3 w-3" />
+                      <Send className="h-3 w-3" aria-hidden="true" />
                     )}{" "}
                     Post
                   </button>

--- a/src/components/cases/AcknowledgeAndCloseDialog.tsx
+++ b/src/components/cases/AcknowledgeAndCloseDialog.tsx
@@ -105,7 +105,7 @@ export function AcknowledgeAndCloseDialog({
             role="alert"
             className="flex items-center gap-2 text-sm text-destructive"
           >
-            <AlertCircle className="h-4 w-4 shrink-0" />
+            <AlertCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
             {error}
           </p>
         )}

--- a/src/components/cases/FeeEditModal.tsx
+++ b/src/components/cases/FeeEditModal.tsx
@@ -179,9 +179,10 @@ export default function FeeEditModal({
           </div>
           <button
             onClick={onClose}
+            aria-label="Close"
             className={`h-7 w-7 rounded-md flex items-center justify-center ${t.hover} ${t.textSub}`}
           >
-            <X className="h-4 w-4" />
+            <X className="h-4 w-4" aria-hidden="true" />
           </button>
         </div>
 

--- a/src/components/chronicle/ChroniclePull.tsx
+++ b/src/components/chronicle/ChroniclePull.tsx
@@ -528,11 +528,11 @@ export const ChroniclePull = () => {
         }`}
       >
         {fav ? (
-          <CheckCircle2 className="h-3.5 w-3.5" />
+          <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />
         ) : unfav ? (
-          <XCircle className="h-3.5 w-3.5" />
+          <XCircle className="h-3.5 w-3.5" aria-hidden="true" />
         ) : (
-          <Clock className="h-3.5 w-3.5" />
+          <Clock className="h-3.5 w-3.5" aria-hidden="true" />
         )}
         <span>{label}:</span> <span>{decision}</span>
       </div>
@@ -563,8 +563,7 @@ export const ChroniclePull = () => {
               className={`w-10 h-10 rounded-lg flex items-center justify-center ${dark ? "bg-indigo-900/40" : "bg-indigo-50"}`}
             >
               <Database
-                className={`h-5 w-5 ${dark ? "text-indigo-400" : "text-indigo-600"}`}
-              />
+                className={`h-5 w-5 ${dark ? "text-indigo-400" : "text-indigo-600"}`} aria-hidden="true" />
             </div>
             <div>
               <h3 className={`text-sm font-bold ${t.text}`}>
@@ -579,8 +578,7 @@ export const ChroniclePull = () => {
           <div className="flex gap-2">
             <div className="flex-1 relative">
               <Search
-                className={`absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 ${t.textMuted}`}
-              />
+                className={`absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 ${t.textMuted}`} aria-hidden="true" />
               <input
                 value={clientId}
                 onChange={(e) => setClientId(e.target.value)}
@@ -595,9 +593,9 @@ export const ChroniclePull = () => {
               className={`h-9 px-4 rounded-lg text-xs font-semibold flex items-center gap-2 ${t.ctaBtn} disabled:opacity-40`}
             >
               {pulling ? (
-                <RefreshCw className="h-3.5 w-3.5 animate-spin" />
+                <RefreshCw className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
               ) : (
-                <Download className="h-3.5 w-3.5" />
+                <Download className="h-3.5 w-3.5" aria-hidden="true" />
               )}
               {pulling ? "Pulling..." : "Pull"}
             </button>
@@ -613,8 +611,7 @@ export const ChroniclePull = () => {
               className={`w-10 h-10 rounded-lg flex items-center justify-center ${dark ? "bg-violet-900/40" : "bg-violet-50"}`}
             >
               <FileSearch
-                className={`h-5 w-5 ${dark ? "text-violet-400" : "text-violet-600"}`}
-              />
+                className={`h-5 w-5 ${dark ? "text-violet-400" : "text-violet-600"}`} aria-hidden="true" />
             </div>
             <div>
               <h3 className={`text-sm font-bold ${t.text}`}>
@@ -681,9 +678,9 @@ export const ChroniclePull = () => {
               className={`h-9 px-4 rounded-lg text-xs font-semibold flex items-center gap-2 ${t.ctaBtn} disabled:opacity-40`}
             >
               {searching ? (
-                <RefreshCw className="h-3.5 w-3.5 animate-spin" />
+                <RefreshCw className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
               ) : (
-                <Search className="h-3.5 w-3.5" />
+                <Search className="h-3.5 w-3.5" aria-hidden="true" />
               )}
               {searching ? "Searching..." : "Search"}
             </button>
@@ -699,7 +696,7 @@ export const ChroniclePull = () => {
             <div
               className={`mt-3 rounded-lg border p-2.5 flex items-center gap-2 ${dark ? "bg-red-900/20 border-red-800 text-red-400" : "bg-red-50 border-red-200 text-red-700"}`}
             >
-              <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+              <AlertCircle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
               <span className="text-[14px]">{searchError}</span>
             </div>
           )}
@@ -752,7 +749,7 @@ export const ChroniclePull = () => {
                           className={`inline-flex items-center gap-1 h-7 px-2 rounded-md text-[13px] font-semibold border ${t.outlineBtn}`}
                           title="Pull this client into the lookup above"
                         >
-                          <ArrowRight className="h-3 w-3" /> Pull
+                          <ArrowRight className="h-3 w-3" aria-hidden="true" /> Pull
                         </button>
                       </td>
                     </tr>
@@ -773,9 +770,10 @@ export const ChroniclePull = () => {
       {/* Notices */}
       {error && (
         <div
+          role="alert"
           className={`rounded-xl border p-3 flex items-center gap-2.5 ${dark ? "bg-red-900/20 border-red-800 text-red-400" : "bg-red-50 border-red-200 text-red-700"}`}
         >
-          <AlertCircle className="h-4 w-4 shrink-0" />
+          <AlertCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
           <span className="text-sm">{error}</span>
         </div>
       )}
@@ -783,7 +781,7 @@ export const ChroniclePull = () => {
         <div
           className={`rounded-xl border p-3 flex items-center gap-2.5 ${dark ? "bg-emerald-900/20 border-emerald-800 text-emerald-400" : "bg-emerald-50 border-emerald-200 text-emerald-700"}`}
         >
-          <CheckCircle2 className="h-4 w-4 shrink-0" />
+          <CheckCircle2 className="h-4 w-4 shrink-0" aria-hidden="true" />
           <span className="text-sm">{importResult}</span>
         </div>
       )}
@@ -791,7 +789,7 @@ export const ChroniclePull = () => {
         <div
           className={`rounded-xl border p-3 flex items-center gap-2.5 ${dark ? "bg-amber-900/20 border-amber-800 text-amber-400" : "bg-amber-50 border-amber-200 text-amber-700"}`}
         >
-          <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+          <AlertCircle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
           <span className="text-[13px]">
             Using mock data \u2014 set CHRONICLE_API_URL and CHRONICLE_API_KEY
             in .env.local
@@ -802,7 +800,7 @@ export const ChroniclePull = () => {
       {/* Loading */}
       {pulling && (
         <div className="flex items-center justify-center py-12">
-          <RefreshCw className={`h-5 w-5 animate-spin ${t.textMuted}`} />
+          <RefreshCw className={`h-5 w-5 animate-spin ${t.textMuted}`} aria-hidden="true" />
           <span className={`ml-2 text-sm ${t.textSub}`}>
             Fetching from Chronicle...
           </span>
@@ -831,16 +829,13 @@ export const ChroniclePull = () => {
             <div className="flex items-center gap-2.5">
               {result.parsed.isFavorable ? (
                 <CheckCircle2
-                  className={`h-5 w-5 ${dark ? "text-emerald-400" : "text-emerald-600"}`}
-                />
+                  className={`h-5 w-5 ${dark ? "text-emerald-400" : "text-emerald-600"}`} aria-hidden="true" />
               ) : result.parsed.isUnfavorable ? (
                 <XCircle
-                  className={`h-5 w-5 ${dark ? "text-red-400" : "text-red-600"}`}
-                />
+                  className={`h-5 w-5 ${dark ? "text-red-400" : "text-red-600"}`} aria-hidden="true" />
               ) : (
                 <Clock
-                  className={`h-5 w-5 ${dark ? "text-amber-400" : "text-amber-600"}`}
-                />
+                  className={`h-5 w-5 ${dark ? "text-amber-400" : "text-amber-600"}`} aria-hidden="true" />
               )}
               <div>
                 <span className={`text-sm font-bold ${t.text}`}>
@@ -873,9 +868,9 @@ export const ChroniclePull = () => {
                   className={`h-8 px-3 rounded-lg text-xs font-semibold flex items-center gap-1.5 ${t.ctaBtn} disabled:opacity-50`}
                 >
                   {importing ? (
-                    <RefreshCw className="h-3 w-3 animate-spin" />
+                    <RefreshCw className="h-3 w-3 animate-spin" aria-hidden="true" />
                   ) : (
-                    <ArrowRight className="h-3 w-3" />
+                    <ArrowRight className="h-3 w-3" aria-hidden="true" />
                   )}
                   Import to Dashboard
                 </button>
@@ -1015,8 +1010,7 @@ export const ChroniclePull = () => {
           >
             <div className="flex items-center gap-2.5">
               <FileSearch
-                className={`h-4 w-4 ${dark ? "text-violet-400" : "text-violet-600"}`}
-              />
+                className={`h-4 w-4 ${dark ? "text-violet-400" : "text-violet-600"}`} aria-hidden="true" />
               <div>
                 <span className={`text-xs font-bold ${t.text}`}>
                   PDF Data Extraction
@@ -1037,9 +1031,9 @@ export const ChroniclePull = () => {
                 } disabled:opacity-50 transition-colors`}
               >
                 {parsingPdf ? (
-                  <RefreshCw className="h-3 w-3 animate-spin" />
+                  <RefreshCw className="h-3 w-3 animate-spin" aria-hidden="true" />
                 ) : (
-                  <FileSearch className="h-3 w-3" />
+                  <FileSearch className="h-3 w-3" aria-hidden="true" />
                 )}
                 {parsingPdf ? "Parsing PDF..." : "Parse PDF"}
               </button>
@@ -1056,7 +1050,7 @@ export const ChroniclePull = () => {
           {/* Loading */}
           {parsingPdf && (
             <div className="flex items-center justify-center py-8">
-              <RefreshCw className={`h-4 w-4 animate-spin ${t.textMuted}`} />
+              <RefreshCw className={`h-4 w-4 animate-spin ${t.textMuted}`} aria-hidden="true" />
               <span className={`ml-2 text-xs ${t.textSub}`}>
                 Downloading & parsing PDF (this may take a moment)...
               </span>
@@ -1068,7 +1062,7 @@ export const ChroniclePull = () => {
             <div
               className={`mx-4 my-3 rounded-lg p-2.5 flex items-center gap-2 text-xs ${dark ? "bg-red-900/20 text-red-400" : "bg-red-50 text-red-700"}`}
             >
-              <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+              <AlertCircle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
               {pdfError}
             </div>
           )}
@@ -1186,9 +1180,9 @@ export const ChroniclePull = () => {
                     className={`h-9 px-4 rounded-lg text-xs font-semibold flex items-center gap-2 ${t.ctaBtn} disabled:opacity-50`}
                   >
                     {importing ? (
-                      <RefreshCw className="h-3.5 w-3.5 animate-spin" />
+                      <RefreshCw className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
                     ) : (
-                      <ArrowRight className="h-3.5 w-3.5" />
+                      <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
                     )}
                     {importing
                       ? "Importing..."
@@ -1231,16 +1225,13 @@ export const ChroniclePull = () => {
               >
                 {pr.parsed.isFavorable ? (
                   <CheckCircle2
-                    className={`h-4 w-4 shrink-0 ${dark ? "text-emerald-400" : "text-emerald-600"}`}
-                  />
+                    className={`h-4 w-4 shrink-0 ${dark ? "text-emerald-400" : "text-emerald-600"}`} aria-hidden="true" />
                 ) : pr.parsed.isUnfavorable ? (
                   <XCircle
-                    className={`h-4 w-4 shrink-0 ${dark ? "text-red-400" : "text-red-600"}`}
-                  />
+                    className={`h-4 w-4 shrink-0 ${dark ? "text-red-400" : "text-red-600"}`} aria-hidden="true" />
                 ) : (
                   <Clock
-                    className={`h-4 w-4 shrink-0 ${dark ? "text-amber-400" : "text-amber-600"}`}
-                  />
+                    className={`h-4 w-4 shrink-0 ${dark ? "text-amber-400" : "text-amber-600"}`} aria-hidden="true" />
                 )}
                 <div className="flex-1 min-w-0">
                   <span className={`text-[14px] font-semibold ${t.text}`}>
@@ -1280,7 +1271,7 @@ export const ChroniclePull = () => {
       {/* Empty state */}
       {!result && !pulling && pullHistory.length === 0 && (
         <div className={`rounded-xl border p-12 text-center ${t.card}`}>
-          <Database className={`h-10 w-10 mx-auto ${t.textMuted} mb-3`} />
+          <Database className={`h-10 w-10 mx-auto ${t.textMuted} mb-3`} aria-hidden="true" />
           <p className={`text-sm font-semibold ${t.text}`}>
             Look up a case from Chronicle
           </p>

--- a/src/components/layout/ChangePasswordDialog.tsx
+++ b/src/components/layout/ChangePasswordDialog.tsx
@@ -141,7 +141,7 @@ export function ChangePasswordDialog({
                 role="alert"
                 className="flex items-center gap-2 text-sm text-destructive"
               >
-                <AlertCircle className="h-4 w-4 shrink-0" />
+                <AlertCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
                 {error}
               </p>
             )}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -263,12 +263,16 @@ export const Sidebar = ({ open, onToggle, onMobileClose }: SidebarProps) => {
         <div
           className={`h-14 border-b ${t.borderLight} flex items-center ${open ? "px-4 gap-3" : "justify-center"}`}
         >
-          <button onClick={onToggle} className="shrink-0">
+          <button
+            onClick={onToggle}
+            aria-label={open ? "Collapse sidebar" : "Expand sidebar"}
+            className="shrink-0"
+          >
             <div className={`flex items-center ${open ? "gap-2.5" : ""}`}>
               <div
                 className={`w-7 h-7 rounded-lg flex items-center justify-center ${t.logoBg}`}
               >
-                <DollarSign className={`h-4 w-4 ${t.logoIcon}`} />
+                <DollarSign className={`h-4 w-4 ${t.logoIcon}`} aria-hidden="true" />
               </div>
               {open && (
                 <div className="leading-tight">
@@ -285,9 +289,10 @@ export const Sidebar = ({ open, onToggle, onMobileClose }: SidebarProps) => {
           {open && (
             <button
               onClick={onToggle}
+              aria-label="Collapse sidebar"
               className={`ml-auto ${t.textMuted} ${t.hover} rounded p-0.5`}
             >
-              <PanelLeft className="h-4 w-4" />
+              <PanelLeft className="h-4 w-4" aria-hidden="true" />
             </button>
           )}
         </div>
@@ -299,7 +304,7 @@ export const Sidebar = ({ open, onToggle, onMobileClose }: SidebarProps) => {
               onClick={() => setSearchOpen(true)}
               className={`w-full flex items-center gap-2 px-2.5 py-1.5 rounded-md border text-xs ${t.searchBox} transition-colors`}
             >
-              <Search className="h-3.5 w-3.5" />
+              <Search className="h-3.5 w-3.5" aria-hidden="true" />
               <span>Search cases</span>
               <span
                 className={`ml-auto text-[12px] px-1 py-0.5 rounded border ${t.kbdBg}`}
@@ -315,9 +320,10 @@ export const Sidebar = ({ open, onToggle, onMobileClose }: SidebarProps) => {
                 onToggle();
                 setTimeout(() => setSearchOpen(true), 200);
               }}
+              aria-label="Search cases"
               className={`w-full flex justify-center py-1.5 rounded-md ${t.hover}`}
             >
-              <Search className={`h-4 w-4 ${t.textMuted}`} />
+              <Search className={`h-4 w-4 ${t.textMuted}`} aria-hidden="true" />
             </button>
           </div>
         )}

--- a/src/components/modals/AddCaseModal.tsx
+++ b/src/components/modals/AddCaseModal.tsx
@@ -214,9 +214,10 @@ export default function AddCaseModal({
           <h3 className={`text-sm font-bold ${t.text}`}>Add New Case</h3>
           <button
             onClick={onClose}
+            aria-label="Close"
             className={`h-7 w-7 rounded-md flex items-center justify-center ${t.hover} ${t.textSub}`}
           >
-            <X className="h-4 w-4" />
+            <X className="h-4 w-4" aria-hidden="true" />
           </button>
         </div>
 

--- a/src/components/modals/ImportCasesModal.tsx
+++ b/src/components/modals/ImportCasesModal.tsx
@@ -224,9 +224,10 @@ export default function ImportCasesModal({
           <h3 className={`text-sm font-bold ${t.text}`}>Import Cases</h3>
           <button
             onClick={onClose}
+            aria-label="Close"
             className={`h-7 w-7 rounded-md flex items-center justify-center ${t.hover} ${t.textSub}`}
           >
-            <X className="h-4 w-4" />
+            <X className="h-4 w-4" aria-hidden="true" />
           </button>
         </div>
 
@@ -268,6 +269,7 @@ export default function ImportCasesModal({
         <div className="flex-1 overflow-y-auto p-5">
           {error && (
             <div
+              role="alert"
               className={`mb-4 rounded-md border p-3 text-xs ${dark ? "bg-red-900/20 border-red-800 text-red-300" : "bg-red-50 border-red-200 text-red-700"}`}
             >
               {error}

--- a/src/components/modals/NotesModal.tsx
+++ b/src/components/modals/NotesModal.tsx
@@ -190,9 +190,10 @@ export default function NotesModal({
           </div>
           <button
             onClick={onClose}
+            aria-label="Close"
             className={`h-7 w-7 rounded-md flex items-center justify-center ${t.hover} ${t.textSub}`}
           >
-            <X className="h-4 w-4" />
+            <X className="h-4 w-4" aria-hidden="true" />
           </button>
         </div>
 
@@ -214,11 +215,12 @@ export default function NotesModal({
               disabled={!draft.trim() || adding}
               className={`h-8 px-4 rounded-md text-xs font-semibold flex items-center gap-1.5 ${t.ctaBtn} disabled:opacity-50`}
             >
-              {adding && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+              {adding && <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />}
               Add Note
             </button>
             {actionError && (
               <span
+                role="alert"
                 className={`text-[13px] ${dark ? "text-red-400" : "text-red-600"}`}
               >
                 {actionError}
@@ -236,13 +238,14 @@ export default function NotesModal({
           <div
             className={`flex items-center justify-center py-12 ${t.textMuted}`}
           >
-            <RefreshCw className="h-4 w-4 animate-spin mr-2" />
+            <RefreshCw className="h-4 w-4 animate-spin mr-2" aria-hidden="true" />
             <span className="text-xs">Loading notes…</span>
           </div>
         )}
 
         {error && (
           <div
+            role="alert"
             className={`rounded-md border p-3 text-xs ${dark ? "bg-red-900/20 border-red-800 text-red-300" : "bg-red-50 border-red-200 text-red-700"}`}
           >
             {error}
@@ -253,7 +256,7 @@ export default function NotesModal({
           <div
             className={`flex flex-col items-center justify-center py-10 ${t.textMuted}`}
           >
-            <FileText className="h-6 w-6 mb-2" />
+            <FileText className="h-6 w-6 mb-2" aria-hidden="true" />
             <p className="text-xs">{isLeader ? "No notes for this case yet." : "No log entries for this case yet."}</p>
           </div>
         )}
@@ -294,7 +297,7 @@ export default function NotesModal({
                           className={`h-6 px-2 rounded text-[12px] font-semibold flex items-center gap-1 disabled:opacity-50 ${dark ? "bg-red-900/40 text-red-300 hover:bg-red-900/60" : "bg-red-600 text-white hover:bg-red-700"}`}
                         >
                           {deletingId === n.id && (
-                            <Loader2 className="h-3 w-3 animate-spin" />
+                            <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
                           )}
                           Delete
                         </button>
@@ -315,7 +318,7 @@ export default function NotesModal({
                             title="Edit note"
                             className={`-mt-1 h-6 w-6 rounded-md flex items-center justify-center ${t.hover} ${t.textSub}`}
                           >
-                            <Pencil className="h-3.5 w-3.5" />
+                            <Pencil className="h-3.5 w-3.5" aria-hidden="true" />
                           </button>
                         )}
                         <button
@@ -324,7 +327,7 @@ export default function NotesModal({
                           title="Delete note"
                           className={`-mt-1 -mr-1 h-6 w-6 shrink-0 rounded-md flex items-center justify-center ${t.hover} ${t.textSub}`}
                         >
-                          <X className="h-3.5 w-3.5" />
+                          <X className="h-3.5 w-3.5" aria-hidden="true" />
                         </button>
                       </div>
                     ))}
@@ -344,7 +347,7 @@ export default function NotesModal({
                         className={`h-7 px-3 rounded-md text-[12px] font-semibold flex items-center gap-1.5 ${t.ctaBtn} disabled:opacity-50`}
                       >
                         {savingEditId === n.id && (
-                          <Loader2 className="h-3 w-3 animate-spin" />
+                          <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
                         )}
                         Save
                       </button>

--- a/src/components/team/TeamManagement.tsx
+++ b/src/components/team/TeamManagement.tsx
@@ -542,8 +542,9 @@ export const TeamManagement = () => {
                           onClick={() => openEditDialog(m)}
                           className={`rounded-md p-1.5 ${t.textMuted} hover:text-indigo-500 ${t.hover} transition-colors`}
                           title="Edit"
+                          aria-label="Edit"
                         >
-                          <Pencil className="h-3.5 w-3.5" />
+                          <Pencil className="h-3.5 w-3.5" aria-hidden="true" />
                         </button>
                         <button
                           onClick={() => handleToggleActive(m)}
@@ -553,11 +554,12 @@ export const TeamManagement = () => {
                               : "hover:text-emerald-500"
                           } ${t.hover}`}
                           title={m.isActive ? "Deactivate" : "Reactivate"}
+                          aria-label={m.isActive ? "Deactivate" : "Reactivate"}
                         >
                           {m.isActive ? (
-                            <UserX className="h-3.5 w-3.5" />
+                            <UserX className="h-3.5 w-3.5" aria-hidden="true" />
                           ) : (
-                            <UserCheck className="h-3.5 w-3.5" />
+                            <UserCheck className="h-3.5 w-3.5" aria-hidden="true" />
                           )}
                         </button>
                       </div>


### PR DESCRIPTION
## Summary
- Add `aria-hidden="true"` to decorative icons sitting next to readable text or inside labeled buttons, across 12 files
- Add `aria-label` to icon-only buttons (close, edit, deactivate, refresh, collapse/expand sidebar, search)
- Add `role="alert"` to dynamically-rendered error/status blocks so screen readers announce them
- Swap `transition-all` → `transition-[width]` on the case-detail fee progress bar

No functional changes — every edit is an attribute addition; no `onClick` handlers, `className` logic, or JSX structure touched.

## Test plan
- [x] `npx tsc --noEmit`, `npm run lint`, `npm test` (102/102), `npm run build` all pass
- [x] Verified `Sidebar.tsx`'s dynamic `aria-label` (Collapse/Expand) tracks visible state correctly in both directions
- [x] Diffed every file to confirm no functional/behavioral change, only attribute additions