### PR TITLE
Link Overpaid Cases claimant names directly to MyCase

### DIFF
--- a/src/app/api/overpaid-cases/route.ts
+++ b/src/app/api/overpaid-cases/route.ts
@@ -129,6 +129,7 @@ export const GET = async (req: NextRequest) => {
         clientId: cases.clientId,
         firstName: cases.firstName,
         lastName: cases.lastName,
+        externalId: cases.externalId,
         assignedTo: feeRecords.assignedTo,
         feesReceived: sql<string>`ROUND(${feeRecords.totalFeesPaid}::numeric, 2)`,
         overpaidAmount: overpaidCases.overpaidAmount,
@@ -152,6 +153,7 @@ export const GET = async (req: NextRequest) => {
     const data = rows.map((r) => ({
       id: r.clientId,
       claimant: `${r.lastName}, ${r.firstName}`,
+      externalId: r.externalId ?? null,
       assignedTo: r.assignedTo ?? null,
       feesReceived: Number(r.feesReceived),
       overpaidAmount: r.overpaidAmount != null ? Number(r.overpaidAmount) : null,

--- a/src/components/overpaid-cases/ClearedCases.tsx
+++ b/src/components/overpaid-cases/ClearedCases.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import Link from "next/link";
 import {
   Search,
   ArrowUp,
@@ -18,15 +17,18 @@ import {
   RefreshCw,
   TrendingDown,
   Download,
+  ExternalLink,
 } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
 import { fmt, fmtFull, fmtDateLong } from "@/lib/formatters";
 import { upsertOverpaidCase, bulkRestoreCleared } from "@/app/(dashboard)/overpaid-cases/actions";
 import { NoteField } from "@/components/shared/NoteField";
+import { buildMyCaseUrl } from "@/lib/import/case-link";
 
 interface ClearedRow {
   id: number;
   claimant: string;
+  externalId: string | null;
   assignedTo: string | null;
   region: string | null;
   feesReceived: number;
@@ -669,12 +671,15 @@ export const ClearedCases = ({ dark, t, refreshToken, onRestored }: Props) => {
                           className={`${tdBase} font-semibold max-w-45 sticky left-10 z-10 ${stickyBg} ${stickyHover}`}
                           title={row.claimant}
                         >
-                          <Link
-                            href={`/cases/${row.id}`}
-                            className={`hover:underline truncate block ${dark ? "text-indigo-400" : "text-indigo-600"}`}
+                          <a
+                            href={row.externalId || buildMyCaseUrl(row.id)}
+                            target="_blank"
+                            rel="noreferrer"
+                            className={`inline-flex items-center gap-1 max-w-full truncate hover:underline ${dark ? "text-indigo-400" : "text-indigo-600"}`}
                           >
-                            {row.claimant}
-                          </Link>
+                            <span className="truncate">{row.claimant}</span>
+                            <ExternalLink className="h-3 w-3 shrink-0 opacity-50" aria-hidden="true" />
+                          </a>
                         </td>
                         <td className={`${tdBase} ${t.textMuted}`}>{row.assignedTo ?? "—"}</td>
                         <td className={`${tdBase} ${t.textMuted}`}>{row.region ?? "—"}</td>

--- a/src/components/overpaid-cases/OverpaidCases.tsx
+++ b/src/components/overpaid-cases/OverpaidCases.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
-import Link from "next/link";
 import { useTheme } from "next-themes";
 import {
   Search,
@@ -20,9 +19,11 @@ import {
   X,
   Undo2,
   Trash2,
+  ExternalLink,
 } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
 import { fmt, fmtFull } from "@/lib/formatters";
+import { buildMyCaseUrl } from "@/lib/import/case-link";
 import { upsertOverpaidCase, updateFeesConfirmation, bulkMarkCleared, bulkRestoreCleared, bulkRemoveFromOverpaid, markCaseOverpaid } from "@/app/(dashboard)/overpaid-cases/actions";
 import AddCaseModal from "@/components/modals/AddCaseModal";
 import { fetchDropdownOptions, type DropdownOptionsByCategory } from "@/lib/dropdown-options";
@@ -34,6 +35,7 @@ import { useCapabilities } from "@/hooks/useCapabilities";
 interface OverpaidCaseRow {
   id: number;
   claimant: string;
+  externalId: string | null;
   assignedTo: string | null;
   region: string | null;
   feesReceived: number;
@@ -1295,9 +1297,15 @@ export const OverpaidCases = () => {
                             />
                           )}
                           <div className="min-w-0">
-                            <Link href={`/cases/${row.id}`} className={`hover:underline truncate block ${dark ? "text-indigo-400" : "text-indigo-600"}`}>
-                              {row.claimant}
-                            </Link>
+                            <a
+                              href={row.externalId || buildMyCaseUrl(row.id)}
+                              target="_blank"
+                              rel="noreferrer"
+                              className={`inline-flex items-center gap-1 max-w-full truncate hover:underline ${dark ? "text-indigo-400" : "text-indigo-600"}`}
+                            >
+                              <span className="truncate">{row.claimant}</span>
+                              <ExternalLink className="h-3 w-3 shrink-0 opacity-50" aria-hidden="true" />
+                            </a>
                             {row.updatedAt && (
                               <p className={`text-[12px] ${t.textMuted} mt-0.5 font-normal`}>
                                 Updated {formatRelativeDate(row.updatedAt)}


### PR DESCRIPTION
## Summary
- Requested by Ms. Jazz: Overpaid Cases claimant names only linked to the internal case page; she wanted the same direct-to-MyCase link already used on Master Fees, Fee Petitions, and Fees Closed
- Added `externalId` to the `/api/overpaid-cases` query (select + response shape) — was missing end-to-end
- Swapped the internal `/cases/[id]` `Link` for the external MyCase `<a>` (with `buildMyCaseUrl` fallback and the same `ExternalLink` icon styling) in both the main Cases table and the collapsible Cleared Cases table