### PR TITLE
feat: restore Fees Received column in Completed Petitions

### DIFF
--- a/src/components/fee-petitions/CompletedPetitions.tsx
+++ b/src/components/fee-petitions/CompletedPetitions.tsx
@@ -392,10 +392,10 @@ export const CompletedPetitions = ({ dark }: Props) => {
                       Claimant {sortIcon("claimant")}
                     </button>
                   </th>
-                  <th className={`${thBase} w-24 min-w-24 max-w-24 ${t.textSub} text-right sticky left-40 top-0 z-30 ${stickyHeaderBg}`}>
+                  <th className={`${thBase} w-24 min-w-24 max-w-24 overflow-hidden ${t.textSub} text-right sticky left-40 top-0 z-30 ${stickyHeaderBg}`}>
                     Fee Requested
                   </th>
-                  <th className={`${thBase} ${t.textSub} text-right sticky top-0 z-20 ${stickyHeaderBg}`}>
+                  <th className={`${thBase} w-28 min-w-28 ${t.textSub} text-right sticky top-0 z-20 ${stickyHeaderBg}`}>
                     Fees Received
                   </th>
                   <th
@@ -499,7 +499,7 @@ export const CompletedPetitions = ({ dark }: Props) => {
                         >
                           {row.feeAmount != null ? fmt(row.feeAmount) : "—"}
                         </td>
-                        <td className={`${tdBase} ${t.textMuted} text-right tabular-nums`}>
+                        <td className={`${tdBase} w-28 min-w-28 ${t.textMuted} text-right tabular-nums`}>
                           {row.feesReceived != null ? fmt(row.feesReceived) : "—"}
                         </td>
                         <td className={`${tdBase} ${t.textMuted}`}>{fmtDate(row.approvalDate)}</td>

--- a/src/components/fee-petitions/CompletedPetitions.tsx
+++ b/src/components/fee-petitions/CompletedPetitions.tsx
@@ -28,6 +28,7 @@ interface CompletedRow {
   approvalDate: string | null;
   updatedAt: string | null;
   feeAmount: number | null;
+  feesReceived: number | null;
   assignedTo: string | null;
   noa: boolean;
   timeDelineation: boolean;
@@ -254,8 +255,8 @@ export const CompletedPetitions = ({ dark }: Props) => {
   const stickyHeaderBg = dark ? "bg-neutral-900" : "bg-white";
   const stickyBg = dark ? "bg-emerald-900" : "bg-emerald-100";
   const stickyHover = dark ? "group-hover/row:bg-emerald-800" : "group-hover/row:bg-emerald-200";
-  // claimant + fee requested + fees received + approved + completed + assigned + 7 checkbox cols + note
-  const colSpan = CHECKBOX_COLUMNS.length + 7;
+  // claimant + fee requested + fees received + approved + completed + assigned + 7 checkbox cols + approved flag + note
+  const colSpan = CHECKBOX_COLUMNS.length + 8;
 
   return (
     // contain:layout stops the sticky frozen-column/header cells in the table
@@ -394,6 +395,9 @@ export const CompletedPetitions = ({ dark }: Props) => {
                   <th className={`${thBase} w-24 min-w-24 max-w-24 ${t.textSub} text-right sticky left-40 top-0 z-30 ${stickyHeaderBg}`}>
                     Fee Requested
                   </th>
+                  <th className={`${thBase} ${t.textSub} text-right sticky top-0 z-20 ${stickyHeaderBg}`}>
+                    Fees Received
+                  </th>
                   <th
                     aria-sort={sortKey === "approvalDate" ? (sortDir === "asc" ? "ascending" : "descending") : "none"}
                     className={`${thBase} ${t.textSub} text-left sticky top-0 z-20 ${stickyHeaderBg}`}
@@ -494,6 +498,9 @@ export const CompletedPetitions = ({ dark }: Props) => {
                           className={`${tdBase} w-24 min-w-24 max-w-24 ${t.text} text-right font-medium tabular-nums sticky left-40 z-10 ${stickyBg} ${stickyHover}`}
                         >
                           {row.feeAmount != null ? fmt(row.feeAmount) : "—"}
+                        </td>
+                        <td className={`${tdBase} ${t.textMuted} text-right tabular-nums`}>
+                          {row.feesReceived != null ? fmt(row.feesReceived) : "—"}
                         </td>
                         <td className={`${tdBase} ${t.textMuted}`}>{fmtDate(row.approvalDate)}</td>
                         <td className={`${tdBase} ${t.textMuted}`}>{fmtDate(row.updatedAt)}</td>


### PR DESCRIPTION
Adds back the Fees Received column to the Completed Petitions table only, per Ms. Jazz and Lori's request.

- `feesReceived` field added to `CompletedRow` type — the API already returns it, the type just wasn't declaring it
- Column header inserted after Fee Requested
- Cell renders `fmt(row.feesReceived)` (right-aligned, tabular nums), falling back to `—`
- `colSpan` incremented from 7 to 8

The main Fee Petitions tab is unchanged.