### PR TITLE
fix: make case detail phone/email actionable links

### DIFF
--- a/src/app/cases/[id]/page.tsx
+++ b/src/app/cases/[id]/page.tsx
@@ -1043,14 +1043,26 @@ const CaseDetailPage = () => {
                       <Phone className="h-3 w-3 inline mr-1" aria-hidden="true" />
                       Phone
                     </p>
-                    <p className={val}>{caseData.phone || "—"}</p>
+                    {caseData.phone ? (
+                      <a href={`tel:${caseData.phone}`} className={`${val} hover:underline`}>
+                        {caseData.phone}
+                      </a>
+                    ) : (
+                      <p className={val}>—</p>
+                    )}
                   </div>
                   <div>
                     <p className={lbl}>
                       <Mail className="h-3 w-3 inline mr-1" aria-hidden="true" />
                       Email
                     </p>
-                    <p className={val}>{caseData.email || "—"}</p>
+                    {caseData.email ? (
+                      <a href={`mailto:${caseData.email}`} className={`${val} hover:underline`}>
+                        {caseData.email}
+                      </a>
+                    ) : (
+                      <p className={val}>—</p>
+                    )}
                   </div>
                   <div>
                     <p className={lbl}>Assigned To</p>


### PR DESCRIPTION
## Summary
From the docket cleanup pass — `src/app/cases/[id]/page.tsx` rendered phone/email as plain text instead of `tel:`/`mailto:` links, unlike `CaseDetailSheet.tsx` which already had this fix.

- Phone now wraps in `<a href="tel:...">`
- Email now wraps in `<a href="mailto:...">`
- Falls back to `—` when either field is empty, same as before

Two other items from the same docket pass were investigated and intentionally left alone (not included here):
- `FeeEditModal.tsx`'s `caseId: string` — not a bug; matches how every other handler on this page threads the same string route param
- Duplicate `num`/`dateOnly` helpers across the import mappers — not pure duplication; each has genuinely different behavior (Date-instance handling, NaN validation) that would need careful reconciliation, not a mechanical extraction

## Test plan
- [x] `npx tsc --noEmit`, `npm run lint`, `npm test` (102/102), `npm run build` all pass