### PR TITLE
fix: security audit — authz gaps, PII-read leak, unparameterized SQL

### DIFF
--- a/src/app/(dashboard)/inbound-calls/actions.ts
+++ b/src/app/(dashboard)/inbound-calls/actions.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { auth } from "@/auth";
 import { db } from "@/lib/db";
 import { inboundCallRecords } from "@/lib/db/schema";
 import { parseBool, parseDate } from "@/lib/import/csv-parser";
@@ -19,6 +20,16 @@ function getMondayOf(dateStr: string): string {
 export async function bulkImportInboundCalls(
   rawRows: Record<string, string>[],
 ): Promise<ImportResult> {
+  const session = await auth();
+  if (!session?.user) {
+    return {
+      imported: 0,
+      failed: 0,
+      rowErrors: [],
+      error: "You must be signed in to import inbound calls.",
+    };
+  }
+
   let imported = 0;
   const rowErrors: ImportResult["rowErrors"] = [];
 

--- a/src/app/(dashboard)/overpaid-cases/actions.ts
+++ b/src/app/(dashboard)/overpaid-cases/actions.ts
@@ -25,6 +25,8 @@ export async function upsertOverpaidCase(input: {
   fields: Updates;
 }): Promise<Result<{ data: typeof overpaidCases.$inferSelect }>> {
   try {
+    const guard = await requireCapability("case.finalize");
+    if (!guard.ok) return { ok: false, error: "You don't have permission to edit overpaid cases." };
     if (!Number.isFinite(input.caseId)) {
       return { ok: false, error: "Invalid case ID" };
     }
@@ -79,6 +81,8 @@ export async function bulkMarkCleared(input: {
   caseIds: number[];
 }): Promise<Result> {
   try {
+    const guard = await requireCapability("case.finalize");
+    if (!guard.ok) return { ok: false, error: "You don't have permission to clear checks." };
     if (!input.caseIds.length) return { ok: false, error: "No cases selected" };
     if (input.caseIds.length > 500) return { ok: false, error: "Too many cases (max 500)" };
     if (!input.caseIds.every((id) => Number.isFinite(id))) return { ok: false, error: "Invalid case IDs" };
@@ -101,6 +105,8 @@ export async function bulkRestoreCleared(input: {
   caseIds: number[];
 }): Promise<Result> {
   try {
+    const guard = await requireCapability("case.finalize");
+    if (!guard.ok) return { ok: false, error: "You don't have permission to restore checks." };
     if (!input.caseIds.length) return { ok: false, error: "No cases to restore" };
     if (input.caseIds.length > 500) return { ok: false, error: "Too many cases (max 500)" };
     if (!input.caseIds.every((id) => Number.isFinite(id))) return { ok: false, error: "Invalid case IDs" };

--- a/src/app/api/cases/[id]/route.ts
+++ b/src/app/api/cases/[id]/route.ts
@@ -446,17 +446,20 @@ export const PATCH = async (
         externalId: "external_id",
       };
 
+      // Column names come only from the fixed map above (never from request
+      // data) — sql.raw() only ever sees a trusted column name here. Values
+      // are bound as query parameters via the sql`` tag rather than
+      // string-concatenated, so no manual escaping is needed.
       const updates = Object.entries(caseFields)
         .filter(([k]) => CASE_FIELD_MAP[k])
         .map(([k, v]) => {
-          const col = CASE_FIELD_MAP[k];
-          if (v === null) return `${col} = NULL`;
-          return `${col} = '${String(v).replace(/'/g, "''")}'`;
+          const col = sql.raw(CASE_FIELD_MAP[k]);
+          return v === null ? sql`${col} = NULL` : sql`${col} = ${v}`;
         });
 
       if (updates.length > 0) {
         await db.execute(
-          sql`UPDATE cases SET ${sql.raw(updates.join(", "))}, updated_at = NOW() WHERE client_id = ${caseId}`,
+          sql`UPDATE cases SET ${sql.join(updates, sql`, `)}, updated_at = NOW() WHERE client_id = ${caseId}`,
         );
       }
     }
@@ -495,22 +498,21 @@ export const PATCH = async (
         markedOverpaid: "marked_overpaid",
       };
 
+      // Column names come only from the fixed map above; values are bound as
+      // query parameters via the sql`` tag rather than string-concatenated.
       const updates = Object.entries(feeFields)
         .filter(([k]) => FEE_FIELD_MAP[k])
         .map(([k, v]) => {
-          const col = FEE_FIELD_MAP[k];
-          if (v === null) return `${col} = NULL`;
-          if (typeof v === "boolean") return `${col} = ${v}`;
-          if (typeof v === "number") return `${col} = ${v}`;
-          return `${col} = '${String(v).replace(/'/g, "''")}'`;
+          const col = sql.raw(FEE_FIELD_MAP[k]);
+          return v === null ? sql`${col} = NULL` : sql`${col} = ${v}`;
         });
 
       // When isClosed flips, also stamp/clear closed_at so the fees-closed
       // page can show "closed on …" without the client having to track time.
       if (feeFields.isClosed === true) {
-        updates.push("closed_at = NOW()");
+        updates.push(sql`closed_at = NOW()`);
       } else if (feeFields.isClosed === false) {
-        updates.push("closed_at = NULL");
+        updates.push(sql`closed_at = NULL`);
       }
 
       // Explicitly (re-)marking a case overpaid also clears any earlier
@@ -519,7 +521,7 @@ export const PATCH = async (
       // invisible there even after this deliberate re-add, since the page's
       // query excludes on overpaid_dismissed_at regardless of marked_overpaid.
       if (feeFields.markedOverpaid === true) {
-        updates.push("overpaid_dismissed_at = NULL");
+        updates.push(sql`overpaid_dismissed_at = NULL`);
       }
 
       // Setting Remarks to "FEE PETITION APPROVED" also checks the Fee
@@ -548,7 +550,7 @@ export const PATCH = async (
         // and a real footgun for closed ones (the trigger skips closed
         // records entirely, so a stray write here would actually persist).
         await db.execute(sql`
-          UPDATE fee_records SET ${sql.raw(updates.join(", "))}, updated_at = NOW()
+          UPDATE fee_records SET ${sql.join(updates, sql`, `)}, updated_at = NOW()
           WHERE case_id = ${caseId}
         `);
       }
@@ -556,34 +558,26 @@ export const PATCH = async (
 
     // Update user_details fields if provided
     if (userDetailsFields && Object.keys(userDetailsFields).length > 0) {
-      const UD_FIELD_MAP: Record<string, string> = {
-        ssnLast4: "ssn_last4",
-        chronicleId: "chronicle_id",
-      };
+      const UD_FIELD_MAP = {
+        ssnLast4: "ssnLast4",
+        chronicleId: "chronicleId",
+      } as const;
 
-      const colDefs: { col: string; sqlVal: string }[] = [];
+      const udUpdates: Partial<typeof userDetails.$inferInsert> = {};
       for (const [k, v] of Object.entries(userDetailsFields)) {
-        const col = UD_FIELD_MAP[k];
+        const col = UD_FIELD_MAP[k as keyof typeof UD_FIELD_MAP];
         if (!col) continue;
-        let sqlVal: string;
-        if (v === null) sqlVal = "NULL";
-        else if (typeof v === "number") sqlVal = String(v);
-        else sqlVal = `'${String(v).replace(/'/g, "''")}'`;
-        colDefs.push({ col, sqlVal });
+        (udUpdates as Record<string, string | number | boolean | null>)[col] = v;
       }
 
-      if (colDefs.length > 0) {
-        const insertCols = colDefs.map((d) => d.col).join(", ");
-        const insertVals = colDefs.map((d) => d.sqlVal).join(", ");
-        const conflictSet = colDefs.map((d) => `${d.col} = ${d.sqlVal}`).join(", ");
-        await db.execute(
-          sql`
-            INSERT INTO user_details (case_id, ${sql.raw(insertCols)}, updated_at)
-            VALUES (${caseId}, ${sql.raw(insertVals)}, NOW())
-            ON CONFLICT (case_id) DO UPDATE
-              SET ${sql.raw(conflictSet)}, updated_at = NOW()
-          `,
-        );
+      if (Object.keys(udUpdates).length > 0) {
+        await db
+          .insert(userDetails)
+          .values({ caseId, ...udUpdates })
+          .onConflictDoUpdate({
+            target: userDetails.caseId,
+            set: { ...udUpdates, updatedAt: new Date() },
+          });
       }
     }
 

--- a/src/app/api/cases/[id]/route.ts
+++ b/src/app/api/cases/[id]/route.ts
@@ -3,7 +3,8 @@ import { z } from "zod";
 import { db } from "@/lib/db";
 import { cases, feeRecords, feePetitions, activityLog, userDetails } from "@/lib/db/schema";
 import { eq, desc, sql } from "drizzle-orm";
-import { requireCapability, requireAdmin, guardStatus } from "@/lib/auth-helpers";
+import { auth } from "@/auth";
+import { requireCapability, requireAdmin, guardStatus, sessionHasCapability } from "@/lib/auth-helpers";
 
 // Loose on purpose — the actual set of writable columns is whitelisted by
 // CASE_FIELD_MAP/FEE_FIELD_MAP/UD_FIELD_MAP below. This just rejects a
@@ -49,6 +50,12 @@ export const GET = async (
   context: { params: { id: string } | Promise<{ id: string }> },
 ) => {
   try {
+    const session = await auth();
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+    }
+    const canViewPii = sessionHasCapability(session, "case.editPii");
+
     const caseId = await resolveParams(context);
 
     if (isNaN(caseId)) {
@@ -216,9 +223,10 @@ export const GET = async (
       winSheetLink: row.winSheetLink ?? null,
       winSheetLinkText: row.winSheetLinkText ?? null,
 
-      // PDF-extracted fields
-      fullSsn: row.fullSsn || null,
-      dob: row.dob || null,
+      // PDF-extracted fields — SSN/DOB are identity PII, gated by case.editPii
+      // on read as well as write (write gate lives in PATCH below).
+      fullSsn: canViewPii ? row.fullSsn || null : null,
+      dob: canViewPii ? row.dob || null : null,
       email: row.email || null,
       phone: row.phone || null,
       primaryDiagnosis: row.primaryDiagnosis || null,
@@ -303,12 +311,12 @@ export const GET = async (
         country: row.udCountry || null,
         cellPhone: row.udCellPhone || null,
         email: row.udEmail || null,
-        ssn: row.udSsn || null,
-        dateOfBirth: row.udDateOfBirth || null,
+        ssn: canViewPii ? row.udSsn || null : null,
+        dateOfBirth: canViewPii ? row.udDateOfBirth || null : null,
         ageAtApproval: row.udAgeAtApproval || null,
-        placeOfBirth: row.udPlaceOfBirth || null,
-        mothersName: row.udMothersName || null,
-        fathersName: row.udFathersName || null,
+        placeOfBirth: canViewPii ? row.udPlaceOfBirth || null : null,
+        mothersName: canViewPii ? row.udMothersName || null : null,
+        fathersName: canViewPii ? row.udFathersName || null : null,
       },
 
       // Activity log

--- a/src/app/api/chronicle/search/route.ts
+++ b/src/app/api/chronicle/search/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { searchChronicleClients } from "@/lib/chronicle-client";
+import { requirePageAccess, guardStatus } from "@/lib/auth-helpers";
 
 // ============================================================================
 // POST /api/chronicle/search — Search Chronicle clients (test/lookup helper)
@@ -18,6 +19,14 @@ const bodySchema = z.object({
 
 export const POST = async (req: NextRequest) => {
   try {
+    const guard = await requirePageAccess("chronicle");
+    if (!guard.ok) {
+      return NextResponse.json(
+        { error: guard.error },
+        { status: guardStatus(guard.error) },
+      );
+    }
+
     const rawBody = await req.json().catch(() => null);
     const parsedBody = bodySchema.safeParse(rawBody);
     if (!parsedBody.success) {

--- a/src/app/api/daily-metrics/route.ts
+++ b/src/app/api/daily-metrics/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import type { Session } from "next-auth";
 import { auth } from "@/auth";
 import { db } from "@/lib/db";
@@ -6,6 +7,19 @@ import { dailyMetrics } from "@/lib/db/schema";
 import { eq, and, sql } from "drizzle-orm";
 import { sessionHasCapability } from "@/lib/auth-helpers";
 import { namesMatch } from "@/lib/formatters";
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const metricCountSchema = z.number().int().min(0).optional();
+const metricEntrySchema = z.object({
+  agent: z.string().trim().min(1),
+  date: z.string().regex(DATE_RE, "Invalid date (expected YYYY-MM-DD)"),
+  ssaCalls: metricCountSchema,
+  clientCallsIb: metricCountSchema,
+  clientCallsOb: metricCountSchema,
+  winSheetsCreated: metricCountSchema,
+  faxSent: metricCountSchema,
+  notes: z.string().trim().max(2000).nullable().optional(),
+});
 
 // Members can only log their own calls — agent_name is matched against the
 // session's display name (team_members.name mirrors users.name for real
@@ -141,10 +155,14 @@ export const POST = async (req: NextRequest) => {
     if (body.entries && Array.isArray(body.entries)) {
       const results = [];
       let skipped = 0;
-      for (const entry of body.entries) {
+      for (const rawEntry of body.entries) {
+        const parsedEntry = metricEntrySchema.safeParse(rawEntry);
+        if (!parsedEntry.success) {
+          skipped++;
+          continue;
+        }
         const { agent, date, ssaCalls, clientCallsIb, clientCallsOb, winSheetsCreated, faxSent, notes } =
-          entry;
-        if (!agent || typeof agent !== "string" || !date) continue;
+          parsedEntry.data;
         if (!canWriteAgent(session, agent)) {
           skipped++;
           continue;
@@ -181,11 +199,18 @@ export const POST = async (req: NextRequest) => {
     }
 
     // Single mode
-    const { agent, date, ssaCalls, clientCallsIb, clientCallsOb, winSheetsCreated, faxSent, notes } = body;
-
-    if (!agent || typeof agent !== "string") {
-      return NextResponse.json({ error: "agent is required" }, { status: 400 });
+    const parsedSingle = metricEntrySchema
+      .extend({ date: z.string().regex(DATE_RE, "Invalid date (expected YYYY-MM-DD)").optional() })
+      .safeParse(body);
+    if (!parsedSingle.success) {
+      return NextResponse.json(
+        { error: "Invalid request body", details: parsedSingle.error.flatten() },
+        { status: 422 },
+      );
     }
+    const { agent, date, ssaCalls, clientCallsIb, clientCallsOb, winSheetsCreated, faxSent, notes } =
+      parsedSingle.data;
+
     if (!canWriteAgent(session, agent)) {
       return NextResponse.json(
         { error: "You can only log your own calls." },

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { auth } from "@/auth";
 import { db } from "@/lib/db";
 import { notifications } from "@/lib/db/schema";
@@ -9,6 +10,20 @@ import { namesMatch } from "@/lib/formatters";
 // including leads/admins, sees these (unlike the other types, which are
 // team-wide operational alerts visible to anyone with page access).
 const AGENT_ONLY_TYPES = new Set(["follow_up_due"]);
+
+const postBodySchema = z.object({
+  type: z.enum(["case_aging", "fee_payment", "call_target_missed", "case_assigned", "follow_up_due"]),
+  severity: z.enum(["info", "warning", "critical"]).optional(),
+  title: z.string().trim().min(1).max(300),
+  message: z.string().trim().min(1),
+  caseId: z.number().int().nullable().optional(),
+  agentName: z.string().trim().max(100).nullable().optional(),
+});
+
+const patchBodySchema = z.union([
+  z.object({ markAllRead: z.literal(true) }),
+  z.object({ ids: z.array(z.string()).min(1) }),
+]);
 
 // ============================================================================
 // GET /api/notifications
@@ -96,15 +111,19 @@ export const GET = async (req: NextRequest) => {
 // ============================================================================
 export const POST = async (req: NextRequest) => {
   try {
-    const body = await req.json();
-    const { type, severity, title, message, caseId, agentName } = body;
+    const session = await auth();
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+    }
 
-    if (!type || !title || !message) {
+    const parsedBody = postBodySchema.safeParse(await req.json());
+    if (!parsedBody.success) {
       return NextResponse.json(
-        { error: "type, title, and message are required" },
-        { status: 400 },
+        { error: "Invalid request body", details: parsedBody.error.flatten() },
+        { status: 422 },
       );
     }
+    const { type, severity, title, message, caseId, agentName } = parsedBody.data;
 
     const [row] = await db
       .insert(notifications)
@@ -134,9 +153,21 @@ export const POST = async (req: NextRequest) => {
 // ============================================================================
 export const PATCH = async (req: NextRequest) => {
   try {
-    const body = await req.json();
+    const session = await auth();
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+    }
 
-    if (body.markAllRead) {
+    const parsedBody = patchBodySchema.safeParse(await req.json());
+    if (!parsedBody.success) {
+      return NextResponse.json(
+        { error: "Invalid request body", details: parsedBody.error.flatten() },
+        { status: 422 },
+      );
+    }
+    const body = parsedBody.data;
+
+    if ("markAllRead" in body) {
       await db
         .update(notifications)
         .set({ isRead: true, readAt: new Date() })
@@ -145,19 +176,12 @@ export const PATCH = async (req: NextRequest) => {
       return NextResponse.json({ status: "ok", message: "All marked as read" });
     }
 
-    if (body.ids && Array.isArray(body.ids) && body.ids.length > 0) {
-      await db
-        .update(notifications)
-        .set({ isRead: true, readAt: new Date() })
-        .where(inArray(notifications.id, body.ids));
+    await db
+      .update(notifications)
+      .set({ isRead: true, readAt: new Date() })
+      .where(inArray(notifications.id, body.ids));
 
-      return NextResponse.json({ status: "ok", count: body.ids.length });
-    }
-
-    return NextResponse.json(
-      { error: "ids or markAllRead required" },
-      { status: 400 },
-    );
+    return NextResponse.json({ status: "ok", count: body.ids.length });
   } catch (error) {
     console.error("PATCH /api/notifications error:", error);
     return NextResponse.json(

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,8 +1,20 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { db } from "@/lib/db";
 import { appSettings, feeCapHistory } from "@/lib/db/schema";
 import { eq, sql, desc } from "drizzle-orm";
 import { requireAdmin } from "@/lib/auth-helpers";
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const settingsValueSchema = z.union([z.string(), z.number(), z.boolean()]);
+const feeCapBodySchema = z.object({
+  effectiveDate: z.string().regex(DATE_RE, "Invalid date (expected YYYY-MM-DD)"),
+  capAmount: z
+    .union([z.string(), z.number()])
+    .transform((v) => Number(v))
+    .refine((v) => Number.isFinite(v) && v > 0, "capAmount must be a positive number"),
+  notes: z.string().trim().max(200).nullable().optional(),
+});
 
 // ============================================================================
 // GET /api/settings
@@ -77,7 +89,14 @@ export const PATCH = async (req: NextRequest) => {
 
     // Update settings
     if (body.settings && typeof body.settings === "object") {
-      const entries = Object.entries(body.settings) as [string, string][];
+      const parsedSettings = z.record(z.string(), settingsValueSchema).safeParse(body.settings);
+      if (!parsedSettings.success) {
+        return NextResponse.json(
+          { error: "Invalid settings values", details: parsedSettings.error.flatten() },
+          { status: 422 },
+        );
+      }
+      const entries = Object.entries(parsedSettings.data);
       for (const [key, value] of entries) {
         await db
           .update(appSettings)
@@ -89,13 +108,14 @@ export const PATCH = async (req: NextRequest) => {
 
     // Add fee cap
     if (body.feeCap) {
-      const { effectiveDate, capAmount, notes } = body.feeCap;
-      if (!effectiveDate || !capAmount) {
+      const parsedFeeCap = feeCapBodySchema.safeParse(body.feeCap);
+      if (!parsedFeeCap.success) {
         return NextResponse.json(
-          { error: "effectiveDate and capAmount required" },
-          { status: 400 },
+          { error: "Invalid fee cap", details: parsedFeeCap.error.flatten() },
+          { status: 422 },
         );
       }
+      const { effectiveDate, capAmount, notes } = parsedFeeCap.data;
       const [row] = await db
         .insert(feeCapHistory)
         .values({
@@ -116,10 +136,14 @@ export const PATCH = async (req: NextRequest) => {
 
     // Delete fee cap
     if (body.deleteFeeCap) {
+      const parsedId = z.coerce.number().int().positive().safeParse(body.deleteFeeCap);
+      if (!parsedId.success) {
+        return NextResponse.json({ error: "Invalid deleteFeeCap id" }, { status: 422 });
+      }
       await db
         .delete(feeCapHistory)
-        .where(eq(feeCapHistory.id, body.deleteFeeCap));
-      return NextResponse.json({ status: "ok", deleted: body.deleteFeeCap });
+        .where(eq(feeCapHistory.id, parsedId.data));
+      return NextResponse.json({ status: "ok", deleted: parsedId.data });
     }
 
     return NextResponse.json(


### PR DESCRIPTION
## Summary
Full security audit of the app (not scoped to a diff) surfaced several gaps, fixed here:

**Blockers**
- `overpaid-cases/actions.ts`: `upsertOverpaidCase`, `bulkMarkCleared`, `bulkRestoreCleared` had no capability check — any authenticated user could write overpaid amounts and flip checks-cleared status. Now require `case.finalize`, matching their siblings in the same file.
- `api/cases/[id]` GET: returned full SSN, DOB, place of birth, mother's/father's name to any authenticated user regardless of role. Now requires a session and gates those fields behind `case.editPii` (the same capability that already gated writes to them).
- `api/chronicle/search`: missing the `requirePageAccess("chronicle")` guard present on its sibling routes (`pull`, `pdf-parse`).

**Warnings**
- `api/cases/[id]` PATCH: case/fee/user-details field updates were hand-escaped into raw SQL strings. Values are now bound as query parameters via the `sql` tag; `sql.raw()` is only ever used for column names from a fixed allowlist.
- `api/notifications` POST/PATCH: added session check + Zod validation (previously accepted any body shape).
- `api/settings` PATCH: added Zod validation for `feeCap`/`settings`/`deleteFeeCap` (route was already `requireAdmin()`-gated).
- `inbound-calls/actions.ts`: `bulkImportInboundCalls` had no session check.
- `api/daily-metrics` POST: added Zod validation for both batch and single-entry modes (date format, non-negative integers).