### PR TITLE
feat: default fee petitions sort to date added (newest first)

### DIFF
--- a/src/app/api/fee-petitions/route.ts
+++ b/src/app/api/fee-petitions/route.ts
@@ -4,7 +4,7 @@ import { cases, feePetitions, feeRecords } from "@/lib/db/schema";
 import { eq, ilike, sql } from "drizzle-orm";
 import { requirePageAccess, guardStatus } from "@/lib/auth-helpers";
 
-const SORT_KEYS = ["claimant", "approvalDate", "updatedAt", "progress"] as const;
+const SORT_KEYS = ["claimant", "approvalDate", "updatedAt", "progress", "createdAt"] as const;
 type SortKey = (typeof SORT_KEYS)[number];
 
 // Fee Requested/Received are sums across t16/t2/aux fee_records columns, but
@@ -173,7 +173,7 @@ export const GET = async (req: NextRequest) => {
     const sortParam = searchParams.get("sort");
     const sort: SortKey = SORT_KEYS.includes(sortParam as SortKey)
       ? (sortParam as SortKey)
-      : "approvalDate";
+      : "createdAt";
     const dir = searchParams.get("dir") === "asc" ? sql`asc` : sql`desc`;
     const rawPage = parseInt(searchParams.get("page") || "1");
     const rawLimit = parseInt(searchParams.get("limit") || "50");
@@ -291,7 +291,9 @@ export const GET = async (req: NextRequest) => {
           ? sql`${feePetitions.updatedAt} ${dir} NULLS LAST`
           : sort === "progress"
             ? sql`${progressExpr} ${dir} NULLS LAST`
-            : sql`${cases.approvalDate} ${dir} NULLS LAST`;
+            : sort === "approvalDate"
+              ? sql`${cases.approvalDate} ${dir} NULLS LAST`
+              : sql`${cases.createdAt} ${dir} NULLS LAST`;
 
     const rows = await db
       .select(ROW_COLUMNS)

--- a/src/components/fee-petitions/FeePetitions.tsx
+++ b/src/components/fee-petitions/FeePetitions.tsx
@@ -67,7 +67,7 @@ type CheckboxKey =
   | "ltrToClmtWithSignature"
   | "ltrToAlj"
   | "faxConfFeePet";
-type SortKey = "claimant" | "approvalDate" | "updatedAt" | "progress";
+type SortKey = "claimant" | "approvalDate" | "updatedAt" | "progress" | "createdAt";
 type SortDir = "asc" | "desc";
 type TouchedFilter = "" | "none";
 type MissingFilter = "" | CheckboxKey;
@@ -76,7 +76,7 @@ type Assignee = { name: string; count: number };
 
 // ---------- helpers ----------
 const PAGE_SIZE_OPTIONS = [25, 50, 100, 200];
-const SORT_KEYS: SortKey[] = ["claimant", "approvalDate", "updatedAt", "progress"];
+const SORT_KEYS: SortKey[] = ["claimant", "approvalDate", "updatedAt", "progress", "createdAt"];
 const CHECKBOX_KEYS = ["timeDelineation", "feePetitionDoc", "ltrToClmt", "ltrToClmtWithSignature", "ltrToAlj", "faxConfFeePet"] as const;
 
 const daysSince = (dateStr: string | null): number | null => {
@@ -98,7 +98,7 @@ const DEFAULTS = {
   missing: "" as MissingFilter,
   aging: "" as AgingFilter,
   assignedTo: "",
-  sort: "approvalDate" as SortKey,
+  sort: "createdAt" as SortKey,
   dir: "desc" as SortDir,
   page: 1,
   pageSize: 50,


### PR DESCRIPTION
Changes the default sort on the Fee Petitions page from **Approval Date** to **Date Added** (`cases.created_at DESC`), so newly added fee petition cases appear at the top of the list.

- Adds `createdAt` as a valid sort key in both the API route and client component
- Default fallback in the API changed from `approvalDate` → `createdAt`
- `DEFAULTS.sort` in the client changed to `"createdAt"`
- `approvalDate` column sort still works as a manual override (backward compatible with bookmarked URLs)