### PR TITLE
sync: develop → main (2026-07-16 #2)

### DIFF
--- a/src/app/(dashboard)/notifications/page.tsx
+++ b/src/app/(dashboard)/notifications/page.tsx
@@ -61,7 +61,7 @@ const TYPE_META: Record<
     darkColor: "text-emerald-400 bg-emerald-900/20 border-emerald-800/50",
   },
   call_target_missed: {
-    label: "Missed Calls",
+    label: "Calls Logged",
     icon: Phone,
     color: "text-amber-600 bg-amber-50 border-amber-200",
     darkColor: "text-amber-400 bg-amber-900/20 border-amber-800/50",
@@ -93,7 +93,7 @@ const FILTER_TABS: { key: FilterType; label: string }[] = [
   { key: "all", label: "All" },
   { key: "case_aging", label: "Case Aging" },
   { key: "fee_payment", label: "Payments" },
-  { key: "call_target_missed", label: "Missed Calls" },
+  { key: "call_target_missed", label: "Calls Logged" },
   { key: "case_assigned", label: "Assignments" },
   { key: "follow_up_due", label: "Follow-Ups" },
 ];

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -10,7 +10,7 @@ import { feePetitions } from "@/lib/db/schema";
 // Notification types visible only to their assigned agent — nobody else,
 // including leads/admins, sees these (unlike the other types, which are
 // team-wide operational alerts visible to anyone with page access).
-const AGENT_ONLY_TYPES = new Set(["follow_up_due"]);
+const AGENT_ONLY_TYPES = new Set(["follow_up_due", "fee_payment"]);
 
 const postBodySchema = z.object({
   type: z.enum(["case_aging", "fee_payment", "call_target_missed", "case_assigned", "follow_up_due"]),
@@ -324,6 +324,7 @@ async function computeLiveAlerts() {
       FROM team_members tm
       LEFT JOIN daily_metrics dm ON dm.agent_name = tm.name AND dm.metric_date = ${yesterdayStr}::date
       WHERE tm.is_active = TRUE
+        AND COALESCE(tm.role, '') != 'team_lead'
         AND (dm.id IS NULL OR (dm.ssa_calls = 0 AND dm.client_calls_ib = 0 AND dm.client_calls_ob = 0))
     `);
 


### PR DESCRIPTION
Syncs develop into main.

- feat: notifications — scope payments to agent, rename Missed Calls, exclude team leads (#285)