### PR TITLE
Add Case Level column to No Fees Cases table on Reports

### DIFF
--- a/src/app/api/scoreboard/route.ts
+++ b/src/app/api/scoreboard/route.ts
@@ -402,6 +402,7 @@ export const GET = async (req: NextRequest) => {
         c.last_name AS last_name,
         c.external_id AS external_id,
         fr.assigned_to AS assigned,
+        c.level_won AS level_won,
         c.claim_type_label AS claim_type_label,
         c.approval_date AS approval_date,
         (CURRENT_DATE - c.approval_date)::int AS days_since_approval
@@ -418,6 +419,7 @@ export const GET = async (req: NextRequest) => {
       last_name: string | null;
       external_id: string | null;
       assigned: string | null;
+      level_won: string | null;
       claim_type_label: string | null;
       approval_date: string | null;
       days_since_approval: number;
@@ -428,6 +430,7 @@ export const GET = async (req: NextRequest) => {
       name: `${r.last_name ?? ""}, ${r.first_name ?? ""}`,
       externalId: r.external_id,
       assigned: r.assigned || "—",
+      level: r.level_won || "—",
       claim: r.claim_type_label === "T2_T16" || r.claim_type_label === "CONCURRENT" ? "CONC" : r.claim_type_label || "—",
       approvalDate: r.approval_date,
       daysSinceApproval: Number(r.days_since_approval) || 0,

--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -75,6 +75,7 @@ interface NoFeesCaseRow {
   name: string;
   externalId: string | null;
   assigned: string;
+  level: string;
   claim: string;
   approvalDate: string | null;
   daysSinceApproval: number;
@@ -574,6 +575,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                   <tr className={`border-b ${t.borderLight}`}>
                     <th className={`${thBase} ${t.textSub} text-left`}>Case Name</th>
                     <th className={`${thBase} ${t.textSub} text-left`}>Assigned</th>
+                    <th className={`${thBase} ${t.textSub} text-left`}>Level</th>
                     <th className={`${thBase} ${t.textSub} text-left`}>Claim</th>
                     <th className={`${thBase} ${t.textSub} text-left`}>Approval</th>
                     <th className={`${thBase} ${t.textSub} text-right`}>Days</th>
@@ -598,6 +600,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                         )}
                       </td>
                       <td className={`${tdBase} ${t.textSub}`}>{c.assigned}</td>
+                      <td className={`${tdBase} ${t.textSub}`}>{c.level.replace(/_/g, " ")}</td>
                       <td className={`${tdBase} ${t.textSub}`}>{c.claim}</td>
                       <td className={`${tdBase} ${t.textSub}`}>{fmtDate(c.approvalDate)}</td>
                       <td


### PR DESCRIPTION
## Summary
- Requested by DeAnne (via Ms. Jazz): add Case Level to the No Fees Cases table on Reports, matching the data already shown on Master Fees, so staff can tell if a case is under Fee Petition
- Added `level_won` to the noFeesCaseRows query and mapped it to the table's row type
- Added a Level column between Assigned and Claim, matching Master Fees' column order
- Normalized underscore-vs-space inconsistencies in the legacy free-text data (e.g. "FEE_PETITION" → "FEE PETITION"), matching the existing precedent in CaseDetailSheet.tsx