### PR TITLE
Fee Petition Approved now gates Completed Petitions

### DIFF
--- a/src/app/api/fee-petitions/route.ts
+++ b/src/app/api/fee-petitions/route.ts
@@ -266,16 +266,14 @@ export const GET = async (req: NextRequest) => {
       .map((r) => ({ name: r.assignedTo, count: r.caseCount }));
     const unassignedCount = assignedToRows.find((r) => r.assignedTo == null)?.caseCount ?? 0;
 
-    // Single aggregate for stats + count. Fee totals sum across the FULL
-    // filtered set (not just the current page), so they stay accurate
+    // Single aggregate for count and fee total. Sums across the FULL
+    // filtered set (not just the current page) so they stay accurate
     // regardless of pagination.
     const [agg] = await db
       .select({
         total: sql<number>`COUNT(*)::int`,
         completeCount: sql<number>`COUNT(*) FILTER (WHERE ${isApproved})::int`,
-        neverTouchedCount: sql<number>`COUNT(*) FILTER (WHERE ${feePetitions.updatedAt} IS NULL)::int`,
         totalFeeRequested: sql<number>`COALESCE(SUM(${feeRecords.totalFeesExpected}), 0)::numeric`,
-        totalFeesReceived: sql<number>`COALESCE(SUM(${feeRecords.totalFeesPaid}), 0)::numeric`,
       })
       .from(cases)
       .leftJoin(feePetitions, eq(feePetitions.caseId, cases.clientId))
@@ -284,10 +282,7 @@ export const GET = async (req: NextRequest) => {
 
     const total = agg?.total ?? 0;
     const completeCount = agg?.completeCount ?? 0;
-    const incompleteCount = total - completeCount;
-    const neverTouchedCount = agg?.neverTouchedCount ?? 0;
     const totalFeeRequested = Number(agg?.totalFeeRequested) || 0;
-    const totalFeesReceived = Number(agg?.totalFeesReceived) || 0;
 
     const orderClause =
       sort === "claimant"
@@ -316,10 +311,7 @@ export const GET = async (req: NextRequest) => {
       limit,
       total,
       completeCount,
-      incompleteCount,
-      neverTouchedCount,
       totalFeeRequested,
-      totalFeesReceived,
       assignees,
       unassignedCount,
     });

--- a/src/app/api/fee-petitions/route.ts
+++ b/src/app/api/fee-petitions/route.ts
@@ -181,23 +181,14 @@ export const GET = async (req: NextRequest) => {
     const limit = Number.isFinite(rawLimit) ? Math.min(Math.max(1, rawLimit), 10000) : 50;
     const offset = (page - 1) * limit;
 
-    // All 6 checklist fields true (NULLs from LEFT JOIN coalesce to false).
-    // NOA dropped from the checklist — a petition can now be filed without it.
-    const allChecked = sql`(
-      COALESCE(${feePetitions.timeDelineation}, false)
-      AND COALESCE(${feePetitions.feePetitionDoc}, false)
-      AND COALESCE(${feePetitions.ltrToClmt}, false)
-      AND COALESCE(${feePetitions.ltrToClmtWithSignature}, false)
-      AND COALESCE(${feePetitions.ltrToAlj}, false)
-      AND COALESCE(${feePetitions.faxConfFeePet}, false)
-    )`;
-
-    // A petition only belongs in "Completed Petitions" once the checklist is
-    // done AND fees have actually been received — finishing the paperwork
-    // alone isn't enough to file it as complete. `allChecked` on its own
-    // still drives the per-row checklist progress badge (7/7) client-side,
-    // which intentionally stays independent of fee timing.
-    const isFullyComplete = sql`(${allChecked} AND COALESCE(${feeRecords.totalFeesPaid}, 0)::numeric > 0)`;
+    // A petition moves to "Completed Petitions" once staff check Fee
+    // Petition Approved — not tied to the filing checklist or fees received.
+    // Once approved, staff change the case's Level away from FEE_PETITION
+    // (removing it from this page entirely); Completed Petitions is the
+    // holding view of "approved, ready to move to Master Fee Records."
+    // The 6-item filing checklist still drives the per-row progress badge
+    // (via progressExpr below) but no longer gates section membership.
+    const isApproved = sql`COALESCE(${feePetitions.feePetitionApproved}, false)`;
 
     // Sum of checked boxes — used for progress sort
     const progressExpr = sql`(
@@ -211,9 +202,9 @@ export const GET = async (req: NextRequest) => {
 
     const statusClause =
       status === "complete"
-        ? sql`AND ${isFullyComplete}`
+        ? sql`AND ${isApproved}`
         : status === "incomplete"
-          ? sql`AND NOT ${isFullyComplete}`
+          ? sql`AND NOT ${isApproved}`
           : sql``;
 
     const searchClause = search
@@ -281,7 +272,7 @@ export const GET = async (req: NextRequest) => {
     const [agg] = await db
       .select({
         total: sql<number>`COUNT(*)::int`,
-        completeCount: sql<number>`COUNT(*) FILTER (WHERE ${isFullyComplete})::int`,
+        completeCount: sql<number>`COUNT(*) FILTER (WHERE ${isApproved})::int`,
         neverTouchedCount: sql<number>`COUNT(*) FILTER (WHERE ${feePetitions.updatedAt} IS NULL)::int`,
         totalFeeRequested: sql<number>`COALESCE(SUM(${feeRecords.totalFeesExpected}), 0)::numeric`,
         totalFeesReceived: sql<number>`COALESCE(SUM(${feeRecords.totalFeesPaid}), 0)::numeric`,

--- a/src/components/fee-petitions/CompletedPetitions.tsx
+++ b/src/components/fee-petitions/CompletedPetitions.tsx
@@ -257,7 +257,7 @@ export const CompletedPetitions = ({ dark }: Props) => {
   const stickyBg = dark ? "bg-emerald-900" : "bg-emerald-100";
   const stickyHover = dark ? "group-hover/row:bg-emerald-800" : "group-hover/row:bg-emerald-200";
   // claimant + fee requested + fees received + approved + completed + assigned + 7 checkbox cols + note
-  const colSpan = CHECKBOX_COLUMNS.length + 8;
+  const colSpan = CHECKBOX_COLUMNS.length + 7;
 
   return (
     // contain:layout stops the sticky frozen-column/header cells in the table
@@ -311,7 +311,7 @@ export const CompletedPetitions = ({ dark }: Props) => {
               </p>
               {safeTotal > 0 && (
                 <p className={`text-[13px] ${t.textMuted} mt-0.5`}>
-                  Fees Requested {fmt(totals.feeRequested)} · Fees Received {fmt(totals.feesReceived)}
+                  Fees Requested {fmt(totals.feeRequested)}
                 </p>
               )}
             </div>
@@ -395,9 +395,6 @@ export const CompletedPetitions = ({ dark }: Props) => {
                   </th>
                   <th className={`${thBase} w-24 min-w-24 max-w-24 ${t.textSub} text-right sticky left-40 top-0 z-30 ${stickyHeaderBg}`}>
                     Fee Requested
-                  </th>
-                  <th className={`${thBase} w-24 ${t.textSub} text-right sticky top-0 z-20 ${stickyHeaderBg}`}>
-                    Fees Received
                   </th>
                   <th
                     aria-sort={sortKey === "approvalDate" ? (sortDir === "asc" ? "ascending" : "descending") : "none"}
@@ -499,9 +496,6 @@ export const CompletedPetitions = ({ dark }: Props) => {
                           className={`${tdBase} w-24 min-w-24 max-w-24 ${t.text} text-right font-medium tabular-nums sticky left-40 z-10 ${stickyBg} ${stickyHover}`}
                         >
                           {row.feeAmount != null ? fmt(row.feeAmount) : "—"}
-                        </td>
-                        <td className={`${tdBase} w-24 text-right font-medium tabular-nums ${row.feesReceived != null && row.feesReceived > 0 ? (dark ? "text-emerald-400" : "text-emerald-600") : t.textMuted}`}>
-                          {row.feesReceived != null ? fmt(row.feesReceived) : "—"}
                         </td>
                         <td className={`${tdBase} ${t.textMuted}`}>{fmtDate(row.approvalDate)}</td>
                         <td className={`${tdBase} ${t.textMuted}`}>{fmtDate(row.updatedAt)}</td>

--- a/src/components/fee-petitions/CompletedPetitions.tsx
+++ b/src/components/fee-petitions/CompletedPetitions.tsx
@@ -37,6 +37,7 @@ interface CompletedRow {
   ltrToClmtWithSignature: boolean;
   ltrToAlj: boolean;
   faxConfFeePet: boolean;
+  feePetitionApproved: boolean;
   updateNote: string;
 }
 
@@ -220,6 +221,27 @@ export const CompletedPetitions = ({ dark }: Props) => {
     }
   };
 
+  // Fee Petition Approved is what put this row here (see route.ts's
+  // isApproved) — unchecking it moves the case back to Pending, so it's
+  // removed from this local list immediately rather than waiting on a
+  // refetch. The Pending table has its own refresh button to pick it back
+  // up; there's no live cross-component sync between the two tables.
+  const toggleApproved = async (row: CompletedRow) => {
+    const next = !row.feePetitionApproved;
+    setRows((prev) => prev.map((r) => (r.id === row.id ? { ...r, feePetitionApproved: next } : r)));
+    try {
+      const result = await upsertFeePetition({ caseId: row.id, fields: { feePetitionApproved: next } });
+      if (!result.ok) throw new Error(result.error);
+      if (!next) {
+        setRows((prev) => prev.filter((r) => r.id !== row.id));
+        setTotal((tot) => (tot == null ? tot : Math.max(0, tot - 1)));
+      }
+    } catch (err) {
+      setRows((prev) => prev.map((r) => (r.id === row.id ? { ...r, feePetitionApproved: !next } : r)));
+      setError((err as Error).message);
+    }
+  };
+
   const safeTotal = total ?? 0;
   const totalPages = Math.max(1, Math.ceil(safeTotal / pageSize));
   const rangeStart = safeTotal === 0 ? 0 : (page - 1) * pageSize + 1;
@@ -235,7 +257,7 @@ export const CompletedPetitions = ({ dark }: Props) => {
   const stickyBg = dark ? "bg-emerald-900" : "bg-emerald-100";
   const stickyHover = dark ? "group-hover/row:bg-emerald-800" : "group-hover/row:bg-emerald-200";
   // claimant + fee requested + fees received + approved + completed + assigned + 7 checkbox cols + note
-  const colSpan = CHECKBOX_COLUMNS.length + 7;
+  const colSpan = CHECKBOX_COLUMNS.length + 8;
 
   return (
     // contain:layout stops the sticky frozen-column/header cells in the table
@@ -412,6 +434,9 @@ export const CompletedPetitions = ({ dark }: Props) => {
                       {col.label}
                     </th>
                   ))}
+                  <th className={`${thBase} ${t.textSub} text-center border-l ${t.borderLight} sticky top-0 z-20 ${stickyHeaderBg}`}>
+                    Fee Petition Approved
+                  </th>
                   <th className={`${thBase} ${t.textSub} text-left min-w-50 sticky top-0 z-20 ${stickyHeaderBg}`}>
                     Update
                   </th>
@@ -483,12 +508,26 @@ export const CompletedPetitions = ({ dark }: Props) => {
                         <td className={`${tdBase} ${t.textMuted}`}>{row.assignedTo || "—"}</td>
                         {CHECKBOX_COLUMNS.map((col) => (
                           <td key={col.key} className={`${tdBase} text-center`}>
-                            <Check
-                              aria-hidden="true"
-                              className={`h-3.5 w-3.5 mx-auto ${dark ? "text-emerald-400" : "text-emerald-600"}`}
-                            />
+                            {row[col.key] ? (
+                              <Check
+                                aria-hidden="true"
+                                className={`h-3.5 w-3.5 mx-auto ${dark ? "text-emerald-400" : "text-emerald-600"}`}
+                              />
+                            ) : (
+                              <span className={t.textMuted}>—</span>
+                            )}
                           </td>
                         ))}
+                        <td className={`${tdBase} text-center border-l ${t.borderLight}`}>
+                          <input
+                            type="checkbox"
+                            checked={row.feePetitionApproved}
+                            onChange={() => toggleApproved(row)}
+                            aria-label={`Fee Petition Approved for ${row.claimant}`}
+                            title="Uncheck to move this case back to Pending"
+                            className="h-3.5 w-3.5 cursor-pointer accent-emerald-500"
+                          />
+                        </td>
                         <td className={`${tdBase}`}>
                           <NoteField
                             value={row.updateNote}

--- a/src/components/fee-petitions/CompletedPetitions.tsx
+++ b/src/components/fee-petitions/CompletedPetitions.tsx
@@ -28,7 +28,6 @@ interface CompletedRow {
   approvalDate: string | null;
   updatedAt: string | null;
   feeAmount: number | null;
-  feesReceived: number | null;
   assignedTo: string | null;
   noa: boolean;
   timeDelineation: boolean;
@@ -74,7 +73,7 @@ export const CompletedPetitions = ({ dark }: Props) => {
   const [expanded, setExpanded] = useState(false);
   const [rows, setRows] = useState<CompletedRow[]>([]);
   const [total, setTotal] = useState<number | null>(null);
-  const [totals, setTotals] = useState({ feeRequested: 0, feesReceived: 0 });
+  const [totals, setTotals] = useState({ feeRequested: 0 });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
@@ -159,7 +158,6 @@ export const CompletedPetitions = ({ dark }: Props) => {
       setTotal(typeof json.total === "number" ? json.total : 0);
       setTotals({
         feeRequested: typeof json.totalFeeRequested === "number" ? json.totalFeeRequested : 0,
-        feesReceived: typeof json.totalFeesReceived === "number" ? json.totalFeesReceived : 0,
       });
       noteSnapshot.current = new Map(data.map((r) => [r.id, r.updateNote]));
     } catch (err) {

--- a/src/components/fee-petitions/FeePetitions.tsx
+++ b/src/components/fee-petitions/FeePetitions.tsx
@@ -343,12 +343,11 @@ export const FeePetitions = () => {
 
   const [allTotals, setAllTotals] = useState<{ feeRequested: number } | null>(null);
 
-  // Fees Requested/Received in the stats bar cover pending AND completed
-  // petitions together — fetched with no status filter (unlike fetchPetitions,
-  // which always scopes its own aggregate to incomplete for the row list).
-  // These only change when a payment is recorded on the case detail page, not
-  // from anything this page itself does — refreshed on window focus below
-  // rather than tied to any local action.
+  // Fees Requested in the stats bar covers pending AND completed petitions
+  // together — fetched with no status filter (unlike fetchPetitions, which
+  // always scopes its own aggregate to incomplete for the row list). Only
+  // changes when a payment is recorded on the case detail page, so refreshed
+  // on window focus below rather than tied to any local action.
   const fetchAllTotals = useCallback(() => {
     allTotalsAbortRef.current?.abort();
     const controller = new AbortController();
@@ -990,19 +989,19 @@ export const FeePetitions = () => {
                       {selectedIds.size} selected
                       {selectedIncompleteCount < selectedIds.size && (
                         <span className={`ml-1.5 font-normal ${t.textMuted}`}>
-                          ({selectedIncompleteCount} to complete)
+                          ({selectedIncompleteCount} to check off)
                         </span>
                       )}
                     </span>
                     <button
                       onClick={() => setBulkConfirming(true)}
                       disabled={selectedIncompleteCount === 0}
-                      aria-label="Mark selected cases as complete"
-                      title={selectedIncompleteCount === 0 ? "All selected cases are already complete" : undefined}
+                      aria-label="Mark all checklist steps done for selected cases"
+                      title={selectedIncompleteCount === 0 ? "All selected cases already have all steps done" : undefined}
                       className={`h-7 px-3 rounded-md text-xs font-medium flex items-center gap-1.5 ${dark ? "bg-emerald-700 hover:bg-emerald-600 text-white" : "bg-emerald-600 hover:bg-emerald-700 text-white"} disabled:opacity-40 disabled:cursor-not-allowed transition-colors`}
                     >
                       <Check aria-hidden="true" className="h-3 w-3" />
-                      Mark Complete
+                      All Steps Done
                     </button>
                     <button
                       onClick={clearSelection}

--- a/src/components/fee-petitions/FeePetitions.tsx
+++ b/src/components/fee-petitions/FeePetitions.tsx
@@ -641,9 +641,6 @@ export const FeePetitions = () => {
             : r,
         ),
       );
-      setRows((prev) => prev.filter((r) => !ids.includes(r.id)));
-      setTotal((tot) => Math.max(0, tot - ids.length));
-      fetchCompletedCount();
       clearSelection();
       if (snapshot.length > 0) {
         setUndoInfo({ rows: snapshot, expiresAt: Date.now() + 8000 });
@@ -710,9 +707,6 @@ export const FeePetitions = () => {
     const prevRow = rows.find((r) => r.id === id);
     if (!prevRow) return;
     const next = !prevRow[key];
-    const isComplete = CHECKBOX_COLUMNS.every((c) =>
-      c.key === key ? next : prevRow[c.key],
-    );
     setRows((prev) => prev.map((r) => (r.id === id ? { ...r, [key]: next } : r)));
     try {
       await patchPetition(id, { [key]: next });
@@ -720,11 +714,6 @@ export const FeePetitions = () => {
       setRows((prev) => prev.map((r) => (r.id === id ? { ...r, updatedAt: today } : r)));
       const label = CHECKBOX_COLUMNS.find((c) => c.key === key)?.label ?? key;
       setLiveMessage(`${label} ${next ? "checked" : "unchecked"}`);
-      if (isComplete) {
-        setRows((prev) => prev.filter((r) => r.id !== id));
-        setTotal((tot) => Math.max(0, tot - 1));
-        fetchCompletedCount();
-      }
     } catch (err) {
       setRows((prev) => prev.map((r) => (r.id === id ? { ...r, [key]: !next } : r)));
       setLiveMessage("Save failed");
@@ -732,10 +721,11 @@ export const FeePetitions = () => {
     }
   };
 
-  // Standalone from toggleCheckbox above — this isn't a filing-checklist step
-  // (doesn't count toward completedCount/isComplete), and checking it syncs
-  // Remarks to "FEE PETITION APPROVED" on Master Fees server-side (see
-  // upsertFeePetition). Unchecking only updates this column, not Remarks.
+  // This is what moves a petition to Completed Petitions now — independent
+  // of the filing checklist (toggleCheckbox above no longer does this).
+  // Checking it also syncs Remarks to "FEE PETITION APPROVED" on Master
+  // Fees server-side (see upsertFeePetition); unchecking only updates this
+  // column, not Remarks.
   const toggleFeePetitionApproved = async (id: number) => {
     const prevRow = rows.find((r) => r.id === id);
     if (!prevRow) return;
@@ -746,6 +736,11 @@ export const FeePetitions = () => {
       const today = new Date().toISOString().slice(0, 10);
       setRows((prev) => prev.map((r) => (r.id === id ? { ...r, updatedAt: today } : r)));
       setLiveMessage(`Fee Petition Approved ${next ? "checked" : "unchecked"}`);
+      if (next) {
+        setRows((prev) => prev.filter((r) => r.id !== id));
+        setTotal((tot) => Math.max(0, tot - 1));
+        fetchCompletedCount();
+      }
     } catch (err) {
       setRows((prev) => prev.map((r) => (r.id === id ? { ...r, feePetitionApproved: !next } : r)));
       setLiveMessage("Save failed");
@@ -916,8 +911,8 @@ export const FeePetitions = () => {
       {/* Stats bar */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
         {[
-          { label: "Pending", value: isInitialLoad ? "—" : String(total), sub: "incomplete petitions" },
-          { label: "Completed", value: completedCount == null ? "—" : String(completedCount), sub: "fees received & filed" },
+          { label: "Pending", value: isInitialLoad ? "—" : String(total), sub: "not yet approved" },
+          { label: "Completed", value: completedCount == null ? "—" : String(completedCount), sub: "fee petition approved" },
           { label: "Fees Requested", value: allTotals == null ? "—" : fmt(allTotals.feeRequested), sub: "pending + completed petitions" },
           { label: "Fees Received", value: allTotals == null ? "—" : fmt(allTotals.feesReceived), sub: "pending + completed petitions" },
         ].map((s) => (

--- a/src/components/fee-petitions/FeePetitions.tsx
+++ b/src/components/fee-petitions/FeePetitions.tsx
@@ -874,7 +874,7 @@ export const FeePetitions = () => {
     ? "bg-indigo-700 border-indigo-600 text-white"
     : "bg-indigo-100 border-indigo-400 text-indigo-800";
   const presetBase = `shrink-0 px-2.5 py-1 rounded-full text-[13px] font-medium border transition-colors`;
-  const colSpan = CHECKBOX_COLUMNS.length + 11;
+  const colSpan = CHECKBOX_COLUMNS.length + 10;
 
   return (
     <div className="space-y-4">
@@ -909,12 +909,11 @@ export const FeePetitions = () => {
       </div>
 
       {/* Stats bar */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
         {[
           { label: "Pending", value: isInitialLoad ? "—" : String(total), sub: "not yet approved" },
-          { label: "Completed", value: completedCount == null ? "—" : String(completedCount), sub: "fee petition approved" },
+          { label: "Completed", value: completedCount == null ? "—" : String(completedCount), sub: "fee petitions filed & approved" },
           { label: "Fees Requested", value: allTotals == null ? "—" : fmt(allTotals.feeRequested), sub: "pending + completed petitions" },
-          { label: "Fees Received", value: allTotals == null ? "—" : fmt(allTotals.feesReceived), sub: "pending + completed petitions" },
         ].map((s) => (
           <div key={s.label} className={`${sectionCard} p-4`}>
             <p className={`text-[12px] font-semibold uppercase tracking-wider ${t.textMuted}`}>{s.label}</p>
@@ -1230,9 +1229,6 @@ export const FeePetitions = () => {
                 <th className={`${thBase} w-24 ${t.textSub} text-right sticky left-[256px] top-0 z-30 ${stickyHeaderBg}`}>
                   Fee Requested
                 </th>
-                <th className={`${thBase} w-24 ${t.textSub} text-right sticky top-0 z-20 ${stickyHeaderBg}`}>
-                  Fees Received
-                </th>
                 <th
                   aria-sort={ariaSortFor("approvalDate")}
                   className={`${thBase} ${t.textSub} text-left sticky top-0 z-20 ${stickyHeaderBg}`}
@@ -1388,27 +1384,6 @@ export const FeePetitions = () => {
                           textMuted={t.textMuted}
                           pencilRevealClass="opacity-0 group-hover/row:opacity-100"
                           onEdit={() => { setFeeAmountEdit({ rowId: row.id, field: "feeAmount", draft: String(row.feeAmount ?? 0) }); setFeeAmountError(null); }}
-                          onDraftChange={(v) => setFeeAmountEdit((p) => p ? { ...p, draft: v } : p)}
-                          onSave={saveFeeAmount}
-                          onCancel={() => { setFeeAmountEdit(null); setFeeAmountError(null); }}
-                        />
-                      </td>
-                      <td
-                        className={`${tdBase} w-24 text-right font-medium tabular-nums ${row.feesReceived != null && row.feesReceived > 0 ? (dark ? "text-emerald-400" : "text-emerald-600") : t.textMuted}`}
-                      >
-                        <FeeAmountCell
-                          active={canEditFees && feeAmountEdit?.rowId === row.id && feeAmountEdit.field === "feesReceived"}
-                          value={row.feesReceived ?? 0}
-                          draft={feeAmountEdit?.draft ?? ""}
-                          saving={feeAmountSaving}
-                          error={feeAmountError}
-                          canEdit={canEditFees}
-                          saveLabel="Fees Received"
-                          inputBg={t.inputBg}
-                          hoverCls={t.hover}
-                          textMuted={t.textMuted}
-                          pencilRevealClass="opacity-0 group-hover/row:opacity-100"
-                          onEdit={() => { setFeeAmountEdit({ rowId: row.id, field: "feesReceived", draft: String(row.feesReceived ?? 0) }); setFeeAmountError(null); }}
                           onDraftChange={(v) => setFeeAmountEdit((p) => p ? { ...p, draft: v } : p)}
                           onSave={saveFeeAmount}
                           onCancel={() => { setFeeAmountEdit(null); setFeeAmountError(null); }}

--- a/src/components/fee-petitions/FeePetitions.tsx
+++ b/src/components/fee-petitions/FeePetitions.tsx
@@ -42,10 +42,9 @@ interface FeePetitionRow {
   approvalDate: string | null;
   updatedAt: string | null;
   feeAmount: number | null;
-  feesReceived: number | null;
-  // Which fee_records benefit type Fee Requested/Fees Received edit —
-  // resolved server-side to whichever type actually has data (falling back
-  // to the case's registered claim type when nothing's entered yet).
+  // Which fee_records benefit type Fee Requested edits — resolved
+  // server-side to whichever type actually has data (falling back to the
+  // case's registered claim type when nothing's entered yet).
   activeFeeType: "t16" | "t2" | "aux";
   assignedTo: string | null;
   noa: boolean;
@@ -342,7 +341,7 @@ export const FeePetitions = () => {
       .catch(() => {});
   }, []);
 
-  const [allTotals, setAllTotals] = useState<{ feeRequested: number; feesReceived: number } | null>(null);
+  const [allTotals, setAllTotals] = useState<{ feeRequested: number } | null>(null);
 
   // Fees Requested/Received in the stats bar cover pending AND completed
   // petitions together — fetched with no status filter (unlike fetchPetitions,
@@ -360,7 +359,6 @@ export const FeePetitions = () => {
         if (json != null && mountedRef.current) {
           setAllTotals({
             feeRequested: typeof json.totalFeeRequested === "number" ? json.totalFeeRequested : 0,
-            feesReceived: typeof json.totalFeesReceived === "number" ? json.totalFeesReceived : 0,
           });
         }
       })
@@ -488,16 +486,14 @@ export const FeePetitions = () => {
   // (they're sums of t16/t2/aux Fee Due and Fee Received) — each cell edits
   // row.activeFeeType's column directly (resolved server-side to whichever
   // benefit type the case is actually using).
-  type FeeAmountField = "feeAmount" | "feesReceived";
   const [feeAmountEdit, setFeeAmountEdit] = useState<{
     rowId: number;
-    field: FeeAmountField;
     draft: string;
   } | null>(null);
   const [feeAmountSaving, setFeeAmountSaving] = useState(false);
   const [feeAmountError, setFeeAmountError] = useState<string | null>(null);
   const [feeAmountOverrides, setFeeAmountOverrides] = useState<
-    Record<number, Partial<Pick<FeePetitionRow, "feeAmount" | "feesReceived">>>
+    Record<number, Partial<Pick<FeePetitionRow, "feeAmount">>>
   >({});
   const feeAmountAbortRef = useRef<AbortController | null>(null);
 
@@ -520,10 +516,9 @@ export const FeePetitions = () => {
     }
     const row = rows.find((r) => r.id === feeAmountEdit.rowId);
     if (!row) return;
-    const dbField = feeAmountEdit.field === "feeAmount" ? "FeeDue" : "FeeReceived";
-    const patchField = `${row.activeFeeType}${dbField}`;
+    const patchField = `${row.activeFeeType}FeeDue`;
     const typeLabel = row.activeFeeType === "t16" ? "T16" : row.activeFeeType === "t2" ? "T2" : "AUX";
-    const label = `${typeLabel} ${feeAmountEdit.field === "feeAmount" ? "Fee Due" : "Received"}`;
+    const label = `${typeLabel} Fee Due`;
 
     feeAmountAbortRef.current?.abort();
     const controller = new AbortController();
@@ -546,7 +541,7 @@ export const FeePetitions = () => {
       }
       setFeeAmountOverrides((prev) => ({
         ...prev,
-        [row.id]: { ...prev[row.id], [feeAmountEdit.field]: amount },
+        [row.id]: { ...prev[row.id], feeAmount: amount },
       }));
       setFeeAmountEdit(null);
       fetchAllTotals();
@@ -1372,7 +1367,7 @@ export const FeePetitions = () => {
                         className={`${tdBase} w-24 ${t.text} text-right font-medium tabular-nums sticky left-[256px] z-10 ${stickyBg} ${stickyHover}`}
                       >
                         <FeeAmountCell
-                          active={canEditFees && feeAmountEdit?.rowId === row.id && feeAmountEdit.field === "feeAmount"}
+                          active={canEditFees && feeAmountEdit?.rowId === row.id}
                           value={row.feeAmount ?? 0}
                           draft={feeAmountEdit?.draft ?? ""}
                           saving={feeAmountSaving}
@@ -1383,7 +1378,7 @@ export const FeePetitions = () => {
                           hoverCls={t.hover}
                           textMuted={t.textMuted}
                           pencilRevealClass="opacity-0 group-hover/row:opacity-100"
-                          onEdit={() => { setFeeAmountEdit({ rowId: row.id, field: "feeAmount", draft: String(row.feeAmount ?? 0) }); setFeeAmountError(null); }}
+                          onEdit={() => { setFeeAmountEdit({ rowId: row.id, draft: String(row.feeAmount ?? 0) }); setFeeAmountError(null); }}
                           onDraftChange={(v) => setFeeAmountEdit((p) => p ? { ...p, draft: v } : p)}
                           onSave={saveFeeAmount}
                           onCancel={() => { setFeeAmountEdit(null); setFeeAmountError(null); }}

--- a/src/components/fee-petitions/FeePetitions.tsx
+++ b/src/components/fee-petitions/FeePetitions.tsx
@@ -219,8 +219,8 @@ export const FeePetitions = () => {
   const [sortDir, setSortDir] = useState<SortDir>(initialState.dir);
 
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
-  const [bulkClearing, setBulkClearing] = useState(false);
-  const [bulkConfirming, setBulkConfirming] = useState(false);
+  const [bulkChecklistSaving, setBulkChecklistSaving] = useState(false);
+  const [bulkChecklistConfirming, setBulkChecklistConfirming] = useState(false);
   const [exporting, setExporting] = useState(false);
   const [undoInfo, setUndoInfo] = useState<{
     rows: Array<{ caseId: number; fields: Record<CheckboxKey, boolean> }>;
@@ -417,7 +417,7 @@ export const FeePetitions = () => {
       // would keep shadowing newer data for that row indefinitely.
       setRowOverrides({});
       setSelectedIds(new Set());
-      setBulkConfirming(false);
+      setBulkChecklistConfirming(false);
       setTotal(typeof json.total === "number" ? json.total : data.length);
       if (Array.isArray(json.assignees)) setAssignees(json.assignees);
       if (typeof json.unassignedCount === "number") setUnassignedCount(json.unassignedCount);
@@ -581,7 +581,7 @@ export const FeePetitions = () => {
 
   const clearSelection = () => {
     setSelectedIds(new Set());
-    setBulkConfirming(false);
+    setBulkChecklistConfirming(false);
   };
 
   const toggleSelectAll = () => {
@@ -605,9 +605,9 @@ export const FeePetitions = () => {
     });
   };
 
-  const handleBulkMarkComplete = async () => {
-    if (selectedIds.size === 0 || bulkClearing) return;
-    setBulkClearing(true);
+  const handleBulkChecklistDone = async () => {
+    if (selectedIds.size === 0 || bulkChecklistSaving) return;
+    setBulkChecklistSaving(true);
     const ids = Array.from(selectedIds);
     const previouslyIncomplete = rows.filter(
       (r) => ids.includes(r.id) && !CHECKBOX_COLUMNS.every((c) => r[c.key]),
@@ -642,7 +642,7 @@ export const FeePetitions = () => {
     } catch (err) {
       setError((err as Error).message);
     } finally {
-      setBulkClearing(false);
+      setBulkChecklistSaving(false);
     }
   };
 
@@ -850,7 +850,7 @@ export const FeePetitions = () => {
   const rangeStart = total === 0 ? 0 : (page - 1) * pageSize + 1;
   const rangeEnd = Math.min(page * pageSize, total);
 
-  const selectedIncompleteCount = rows.filter(
+  const selectedChecklistIncompleteCount = rows.filter(
     (r) => selectedIds.has(r.id) && !CHECKBOX_COLUMNS.every((c) => r[c.key]),
   ).length;
 
@@ -935,7 +935,7 @@ export const FeePetitions = () => {
           className={`rounded-xl border p-3 flex items-center gap-3 ${dark ? "bg-emerald-900/20 border-emerald-800 text-emerald-300" : "bg-emerald-50 border-emerald-200 text-emerald-800"}`}
         >
           <Check aria-hidden="true" className="h-4 w-4 shrink-0" />
-          <span className="text-sm">Marked {undoInfo.rows.length} case{undoInfo.rows.length === 1 ? "" : "s"} as complete.</span>
+          <span className="text-sm">Marked all checklist steps done for {undoInfo.rows.length} case{undoInfo.rows.length === 1 ? "" : "s"}.</span>
           <button
             onClick={handleUndoBulk}
             disabled={undoing}
@@ -961,23 +961,23 @@ export const FeePetitions = () => {
           <div>
             {selectedIds.size > 0 ? (
               <div className="flex items-center gap-2 flex-wrap">
-                {bulkConfirming ? (
+                {bulkChecklistConfirming ? (
                   <>
                     <span className={`text-sm ${t.textMuted}`}>
-                      Mark {selectedIncompleteCount} case{selectedIncompleteCount !== 1 ? "s" : ""} as complete?
+                      Mark all steps done for {selectedChecklistIncompleteCount} case{selectedChecklistIncompleteCount !== 1 ? "s" : ""}?
                     </span>
                     <button
-                      onClick={handleBulkMarkComplete}
-                      disabled={bulkClearing || selectedIncompleteCount === 0}
+                      onClick={handleBulkChecklistDone}
+                      disabled={bulkChecklistSaving || selectedChecklistIncompleteCount === 0}
                       className={`h-7 px-3 rounded-md text-xs font-medium flex items-center gap-1.5 ${dark ? "bg-emerald-700 hover:bg-emerald-600 text-white" : "bg-emerald-600 hover:bg-emerald-700 text-white"} disabled:opacity-40 disabled:cursor-not-allowed transition-colors`}
                     >
-                      {bulkClearing
+                      {bulkChecklistSaving
                         ? <Loader2 aria-hidden="true" className="h-3 w-3 animate-spin" />
                         : <Check aria-hidden="true" className="h-3 w-3" />}
                       Confirm
                     </button>
                     <button
-                      onClick={() => setBulkConfirming(false)}
+                      onClick={() => setBulkChecklistConfirming(false)}
                       className={`h-7 px-3 rounded-md border text-xs font-medium ${t.outlineBtn}`}
                     >
                       Cancel
@@ -987,17 +987,17 @@ export const FeePetitions = () => {
                   <>
                     <span className={`text-sm font-bold ${t.text}`}>
                       {selectedIds.size} selected
-                      {selectedIncompleteCount < selectedIds.size && (
+                      {selectedChecklistIncompleteCount < selectedIds.size && (
                         <span className={`ml-1.5 font-normal ${t.textMuted}`}>
-                          ({selectedIncompleteCount} to check off)
+                          ({selectedChecklistIncompleteCount} to check off)
                         </span>
                       )}
                     </span>
                     <button
-                      onClick={() => setBulkConfirming(true)}
-                      disabled={selectedIncompleteCount === 0}
+                      onClick={() => setBulkChecklistConfirming(true)}
+                      disabled={selectedChecklistIncompleteCount === 0}
                       aria-label="Mark all checklist steps done for selected cases"
-                      title={selectedIncompleteCount === 0 ? "All selected cases already have all steps done" : undefined}
+                      title={selectedChecklistIncompleteCount === 0 ? "All selected cases already have all steps done" : undefined}
                       className={`h-7 px-3 rounded-md text-xs font-medium flex items-center gap-1.5 ${dark ? "bg-emerald-700 hover:bg-emerald-600 text-white" : "bg-emerald-600 hover:bg-emerald-700 text-white"} disabled:opacity-40 disabled:cursor-not-allowed transition-colors`}
                     >
                       <Check aria-hidden="true" className="h-3 w-3" />


### PR DESCRIPTION
## Summary
- Requested by Ms. Jazz: Completed Petitions should show cases where Fee Petition Approved is checked (the signal that a case is ready to move to Master Fee Records), not the old checklist+fees-received gate
- Pending list ("not yet approved") and Completed list ("fee petition approved") are now cleanly separated by a single checkbox rather than a compound condition
- Checking Fee Petition Approved on the Pending table moves the row to Completed immediately; unchecking it from the Completed table moves it back
- Fixed Completed Petitions' hardcoded green checkmarks — now shows real per-row checklist state (a completed case no longer implies all boxes are done)
- Added the Fee Petition Approved checkbox to the Completed Petitions table so staff can uncheck a mis-clicked approval without losing their place
- Updated the stat-card copy: "not yet approved" / "fee petition approved"
- Removed the checklist-completion side effect from toggleCheckbox (checking the 6th box no longer moves a row to Completed)