### PR TITLE
Add per-row refresh to Fee Petitions table

### DIFF
--- a/src/app/api/fee-petitions/route.ts
+++ b/src/app/api/fee-petitions/route.ts
@@ -32,6 +32,85 @@ const resolveActiveFeeType = (
   return "t16";
 };
 
+// Shared by the list query and the single-row refresh query below, so both
+// stay in lockstep — a per-row refresh must return the exact same shape the
+// list endpoint would have given that row.
+const ROW_COLUMNS = {
+  clientId: cases.clientId,
+  firstName: cases.firstName,
+  lastName: cases.lastName,
+  externalId: cases.externalId,
+  approvalDate: cases.approvalDate,
+  claimTypeLabel: cases.claimTypeLabel,
+  totalFeesExpected: feeRecords.totalFeesExpected,
+  totalFeesPaid: feeRecords.totalFeesPaid,
+  t16Retro: feeRecords.t16Retro,
+  t2Retro: feeRecords.t2Retro,
+  auxRetro: feeRecords.auxRetro,
+  assignedTo: feePetitions.assignedTo,
+  noa: feePetitions.noa,
+  timeDelineation: feePetitions.timeDelineation,
+  feePetitionDoc: feePetitions.feePetitionDoc,
+  ltrToClmt: feePetitions.ltrToClmt,
+  ltrToClmtWithSignature: feePetitions.ltrToClmtWithSignature,
+  ltrToAlj: feePetitions.ltrToAlj,
+  faxConfFeePet: feePetitions.faxConfFeePet,
+  feePetitionApproved: feePetitions.feePetitionApproved,
+  updateNote: feePetitions.updateNote,
+  updatedAt: feePetitions.updatedAt,
+};
+
+type FeePetitionQueryRow = {
+  clientId: number;
+  firstName: string | null;
+  lastName: string | null;
+  externalId: string | null;
+  approvalDate: string | null;
+  claimTypeLabel: string | null;
+  totalFeesExpected: string | number | null;
+  totalFeesPaid: string | number | null;
+  t16Retro: string | number | null;
+  t2Retro: string | number | null;
+  auxRetro: string | number | null;
+  assignedTo: string | null;
+  noa: boolean | null;
+  timeDelineation: boolean | null;
+  feePetitionDoc: boolean | null;
+  ltrToClmt: boolean | null;
+  ltrToClmtWithSignature: boolean | null;
+  ltrToAlj: boolean | null;
+  faxConfFeePet: boolean | null;
+  feePetitionApproved: boolean | null;
+  updateNote: string | null;
+  updatedAt: Date | null;
+};
+
+const toFeePetitionRow = (r: FeePetitionQueryRow) => ({
+  id: r.clientId,
+  claimant: `${r.lastName}, ${r.firstName}`,
+  externalId: r.externalId ?? null,
+  approvalDate: r.approvalDate ?? null,
+  updatedAt: r.updatedAt ? r.updatedAt.toISOString().slice(0, 10) : null,
+  feeAmount: r.totalFeesExpected != null ? Number(r.totalFeesExpected) : null,
+  feesReceived: r.totalFeesPaid != null ? Number(r.totalFeesPaid) : null,
+  activeFeeType: resolveActiveFeeType(
+    r.claimTypeLabel,
+    Number(r.t16Retro) || 0,
+    Number(r.t2Retro) || 0,
+    Number(r.auxRetro) || 0,
+  ),
+  assignedTo: r.assignedTo ?? null,
+  noa: r.noa ?? false,
+  timeDelineation: r.timeDelineation ?? false,
+  feePetitionDoc: r.feePetitionDoc ?? false,
+  ltrToClmt: r.ltrToClmt ?? false,
+  ltrToClmtWithSignature: r.ltrToClmtWithSignature ?? false,
+  ltrToAlj: r.ltrToAlj ?? false,
+  faxConfFeePet: r.faxConfFeePet ?? false,
+  feePetitionApproved: r.feePetitionApproved ?? false,
+  updateNote: r.updateNote ?? "",
+});
+
 const getMissingClause = (key: string | null) => {
   switch (key) {
     case "timeDelineation": return sql`AND COALESCE(${feePetitions.timeDelineation}, false) = false`;
@@ -57,6 +136,29 @@ export const GET = async (req: NextRequest) => {
     }
 
     const { searchParams } = new URL(req.url);
+
+    // Per-row refresh (Fee Petitions table) — bypasses every list filter
+    // and pagination, since the caller already knows which row it wants
+    // and just needs its current server state after an edit.
+    const caseIdParam = searchParams.get("caseId");
+    if (caseIdParam) {
+      const caseId = parseInt(caseIdParam, 10);
+      if (!Number.isFinite(caseId)) {
+        return NextResponse.json({ error: "Invalid caseId" }, { status: 400 });
+      }
+      const [r] = await db
+        .select(ROW_COLUMNS)
+        .from(cases)
+        .leftJoin(feePetitions, eq(feePetitions.caseId, cases.clientId))
+        .leftJoin(feeRecords, eq(feeRecords.caseId, cases.clientId))
+        .where(eq(cases.clientId, caseId))
+        .limit(1);
+      if (!r) {
+        return NextResponse.json({ error: "Case not found" }, { status: 404 });
+      }
+      return NextResponse.json({ data: [toFeePetitionRow(r)] });
+    }
+
     const search = searchParams.get("search");
     const status = searchParams.get("status"); // "complete" | "incomplete"
     const touched = searchParams.get("touched"); // "none" = no fee_petitions row yet
@@ -201,30 +303,7 @@ export const GET = async (req: NextRequest) => {
             : sql`${cases.approvalDate} ${dir} NULLS LAST`;
 
     const rows = await db
-      .select({
-        clientId: cases.clientId,
-        firstName: cases.firstName,
-        lastName: cases.lastName,
-        externalId: cases.externalId,
-        approvalDate: cases.approvalDate,
-        claimTypeLabel: cases.claimTypeLabel,
-        totalFeesExpected: feeRecords.totalFeesExpected,
-        totalFeesPaid: feeRecords.totalFeesPaid,
-        t16Retro: feeRecords.t16Retro,
-        t2Retro: feeRecords.t2Retro,
-        auxRetro: feeRecords.auxRetro,
-        assignedTo: feePetitions.assignedTo,
-        noa: feePetitions.noa,
-        timeDelineation: feePetitions.timeDelineation,
-        feePetitionDoc: feePetitions.feePetitionDoc,
-        ltrToClmt: feePetitions.ltrToClmt,
-        ltrToClmtWithSignature: feePetitions.ltrToClmtWithSignature,
-        ltrToAlj: feePetitions.ltrToAlj,
-        faxConfFeePet: feePetitions.faxConfFeePet,
-        feePetitionApproved: feePetitions.feePetitionApproved,
-        updateNote: feePetitions.updateNote,
-        updatedAt: feePetitions.updatedAt,
-      })
+      .select(ROW_COLUMNS)
       .from(cases)
       .leftJoin(feePetitions, eq(feePetitions.caseId, cases.clientId))
       .leftJoin(feeRecords, eq(feeRecords.caseId, cases.clientId))
@@ -233,31 +312,7 @@ export const GET = async (req: NextRequest) => {
       .limit(limit)
       .offset(offset);
 
-    const data = rows.map((r) => ({
-      id: r.clientId,
-      claimant: `${r.lastName}, ${r.firstName}`,
-      externalId: r.externalId ?? null,
-      approvalDate: r.approvalDate ?? null,
-      updatedAt: r.updatedAt ? r.updatedAt.toISOString().slice(0, 10) : null,
-      feeAmount: r.totalFeesExpected != null ? Number(r.totalFeesExpected) : null,
-      feesReceived: r.totalFeesPaid != null ? Number(r.totalFeesPaid) : null,
-      activeFeeType: resolveActiveFeeType(
-        r.claimTypeLabel,
-        Number(r.t16Retro) || 0,
-        Number(r.t2Retro) || 0,
-        Number(r.auxRetro) || 0,
-      ),
-      assignedTo: r.assignedTo ?? null,
-      noa: r.noa ?? false,
-      timeDelineation: r.timeDelineation ?? false,
-      feePetitionDoc: r.feePetitionDoc ?? false,
-      ltrToClmt: r.ltrToClmt ?? false,
-      ltrToClmtWithSignature: r.ltrToClmtWithSignature ?? false,
-      ltrToAlj: r.ltrToAlj ?? false,
-      faxConfFeePet: r.faxConfFeePet ?? false,
-      feePetitionApproved: r.feePetitionApproved ?? false,
-      updateNote: r.updateNote ?? "",
-    }));
+    const data = rows.map(toFeePetitionRow);
 
     return NextResponse.json({
       data,

--- a/src/app/api/fee-petitions/route.ts
+++ b/src/app/api/fee-petitions/route.ts
@@ -137,9 +137,12 @@ export const GET = async (req: NextRequest) => {
 
     const { searchParams } = new URL(req.url);
 
-    // Per-row refresh (Fee Petitions table) — bypasses every list filter
-    // and pagination, since the caller already knows which row it wants
-    // and just needs its current server state after an edit.
+    // Per-row refresh (Fee Petitions table) — bypasses list filters like
+    // search/status/touched/missing/aging/assignedTo and pagination, since
+    // the caller already knows which row it wants and just needs its
+    // current server state after an edit. Still scoped to the same
+    // Fee Petition / not-closed universe as the list query, though, so this
+    // can't be used to pull fee-petition-shaped data for an arbitrary case.
     const caseIdParam = searchParams.get("caseId");
     if (caseIdParam) {
       const caseId = parseInt(caseIdParam, 10);
@@ -151,7 +154,9 @@ export const GET = async (req: NextRequest) => {
         .from(cases)
         .leftJoin(feePetitions, eq(feePetitions.caseId, cases.clientId))
         .leftJoin(feeRecords, eq(feeRecords.caseId, cases.clientId))
-        .where(eq(cases.clientId, caseId))
+        .where(sql`${cases.clientId} = ${caseId}
+          AND ${cases.levelWon} IN ('FEE_PETITION', 'FEE PETITION')
+          AND (${feeRecords.isClosed} IS NULL OR ${feeRecords.isClosed} = false)`)
         .limit(1);
       if (!r) {
         return NextResponse.json({ error: "Case not found" }, { status: 404 });

--- a/src/components/fee-petitions/FeePetitions.tsx
+++ b/src/components/fee-petitions/FeePetitions.tsx
@@ -439,8 +439,13 @@ export const FeePetitions = () => {
   }, [fetchPetitions]);
 
   // Re-fetches one petition and patches just its row — lets staff confirm a
-  // checkbox/note/assignee edit's saved state without reloading (and losing
-  // their filters/page/scroll position on) the whole table.
+  // checkbox/assignee edit's saved state without reloading (and losing
+  // their filters/page/scroll position on) the whole table. `updateNote` is
+  // deliberately excluded from the patch — it has its own dedicated
+  // draft/save flow (setUpdateNoteLocal writes straight into `rows`, ahead
+  // of persistUpdateNote's debounced save), and patching it here would
+  // silently revert an in-progress, not-yet-saved note back to the
+  // pre-edit server value if a refresh landed mid-draft.
   const handleRowRefresh = async (id: number) => {
     rowRefreshAbortRef.current.get(id)?.abort();
     const controller = new AbortController();
@@ -454,14 +459,15 @@ export const FeePetitions = () => {
       const json = await res.json();
       const fresh: FeePetitionRow | undefined = json.data?.[0];
       if (!fresh) throw new Error("Petition not found");
-      setRowOverrides((prev) => ({ ...prev, [id]: fresh }));
+      const patch: Partial<FeePetitionRow> = { ...fresh };
+      delete patch.updateNote;
+      setRowOverrides((prev) => ({ ...prev, [id]: patch }));
       setFeeAmountOverrides((prev) => {
         if (!(id in prev)) return prev;
         const next = { ...prev };
         delete next[id];
         return next;
       });
-      noteSnapshot.current.set(id, fresh.updateNote);
     } catch (err) {
       if ((err as Error).name === "AbortError") return;
       console.error("Failed to refresh row:", err);

--- a/src/components/fee-petitions/FeePetitions.tsx
+++ b/src/components/fee-petitions/FeePetitions.tsx
@@ -415,6 +415,10 @@ export const FeePetitions = () => {
       const json = await res.json();
       const data: FeePetitionRow[] = json.data || [];
       setRows(data);
+      // A full list refetch supersedes any per-row refresh snapshot taken
+      // before it — must not outlive this, or a stale rowOverrides entry
+      // would keep shadowing newer data for that row indefinitely.
+      setRowOverrides({});
       setSelectedIds(new Set());
       setBulkConfirming(false);
       setTotal(typeof json.total === "number" ? json.total : data.length);
@@ -434,6 +438,46 @@ export const FeePetitions = () => {
     return () => { fetchAbortRef.current?.abort(); };
   }, [fetchPetitions]);
 
+  // Re-fetches one petition and patches just its row — lets staff confirm a
+  // checkbox/note/assignee edit's saved state without reloading (and losing
+  // their filters/page/scroll position on) the whole table.
+  const handleRowRefresh = async (id: number) => {
+    rowRefreshAbortRef.current.get(id)?.abort();
+    const controller = new AbortController();
+    rowRefreshAbortRef.current.set(id, controller);
+    setRowRefreshing((prev) => new Set(prev).add(id));
+    try {
+      const res = await fetch(`/api/fee-petitions?caseId=${id}`, {
+        signal: controller.signal,
+      });
+      if (!res.ok) throw new Error(`Failed to refresh petition (${res.status})`);
+      const json = await res.json();
+      const fresh: FeePetitionRow | undefined = json.data?.[0];
+      if (!fresh) throw new Error("Petition not found");
+      setRowOverrides((prev) => ({ ...prev, [id]: fresh }));
+      setFeeAmountOverrides((prev) => {
+        if (!(id in prev)) return prev;
+        const next = { ...prev };
+        delete next[id];
+        return next;
+      });
+      noteSnapshot.current.set(id, fresh.updateNote);
+    } catch (err) {
+      if ((err as Error).name === "AbortError") return;
+      console.error("Failed to refresh row:", err);
+      setLiveMessage("Refresh failed");
+    } finally {
+      if (rowRefreshAbortRef.current.get(id) === controller) {
+        rowRefreshAbortRef.current.delete(id);
+      }
+      setRowRefreshing((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+    }
+  };
+
   // Fee Requested/Fees Received have no single editable column of their own
   // (they're sums of t16/t2/aux Fee Due and Fee Received) — each cell edits
   // row.activeFeeType's column directly (resolved server-side to whichever
@@ -450,6 +494,16 @@ export const FeePetitions = () => {
     Record<number, Partial<Pick<FeePetitionRow, "feeAmount" | "feesReceived">>>
   >({});
   const feeAmountAbortRef = useRef<AbortController | null>(null);
+
+  // Per-row "refresh" — re-fetches one petition from the server and patches
+  // just that row, so staff can see a checkbox/note/assignee edit's saved
+  // state confirmed without reloading (and losing their filters/page/scroll
+  // position on) the whole table. Mirrors Master Fees' rowOverrides pattern;
+  // cleared inside fetchPetitions itself (not a [rows] effect, since rows
+  // also changes on every unrelated optimistic edit in this file).
+  const [rowOverrides, setRowOverrides] = useState<Record<number, Partial<FeePetitionRow>>>({});
+  const [rowRefreshing, setRowRefreshing] = useState<Set<number>>(new Set());
+  const rowRefreshAbortRef = useRef<Map<number, AbortController>>(new Map());
 
   const saveFeeAmount = useCallback(async () => {
     if (!feeAmountEdit || feeAmountSaving) return;
@@ -819,7 +873,7 @@ export const FeePetitions = () => {
     ? "bg-indigo-700 border-indigo-600 text-white"
     : "bg-indigo-100 border-indigo-400 text-indigo-800";
   const presetBase = `shrink-0 px-2.5 py-1 rounded-full text-[13px] font-medium border transition-colors`;
-  const colSpan = CHECKBOX_COLUMNS.length + 10;
+  const colSpan = CHECKBOX_COLUMNS.length + 11;
 
   return (
     <div className="space-y-4">
@@ -1154,9 +1208,15 @@ export const FeePetitions = () => {
                     className="h-3.5 w-3.5 cursor-pointer accent-indigo-500"
                   />
                 </th>
+                {/* Refresh — frozen, right after the checkbox, before
+                    Claimant, so it's usable without scrolling right. */}
+                <th className={`${thBase} w-14 text-center sticky left-10 top-0 z-30 ${stickyHeaderBg}`} title="Refresh">
+                  <RefreshCw className="h-3.5 w-3.5 inline" aria-hidden="true" />
+                  <span className="sr-only">Refresh</span>
+                </th>
                 <th
                   aria-sort={ariaSortFor("claimant")}
-                  className={`${thBase} w-40 ${t.textSub} text-left sticky left-10 top-0 z-30 ${stickyHeaderBg}`}
+                  className={`${thBase} w-40 ${t.textSub} text-left sticky left-24 top-0 z-30 ${stickyHeaderBg}`}
                 >
                   <button
                     type="button"
@@ -1166,7 +1226,7 @@ export const FeePetitions = () => {
                     Claimant {sortIcon("claimant")}
                   </button>
                 </th>
-                <th className={`${thBase} w-24 ${t.textSub} text-right sticky left-[200px] top-0 z-30 ${stickyHeaderBg}`}>
+                <th className={`${thBase} w-24 ${t.textSub} text-right sticky left-[256px] top-0 z-30 ${stickyHeaderBg}`}>
                   Fee Requested
                 </th>
                 <th className={`${thBase} w-24 ${t.textSub} text-right sticky top-0 z-20 ${stickyHeaderBg}`}>
@@ -1250,7 +1310,7 @@ export const FeePetitions = () => {
                 </tr>
               ) : (
                 rows.map((rawRow) => {
-                  const row = { ...rawRow, ...feeAmountOverrides[rawRow.id] };
+                  const row = { ...rawRow, ...feeAmountOverrides[rawRow.id], ...rowOverrides[rawRow.id] };
                   const completedCount = CHECKBOX_COLUMNS.reduce((acc, c) => acc + (row[c.key] ? 1 : 0), 0);
                   const isComplete = completedCount === CHECKBOX_COLUMNS.length;
                   const isSelected = selectedIds.has(row.id);
@@ -1277,8 +1337,23 @@ export const FeePetitions = () => {
                           className="h-3.5 w-3.5 cursor-pointer accent-indigo-500"
                         />
                       </td>
+                      <td className={`${tdBase} text-center sticky left-10 z-10 ${stickyBg} ${stickyHover}`}>
+                        <button
+                          type="button"
+                          onClick={() => handleRowRefresh(row.id)}
+                          disabled={rowRefreshing.has(row.id)}
+                          aria-label={`Refresh ${row.claimant}`}
+                          title="Refresh this petition's data from the server"
+                          className={`inline-flex items-center justify-center h-6 w-6 rounded ${t.hover} ${t.textSub} disabled:opacity-50`}
+                        >
+                          <RefreshCw
+                            className={`h-3.5 w-3.5 ${rowRefreshing.has(row.id) ? "animate-spin" : ""}`}
+                            aria-hidden="true"
+                          />
+                        </button>
+                      </td>
                       <td
-                        className={`${tdBase} ${t.text} font-semibold w-40 sticky left-10 z-10 ${stickyBg} ${stickyHover}`}
+                        className={`${tdBase} ${t.text} font-semibold w-40 sticky left-24 z-10 ${stickyBg} ${stickyHover}`}
                         title={row.claimant}
                       >
                         <a
@@ -1297,7 +1372,7 @@ export const FeePetitions = () => {
                         )}
                       </td>
                       <td
-                        className={`${tdBase} w-24 ${t.text} text-right font-medium tabular-nums sticky left-[200px] z-10 ${stickyBg} ${stickyHover}`}
+                        className={`${tdBase} w-24 ${t.text} text-right font-medium tabular-nums sticky left-[256px] z-10 ${stickyBg} ${stickyHover}`}
                       >
                         <FeeAmountCell
                           active={canEditFees && feeAmountEdit?.rowId === row.id && feeAmountEdit.field === "feeAmount"}


### PR DESCRIPTION
## Summary
- Requested follow-up to the toolbar refresh button (PR #270): add a per-row refresh so staff can confirm an edit's saved state without reloading the whole table, mirroring Master Fees' per-row refresh pattern
- Extended `GET /api/fee-petitions` with an optional `?caseId=` param for single-row refresh; refactored the shared column list/row mapping (`ROW_COLUMNS`/`toFeePetitionRow`) so the list and single-row queries can't drift apart in shape
- Added a frozen Refresh icon column (checkbox → Refresh → Claimant), shifting the sticky offsets for Claimant and Fee Requested accordingly
- Scoped the `?caseId=` lookup to the same Fee Petition / not-closed universe as the list query
- Excluded `updateNote` from the refresh patch — Note has its own dedicated draft/save flow, so a refresh can't silently revert an in-progress, not-yet-saved note