### PR TITLE
Highlight Fee Petition level in red on No Fees Cases table

### DIFF
--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -600,7 +600,21 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                         )}
                       </td>
                       <td className={`${tdBase} ${t.textSub}`}>{c.assigned}</td>
-                      <td className={`${tdBase} ${t.textSub}`}>{c.level.replace(/_/g, " ")}</td>
+                      {(() => {
+                        const level = c.level.replace(/_/g, " ");
+                        const isFeePetition = level.trim().toUpperCase() === "FEE PETITION";
+                        return (
+                          <td
+                            className={`${tdBase} ${
+                              isFeePetition
+                                ? `font-semibold ${dark ? "text-red-400" : "text-red-600"}`
+                                : t.textSub
+                            }`}
+                          >
+                            {level}
+                          </td>
+                        );
+                      })()}
                       <td className={`${tdBase} ${t.textSub}`}>{c.claim}</td>
                       <td className={`${tdBase} ${t.textSub}`}>{fmtDate(c.approvalDate)}</td>
                       <td


### PR DESCRIPTION
## Summary
- Follow-up to PR #267 (Case Level column) — highlights "FEE PETITION" in bold red on the No Fees Cases table so it stands out from other level values
- Other level values (Hearing, Initial, Reconsideration, etc.) are unaffected, keeping the normal text color