### PR TITLE
fix: never grant admin/archive/settings page access to non-admin roles

### DIFF
--- a/src/lib/access/resolve.ts
+++ b/src/lib/access/resolve.ts
@@ -21,7 +21,9 @@ export interface AccessOverrides {
   capabilities?: CapabilityOverrides;
 }
 
-const isAdminRole = (role: string | null | undefined): boolean =>
+// Local, edge-safe copy of the same check as auth-helpers.ts's isAdminRole —
+// can't import that here since its file is marked "server-only".
+const roleIsAdmin = (role: string | null | undefined): boolean =>
   role === "admin" || role === "system_admin";
 
 // These pages have no partial-access model — their route (and API, for
@@ -43,7 +45,7 @@ export const effectivePages = (
     if (granted) set.add(key as PageKey);
     else set.delete(key as PageKey);
   }
-  if (!isAdminRole(role)) {
+  if (!roleIsAdmin(role)) {
     for (const key of ADMIN_ONLY_PAGES) set.delete(key);
   }
   return [...set];

--- a/src/lib/access/resolve.ts
+++ b/src/lib/access/resolve.ts
@@ -21,6 +21,17 @@ export interface AccessOverrides {
   capabilities?: CapabilityOverrides;
 }
 
+const isAdminRole = (role: string | null | undefined): boolean =>
+  role === "admin" || role === "system_admin";
+
+// These pages have no partial-access model — their route (and API, for
+// Settings) checks the literal admin/system_admin role server-side, not page
+// access or a capability. Granting them via a per-user override would show
+// the page in the sidebar and let navigation start, but every subsequent
+// server check would still reject a non-admin — a page override can never
+// actually make these usable, so it must never be offered as one.
+const ADMIN_ONLY_PAGES: readonly PageKey[] = ["admin", "archive", "settings"];
+
 /** Effective set of pages a user may open: role default ⊕ overrides. */
 export const effectivePages = (
   role: string | null | undefined,
@@ -31,6 +42,9 @@ export const effectivePages = (
   for (const [key, granted] of Object.entries(pageOverrides)) {
     if (granted) set.add(key as PageKey);
     else set.delete(key as PageKey);
+  }
+  if (!isAdminRole(role)) {
+    for (const key of ADMIN_ONLY_PAGES) set.delete(key);
   }
   return [...set];
 };


### PR DESCRIPTION
## Summary
- A "Test Lead" test account had a per-user page-access override granting `settings` and `archive` — both hard admin-role-gated at the API layer with no partial-access model. The override let the sidebar show them and navigation start, but Settings has no server-side guard (unlike Archive/Admin, which redirect), so it rendered a broken shell with every fetch 403ing.
- `effectivePages()` in `resolve.ts` now strips `admin`, `archive`, and `settings` from the effective page set for any non-admin role, regardless of overrides — since granting page access to these three can never actually work, it's no longer allowed to take effect.
- This also makes direct navigation to `/settings` for a non-admin redirect cleanly, matching Archive/Admin's existing behavior, since the same `pages` array drives the edge middleware's gate.
- Takes effect on next sign-in (page list is baked into the session token at login).