### PR TITLE
fix: guard unvalidated body fields against crash-risk types

### DIFF
--- a/src/app/api/cases/[id]/route.ts
+++ b/src/app/api/cases/[id]/route.ts
@@ -17,6 +17,10 @@ const patchBodySchema = z.object({
   logMessage: z.string().optional(),
 });
 
+const addNoteBodySchema = z.object({
+  message: z.string().trim().min(1, "Message is required"),
+});
+
 // Fee fields that count as "finalizing" a case — gated by case.finalize rather
 // than the broader case.update (members can record payments but not close,
 // reopen, mark overpaid, or sign off "OK to close").
@@ -637,20 +641,21 @@ export const POST = async (
     // Author is stamped from the session — a client-supplied author is ignored
     // so notes can't be attributed to someone else.
     const author = guard.session.user?.name?.trim() || "Unknown";
-    const { message } = await req.json();
-
-    if (!message?.trim()) {
+    const rawBody = await req.json().catch(() => null);
+    const parsedBody = addNoteBodySchema.safeParse(rawBody);
+    if (!parsedBody.success) {
       return NextResponse.json(
         { error: "Message is required" },
         { status: 400 },
       );
     }
+    const message = parsedBody.data.message;
 
     const [entry] = await db
       .insert(activityLog)
       .values({
         caseId,
-        message: message.trim(),
+        message,
         createdBy: author,
       })
       .returning({ id: activityLog.id, createdAt: activityLog.createdAt });
@@ -659,7 +664,7 @@ export const POST = async (
       status: "ok",
       activity: {
         id: entry.id,
-        message: message.trim(),
+        message,
         createdBy: author,
         createdAt: entry.createdAt,
       },

--- a/src/app/api/chronicle/search/route.ts
+++ b/src/app/api/chronicle/search/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { searchChronicleClients } from "@/lib/chronicle-client";
 
 // ============================================================================
@@ -8,13 +9,27 @@ import { searchChronicleClients } from "@/lib/chronicle-client";
 // against the live account before building the chronicle_id backfill.
 // ============================================================================
 
+const bodySchema = z.object({
+  firstName: z.string().trim().optional(),
+  lastName: z.string().trim().optional(),
+  last4Ssn: z.string().trim().optional(),
+  externalId: z.string().trim().optional(),
+});
+
 export const POST = async (req: NextRequest) => {
   try {
-    const body = await req.json();
-    const firstName = (body.firstName || "").trim() || undefined;
-    const lastName = (body.lastName || "").trim() || undefined;
-    const last4Ssn = (body.last4Ssn || "").trim() || undefined;
-    const externalId = (body.externalId || "").trim() || undefined;
+    const rawBody = await req.json().catch(() => null);
+    const parsedBody = bodySchema.safeParse(rawBody);
+    if (!parsedBody.success) {
+      return NextResponse.json(
+        { error: "Invalid request body", issues: parsedBody.error.issues },
+        { status: 400 },
+      );
+    }
+    const firstName = parsedBody.data.firstName || undefined;
+    const lastName = parsedBody.data.lastName || undefined;
+    const last4Ssn = parsedBody.data.last4Ssn || undefined;
+    const externalId = parsedBody.data.externalId || undefined;
 
     if (!firstName && !lastName && !last4Ssn && !externalId) {
       return NextResponse.json(

--- a/src/app/api/daily-metrics/route.ts
+++ b/src/app/api/daily-metrics/route.ts
@@ -144,7 +144,7 @@ export const POST = async (req: NextRequest) => {
       for (const entry of body.entries) {
         const { agent, date, ssaCalls, clientCallsIb, clientCallsOb, winSheetsCreated, faxSent, notes } =
           entry;
-        if (!agent || !date) continue;
+        if (!agent || typeof agent !== "string" || !date) continue;
         if (!canWriteAgent(session, agent)) {
           skipped++;
           continue;
@@ -183,7 +183,7 @@ export const POST = async (req: NextRequest) => {
     // Single mode
     const { agent, date, ssaCalls, clientCallsIb, clientCallsOb, winSheetsCreated, faxSent, notes } = body;
 
-    if (!agent) {
+    if (!agent || typeof agent !== "string") {
       return NextResponse.json({ error: "agent is required" }, { status: 400 });
     }
     if (!canWriteAgent(session, agent)) {


### PR DESCRIPTION
## Summary
Found via a full-codebase sweep for the same bug class just fixed on `team-members` (PRs #241/#242): request-body fields used unvalidated, then fed into a string method that throws on a non-string type.

- `src/app/api/chronicle/search/route.ts` (POST) — `(body.firstName || "").trim()` etc. now validated with a Zod schema before use
- `src/app/api/cases/[id]/route.ts` (POST, add activity note) — `message?.trim()` now validated with a Zod schema (`addNoteBodySchema`); "Message is required" error text unchanged
- `src/app/api/daily-metrics/route.ts` (POST, single + batch) — `agent` was only truthiness-checked before flowing into `namesMatch()`'s `.trim()`; added a `typeof agent !== "string"` guard in both modes ("agent is required" error text unchanged for single mode; batch mode continues its existing silent-skip behavior for malformed entries)

All three previously threw an unhandled 500 on a non-string field (e.g. a number); all three now return a clean 400 (or silently skip, for batch entries) instead.

## Test plan
- [x] `npx tsc --noEmit`, `npm run lint`, `npm test` (102/102), `npm run build` all pass
- [x] Live-verified against the running API: non-string `firstName`, `message`, and `agent` all now return 400 instead of 500 in every affected route/mode; confirmed via follow-up reads that no data was written