### PR TITLE
Move Fees Closed from a per-row column to a batch action on Master Fees

### DIFF
--- a/src/components/cases/BulkFeesClosedConfirmDialog.tsx
+++ b/src/components/cases/BulkFeesClosedConfirmDialog.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { Check, AlertCircle, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface BulkFeesClosedConfirmDialogProps {
+  open: boolean;
+  caseIds: number[];
+  onClose: () => void;
+  onClosed: () => void;
+}
+
+// Closes each selected case through the same PATCH the single-row Fees
+// Closed checkbox used, so permission checks, the closed_at stamp, and
+// activity logging all stay identical to that path — just fanned out.
+const closeSingleCase = async (caseId: number, signal: AbortSignal) => {
+  const res = await fetch(`/api/cases/${caseId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      feeFields: { isClosed: true, feesClosedTrigger: null, nextFollowUpDate: null },
+      logMessage: "Fees Closed checked — moved to Fees Closed.",
+    }),
+    signal,
+  });
+  if (!res.ok) {
+    const j = await res.json().catch(() => ({}));
+    throw new Error((j as { error?: string }).error ?? `Save failed (${res.status})`);
+  }
+};
+
+export function BulkFeesClosedConfirmDialog({
+  open,
+  caseIds,
+  onClose,
+  onClosed,
+}: BulkFeesClosedConfirmDialogProps) {
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const controllerRef = useRef<AbortController | null>(null);
+
+  const count = caseIds.length;
+
+  const handleConfirm = async () => {
+    if (submitting) return;
+    controllerRef.current?.abort();
+    const controller = new AbortController();
+    controllerRef.current = controller;
+    setSubmitting(true);
+    setError(null);
+
+    const results = await Promise.allSettled(
+      caseIds.map((id) => closeSingleCase(id, controller.signal)),
+    );
+    if (controller.signal.aborted) return;
+
+    const failed = results.filter((r) => r.status === "rejected").length;
+    setSubmitting(false);
+
+    if (failed > 0) {
+      setError(
+        failed === count
+          ? `Failed to close ${failed === 1 ? "the case" : `all ${failed} cases`}.`
+          : `${failed} of ${count} cases failed to close — the rest were closed successfully.`,
+      );
+      onClosed();
+      return;
+    }
+    onClosed();
+    onClose();
+  };
+
+  const handleOpenChange = (v: boolean) => {
+    if (!v && !submitting) {
+      controllerRef.current?.abort();
+      setError(null);
+      onClose();
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            Close {count === 1 ? "1 case" : `${count} cases`}?
+          </DialogTitle>
+          <DialogDescription>
+            {count === 1
+              ? "This case will be moved to Fees Closed and removed from the active dashboard."
+              : `These ${count} cases will be moved to Fees Closed and removed from the active dashboard.`}
+          </DialogDescription>
+        </DialogHeader>
+
+        {error && (
+          <p role="alert" className="flex items-center gap-2 text-sm text-destructive">
+            <AlertCircle aria-hidden="true" className="h-4 w-4 shrink-0" />
+            {error}
+          </p>
+        )}
+
+        <DialogFooter className="mt-2 gap-2 sm:gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onClose}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="default"
+            onClick={handleConfirm}
+            disabled={submitting}
+          >
+            {submitting ? (
+              <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" />
+            ) : (
+              <Check aria-hidden="true" className="h-4 w-4" />
+            )}
+            Fees Closed
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/cases/BulkFeesClosedConfirmDialog.tsx
+++ b/src/components/cases/BulkFeesClosedConfirmDialog.tsx
@@ -16,8 +16,18 @@ interface BulkFeesClosedConfirmDialogProps {
   open: boolean;
   caseIds: number[];
   onClose: () => void;
-  onClosed: () => void;
+  // Fired after a partial failure so the parent can refresh table data
+  // (some cases did close) without touching the row selection.
+  onProgress: () => void;
+  // Fired only once every targeted case has closed — parent clears the
+  // selection and refreshes.
+  onSuccess: () => void;
 }
+
+// Closing hundreds of selected cases at once shouldn't open hundreds of
+// simultaneous connections to the (serverless) DB — cap how many PATCHes
+// are in flight together, not how many cases can be closed in one go.
+const CONCURRENCY = 8;
 
 // Closes each selected case through the same PATCH the single-row Fees
 // Closed checkbox used, so permission checks, the closed_at stamp, and
@@ -38,44 +48,79 @@ const closeSingleCase = async (caseId: number, signal: AbortSignal) => {
   }
 };
 
+// Runs the closes CONCURRENCY at a time and returns the ids that failed.
+const closeCasesThrottled = async (
+  ids: number[],
+  signal: AbortSignal,
+): Promise<number[]> => {
+  const failed: number[] = [];
+  for (let i = 0; i < ids.length; i += CONCURRENCY) {
+    const batch = ids.slice(i, i + CONCURRENCY);
+    const results = await Promise.allSettled(
+      batch.map((id) => closeSingleCase(id, signal)),
+    );
+    if (signal.aborted) return failed;
+    batch.forEach((id, j) => {
+      if (results[j].status === "rejected") failed.push(id);
+    });
+  }
+  return failed;
+};
+
 export function BulkFeesClosedConfirmDialog({
   open,
   caseIds,
   onClose,
-  onClosed,
+  onProgress,
+  onSuccess,
 }: BulkFeesClosedConfirmDialogProps) {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // The working set — shrinks to just the failed ids after a partial
+  // failure, so retrying only re-attempts the cases that actually failed
+  // instead of re-closing (and re-stamping closed_at on) ones that already
+  // succeeded.
+  const [remainingIds, setRemainingIds] = useState<number[]>(caseIds);
   const controllerRef = useRef<AbortController | null>(null);
 
-  const count = caseIds.length;
+  // Reset the working set to the fresh selection each time the dialog opens
+  // — adjusted during render (not an effect) per
+  // https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+  const [wasOpen, setWasOpen] = useState(open);
+  if (open !== wasOpen) {
+    setWasOpen(open);
+    if (open) {
+      setRemainingIds(caseIds);
+      setError(null);
+    }
+  }
+
+  const count = remainingIds.length;
 
   const handleConfirm = async () => {
-    if (submitting) return;
+    if (submitting || count === 0) return;
     controllerRef.current?.abort();
     const controller = new AbortController();
     controllerRef.current = controller;
     setSubmitting(true);
     setError(null);
 
-    const results = await Promise.allSettled(
-      caseIds.map((id) => closeSingleCase(id, controller.signal)),
-    );
+    const attempted = remainingIds;
+    const failedIds = await closeCasesThrottled(attempted, controller.signal);
     if (controller.signal.aborted) return;
-
-    const failed = results.filter((r) => r.status === "rejected").length;
     setSubmitting(false);
 
-    if (failed > 0) {
+    if (failedIds.length > 0) {
+      setRemainingIds(failedIds);
       setError(
-        failed === count
-          ? `Failed to close ${failed === 1 ? "the case" : `all ${failed} cases`}.`
-          : `${failed} of ${count} cases failed to close — the rest were closed successfully.`,
+        failedIds.length === attempted.length
+          ? `Failed to close ${failedIds.length === 1 ? "the case" : `all ${failedIds.length} cases`}.`
+          : `${failedIds.length} of ${attempted.length} cases failed to close — the rest closed successfully. Try again to retry the failed one${failedIds.length === 1 ? "" : "s"}.`,
       );
-      onClosed();
+      onProgress();
       return;
     }
-    onClosed();
+    onSuccess();
     onClose();
   };
 

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -2675,7 +2675,8 @@ export const FeeRecordsTable = ({
         open={bulkCloseConfirmOpen}
         caseIds={bulkClosePendingIds}
         onClose={() => setBulkCloseConfirmOpen(false)}
-        onClosed={() => {
+        onProgress={() => onImported?.()}
+        onSuccess={() => {
           setSelectedIds(new Set());
           onImported?.();
         }}

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -48,6 +48,7 @@ import MyCaseSyncModal from "@/components/modals/MyCaseSyncModal";
 import NotesModal from "@/components/modals/NotesModal";
 import { ArchiveConfirmDialog } from "./ArchiveConfirmDialog";
 import { FeesClosedConfirmDialog } from "./FeesClosedConfirmDialog";
+import { BulkFeesClosedConfirmDialog } from "./BulkFeesClosedConfirmDialog";
 import { Listbox } from "@/components/shared/Listbox";
 import { caseLevelVisual } from "@/lib/case-level-icons";
 import { buildListboxOptions } from "@/lib/listbox-options";
@@ -235,7 +236,6 @@ export const FeeRecordsTable = ({
   const { data: session } = useSession();
   const isAdmin =
     session?.user?.role === "admin" || session?.user?.role === "system_admin";
-  const isLead = session?.user?.role === "lead";
   const { can } = useCapabilities();
   const canCreate = can("case.create");
   const canFinalize = can("case.finalize");
@@ -270,8 +270,8 @@ export const FeeRecordsTable = ({
     Record<number, Partial<Record<DropdownRowKey, string>>>
   >({});
 
-  // Case targeted by the Fees Closed / Reopen confirmation dialogs.
-  const [closeConfirmCase, setCloseConfirmCase] = useState<CaseRow | null>(null);
+  // Case targeted by the Reopen confirmation dialog (Fees Closed page only —
+  // closing is now a batch action, see bulkCloseConfirmOpen below).
   const [reopenConfirmCase, setReopenConfirmCase] = useState<CaseRow | null>(null);
 
   // Win sheet link inline edit state.
@@ -335,6 +335,8 @@ export const FeeRecordsTable = ({
   >("active_sheet");
   const [bulkOverpaidSaving, setBulkOverpaidSaving] = useState(false);
   const [bulkOverpaidError, setBulkOverpaidError] = useState<string | null>(null);
+  const [bulkCloseConfirmOpen, setBulkCloseConfirmOpen] = useState(false);
+  const [bulkClosePendingIds, setBulkClosePendingIds] = useState<number[]>([]);
   // Optimistic overrides for fee payment totals after panel add/delete.
   // Pending is deliberately absent — it's fully derived (Fee Due minus
   // Received) by the compute_fee_totals trigger, never set optimistically.
@@ -407,6 +409,12 @@ export const FeeRecordsTable = ({
       mode === "closed" ? "fees_closed_sheet" : "active_sheet",
     );
     setArchiveConfirmOpen(true);
+  };
+
+  const handleBatchFeesClosed = () => {
+    if (selectedIds.size === 0) return;
+    setBulkClosePendingIds(Array.from(selectedIds));
+    setBulkCloseConfirmOpen(true);
   };
 
   // Adds the selected cases to the Overpaid Cases page at will — independent
@@ -1159,9 +1167,9 @@ export const FeeRecordsTable = ({
         </div>
       </div>
 
-      {/* Floating batch action pill — fixed to the viewport bottom. Archive
-          and "Add to Overpaid Cases" (at will, independent of the automatic
-          PIF detection) are the two batch actions. */}
+      {/* Floating batch action pill — fixed to the viewport bottom. Fees
+          Closed, Archive, and "Add to Overpaid Cases" (at will, independent
+          of the automatic PIF detection) are the batch actions. */}
       {selectedIds.size > 0 && isAdmin && (
         <div className="pointer-events-none fixed bottom-6 left-0 right-0 z-50 flex flex-col items-center gap-2">
           {bulkOverpaidError && (
@@ -1176,6 +1184,16 @@ export const FeeRecordsTable = ({
             <span className="text-[13px] font-semibold text-gray-300 pr-1 border-r border-white/20 mr-1">
               {selectedIds.size} selected
             </span>
+            {mode !== "closed" && canFinalize && (
+              <button
+                onClick={handleBatchFeesClosed}
+                disabled={bulkCloseConfirmOpen}
+                className="h-7 px-3 rounded-full text-[13px] font-semibold flex items-center gap-1.5 bg-emerald-600 hover:bg-emerald-500 text-white transition-colors disabled:opacity-50"
+              >
+                <Check aria-hidden="true" className="h-3 w-3" />
+                Fees Closed
+              </button>
+            )}
             {mode !== "closed" && canFinalize && (
               <button
                 onClick={handleBatchMarkOverpaid}
@@ -1267,7 +1285,7 @@ export const FeeRecordsTable = ({
                   className={`${thBase} ${t.textSub} text-left ${stickyGroup3}`}
                 />
                 <th
-                  colSpan={canSeeLeaderNotes ? 9 : 8}
+                  colSpan={(isClosedMode ? 8 : 7) + (canSeeLeaderNotes ? 1 : 0)}
                   aria-hidden="true"
                   className={`${thBase} ${t.textSub} text-left ${stickyThRow1}`}
                 />
@@ -1380,7 +1398,11 @@ export const FeeRecordsTable = ({
                 <th className={`${thBase} ${t.textSub} text-left ${stickyTh3}`}>
                   PIF
                 </th>
-                <th className={`${thBase} ${t.textSub} text-left`}>Fees Closed</th>
+                {/* Fees Closed — Fees Closed page only now; closing from
+                    Master Fees is a batch action (see the selection pill). */}
+                {isClosedMode && (
+                  <th className={`${thBase} ${t.textSub} text-left`}>Fees Closed</th>
+                )}
                 <th className={`${thBase} ${t.textSub} text-left`}>Level</th>
                 <th className={`${thBase} ${t.textSub} text-left`}>Claim</th>
                 <th
@@ -1731,12 +1753,14 @@ export const FeeRecordsTable = ({
                         <FeesConfBadge value={cellValue(c, "feesConfirmation")} dark={dark} />
                       )}
                     </td>
-                    {/* Fees Closed — checkbox; check → close dialog; uncheck → reopen dialog */}
-                    <td
-                      className={`${tdBase} text-center`}
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      {mode === "closed" ? (
+                    {/* Fees Closed — Fees Closed page only; checked, unchecking
+                        opens the reopen dialog. Closing from Master Fees is a
+                        batch action now (see the selection pill). */}
+                    {isClosedMode && (
+                      <td
+                        className={`${tdBase} text-center`}
+                        onClick={(e) => e.stopPropagation()}
+                      >
                         <input
                           type="checkbox"
                           checked
@@ -1745,18 +1769,8 @@ export const FeeRecordsTable = ({
                           disabled={!canFinalize}
                           onChange={() => setReopenConfirmCase(c)}
                         />
-                      ) : (isAdmin || isLead) && canFinalize ? (
-                        <input
-                          type="checkbox"
-                          checked={false}
-                          className="h-4 w-4 cursor-pointer"
-                          aria-label="Mark as Fees Closed"
-                          onChange={() => setCloseConfirmCase(c)}
-                        />
-                      ) : (
-                        "—"
-                      )}
-                    </td>
+                      </td>
+                    )}
                     {/* Level — varchar; lives on the cases row. */}
                     <td
                       className={`${tdBase}`}
@@ -2657,14 +2671,12 @@ export const FeeRecordsTable = ({
         }}
       />
 
-      <FeesClosedConfirmDialog
-        open={closeConfirmCase !== null}
-        mode="close"
-        caseId={closeConfirmCase?.id ?? null}
-        caseName={closeConfirmCase?.name ?? ""}
-        onClose={() => setCloseConfirmCase(null)}
-        onConfirmed={() => {
-          setCloseConfirmCase(null);
+      <BulkFeesClosedConfirmDialog
+        open={bulkCloseConfirmOpen}
+        caseIds={bulkClosePendingIds}
+        onClose={() => setBulkCloseConfirmOpen(false)}
+        onClosed={() => {
+          setSelectedIds(new Set());
           onImported?.();
         }}
       />


### PR DESCRIPTION
## Summary
- Removed the per-row Fees Closed checkbox column from Master Fees; closing is now a batch action from the row-selection pill, positioned before "Add to Overpaid Cases"
- Added a confirmation dialog (BulkFeesClosedConfirmDialog) that closes each selected case through the same per-case PATCH the old checkbox used, so permission checks, the closed_at stamp, and activity logging stay identical
- Fees Closed page is untouched — the column there still shows the per-row Reopen checkbox
- Removed now-dead closeConfirmCase state and the unused isLead variable