### PR TITLE
fix: type FeeEditModal caseId as number

### DIFF
--- a/src/app/cases/[id]/page.tsx
+++ b/src/app/cases/[id]/page.tsx
@@ -786,7 +786,7 @@ const CaseDetailPage = () => {
       {feeModalOpen && caseData && (
         <FeeEditModal
           dark={dark}
-          caseId={id}
+          caseId={caseData.id}
           t16Retro={caseData.t16Retro}
           t16FeeDue={caseData.t16FeeDue}
           t16FeeReceived={caseData.t16FeeReceived}

--- a/src/components/cases/FeeEditModal.tsx
+++ b/src/components/cases/FeeEditModal.tsx
@@ -12,7 +12,7 @@ const toStrFeeDue = (v: number | null) => ((v ?? 0) > 0 ? String(v) : "");
 
 interface FeeEditModalProps {
   dark: boolean;
-  caseId: string;
+  caseId: number;
   t16Retro: number;
   t16FeeDue: number | null;
   t16FeeReceived: number;


### PR DESCRIPTION
## Summary
- `FeeEditModal`'s `caseId` prop was typed as `string`, the only outlier among sibling case-detail components (`CaseDetailSheet`, `FeePaymentPanel`, `NotesModal`, `MyCaseDocumentsDialog` all type it `number`).
- Now typed `number`; the caller passes `caseData.id` (already a number from the API response) instead of the string route param.