### PR TITLE
fix: fall back to computed MyCase URL when external_id is unset

### DIFF
--- a/src/components/cases/CaseDetailSheet.tsx
+++ b/src/components/cases/CaseDetailSheet.tsx
@@ -28,6 +28,7 @@ import {
   SheetDescription,
 } from "@/components/ui/sheet";
 import { themeClasses } from "@/lib/theme-classes";
+import { buildMyCaseUrl } from "@/lib/import/case-link";
 import { MyCaseDocumentsDialog } from "@/components/cases/MyCaseDocumentsDialog";
 import { FeesConfBadge } from "@/components/cases/FeesConfBadge";
 import {
@@ -639,7 +640,7 @@ export default function CaseDetailSheet({
                     <p className={`${val} text-indigo-500`}>#{data.id}</p>
                   </div>
                   <a
-                    href={data.externalId || `https://rgdr.mycase.com/court_cases/${data.id}`}
+                    href={data.externalId || buildMyCaseUrl(data.id)}
                     target="_blank"
                     rel="noopener noreferrer"
                     className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-[12px] font-bold uppercase transition-colors ${dark ? "bg-indigo-900/30 text-indigo-400 hover:bg-indigo-900/50" : "bg-indigo-50 text-indigo-600 hover:bg-indigo-100"}`}

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -1593,25 +1593,22 @@ export const FeeRecordsTable = ({
                       {/* overflow-hidden keeps the sub-line from spilling past
                           the frozen column onto Assigned during h-scroll. */}
                       <div className="flex flex-col gap-0.5 overflow-hidden">
-                        {c.externalId ? (
-                          <a
-                            href={c.externalId}
-                            target="_blank"
-                            rel="noreferrer"
-                            onClick={(e) => e.stopPropagation()}
-                            className={`inline-flex items-center gap-1 max-w-full ${t.text} font-semibold hover:underline`}
-                          >
-                            <span className="truncate">{c.name}</span>
-                            <ExternalLink
-                              className="h-3 w-3 shrink-0 opacity-50"
-                              aria-hidden="true"
-                            />
-                          </a>
-                        ) : (
-                          <span className={`${t.text} font-semibold truncate`}>
-                            {c.name}
-                          </span>
-                        )}
+                        <a
+                          // Same fallback CaseDetailSheet's MyCase button uses
+                          // — external_id isn't populated for every case, but
+                          // the case's own numeric id still resolves on MyCase.
+                          href={c.externalId || `https://rgdr.mycase.com/court_cases/${c.id}`}
+                          target="_blank"
+                          rel="noreferrer"
+                          onClick={(e) => e.stopPropagation()}
+                          className={`inline-flex items-center gap-1 max-w-full ${t.text} font-semibold hover:underline`}
+                        >
+                          <span className="truncate">{c.name}</span>
+                          <ExternalLink
+                            className="h-3 w-3 shrink-0 opacity-50"
+                            aria-hidden="true"
+                          />
+                        </a>
                         <div className="flex items-center gap-2 text-[13px] leading-none min-w-0">
                           {(() => {
                             // Mirror the Claim column's optimistic value so the

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -23,6 +23,7 @@ import {
 } from "lucide-react";
 
 import { themeClasses } from "@/lib/theme-classes";
+import { buildMyCaseUrl } from "@/lib/import/case-link";
 import { FeePaymentPanel } from "@/components/cases/FeePaymentPanel";
 import { FeeAmountCell } from "@/components/cases/FeeAmountCell";
 import { FeesConfBadge } from "@/components/cases/FeesConfBadge";
@@ -1594,10 +1595,7 @@ export const FeeRecordsTable = ({
                           the frozen column onto Assigned during h-scroll. */}
                       <div className="flex flex-col gap-0.5 overflow-hidden">
                         <a
-                          // Same fallback CaseDetailSheet's MyCase button uses
-                          // — external_id isn't populated for every case, but
-                          // the case's own numeric id still resolves on MyCase.
-                          href={c.externalId || `https://rgdr.mycase.com/court_cases/${c.id}`}
+                          href={c.externalId || buildMyCaseUrl(c.id)}
                           target="_blank"
                           rel="noreferrer"
                           onClick={(e) => e.stopPropagation()}

--- a/src/components/fee-petitions/FeePetitions.tsx
+++ b/src/components/fee-petitions/FeePetitions.tsx
@@ -1269,19 +1269,18 @@ export const FeePetitions = () => {
                         className={`${tdBase} ${t.text} font-semibold w-40 sticky left-10 z-10 ${stickyBg} ${stickyHover}`}
                         title={row.claimant}
                       >
-                        {row.externalId ? (
-                          <a
-                            href={row.externalId}
-                            target="_blank"
-                            rel="noreferrer"
-                            className={`inline-flex items-center gap-1 max-w-full truncate hover:underline ${dark ? "text-indigo-400" : "text-indigo-600"}`}
-                          >
-                            <span className="truncate">{row.claimant}</span>
-                            <ExternalLink className="h-3 w-3 shrink-0 opacity-50" aria-hidden="true" />
-                          </a>
-                        ) : (
-                          <span className="truncate block">{row.claimant}</span>
-                        )}
+                        <a
+                          // Same fallback CaseDetailSheet's MyCase button uses
+                          // — external_id isn't populated for every case, but
+                          // the case's own numeric id still resolves on MyCase.
+                          href={row.externalId || `https://rgdr.mycase.com/court_cases/${row.id}`}
+                          target="_blank"
+                          rel="noreferrer"
+                          className={`inline-flex items-center gap-1 max-w-full truncate hover:underline ${dark ? "text-indigo-400" : "text-indigo-600"}`}
+                        >
+                          <span className="truncate">{row.claimant}</span>
+                          <ExternalLink className="h-3 w-3 shrink-0 opacity-50" aria-hidden="true" />
+                        </a>
                         {row.updatedAt && (
                           <p className={`text-[12px] ${t.textMuted} mt-0.5 font-normal`}>
                             Updated {formatRelativeDate(row.updatedAt)}

--- a/src/components/fee-petitions/FeePetitions.tsx
+++ b/src/components/fee-petitions/FeePetitions.tsx
@@ -26,6 +26,7 @@ import { upsertFeePetition, bulkMarkComplete, bulkRestoreChecklists, bulkImportF
 import { CompletedPetitions } from "./CompletedPetitions";
 import CsvImportModal, { type ColumnDef } from "@/components/modals/CsvImportModal";
 import { parseBool } from "@/lib/import/csv-parser";
+import { buildMyCaseUrl } from "@/lib/import/case-link";
 import { NoteField } from "@/components/shared/NoteField";
 import { FeeAmountCell } from "@/components/cases/FeeAmountCell";
 import { useCapabilities } from "@/hooks/useCapabilities";
@@ -1270,10 +1271,7 @@ export const FeePetitions = () => {
                         title={row.claimant}
                       >
                         <a
-                          // Same fallback CaseDetailSheet's MyCase button uses
-                          // — external_id isn't populated for every case, but
-                          // the case's own numeric id still resolves on MyCase.
-                          href={row.externalId || `https://rgdr.mycase.com/court_cases/${row.id}`}
+                          href={row.externalId || buildMyCaseUrl(row.id)}
                           target="_blank"
                           rel="noreferrer"
                           className={`inline-flex items-center gap-1 max-w-full truncate hover:underline ${dark ? "text-indigo-400" : "text-indigo-600"}`}

--- a/src/lib/import/case-link.ts
+++ b/src/lib/import/case-link.ts
@@ -22,6 +22,17 @@ export const extractMyCaseId = (url: string | null | undefined): number | null =
   return m ? Number(m[1]) : null;
 };
 
+// This firm's MyCase tenant — confirmed working 2026-07-14.
+const MYCASE_BASE_URL = "https://rgdr.mycase.com/court_cases/";
+
+/**
+ * Build a MyCase court_cases URL from a case's own numeric id. Used as a
+ * fallback wherever a case's stored `external_id` link hasn't been
+ * populated by a sync — the case's own id still resolves on MyCase.
+ */
+export const buildMyCaseUrl = (id: number | string): string =>
+  `${MYCASE_BASE_URL}${id}`;
+
 // Chronicle client URLs look like
 //   https://app.chroniclelegal.com/dashboard/clients/12345
 // The path segment before /clients/ can vary, so allow any prefix.


### PR DESCRIPTION
## Summary
- Reported by Ms. Jazz (on behalf of DeeAnn): some cases show a working MyCase link in the Win Sheet Quick Look panel but no hyperlink on the case name in the table.
- Root cause: the Quick Look panel's MyCase button (`CaseDetailSheet.tsx`) falls back to a computed URL (`https://rgdr.mycase.com/court_cases/${id}`) when `external_id` isn't populated; the case-name links in `FeeRecordsTable.tsx` (Master Fees / Fees Closed) and `FeePetitions.tsx` had no such fallback and silently rendered plain text instead.
- Both now use the same fallback, confirmed working against a real case.