### PR TITLE
feat: default overpaid cases sort to date added (newest first)

### DIFF
--- a/src/app/api/overpaid-cases/route.ts
+++ b/src/app/api/overpaid-cases/route.ts
@@ -4,7 +4,7 @@ import { cases, feeRecords, overpaidCases } from "@/lib/db/schema";
 import { eq, ilike, sql } from "drizzle-orm";
 import { requirePageAccess, guardStatus } from "@/lib/auth-helpers";
 
-const SORT_KEYS = ["claimant", "feesReceived", "overpaidAmount", "opLtrDate", "assignedTo"] as const;
+const SORT_KEYS = ["claimant", "feesReceived", "overpaidAmount", "opLtrDate", "assignedTo", "createdAt"] as const;
 type SortKey = (typeof SORT_KEYS)[number];
 
 // GET /api/overpaid-cases?page=&limit=&search=&sort=&dir=&status=&agent=&ltr=&minAmount=&maxAmount=
@@ -29,7 +29,7 @@ export const GET = async (req: NextRequest) => {
     const sortParam = searchParams.get("sort");
     const sort: SortKey = SORT_KEYS.includes(sortParam as SortKey)
       ? (sortParam as SortKey)
-      : "overpaidAmount";
+      : "createdAt";
     const dir = searchParams.get("dir") === "asc" ? sql`asc` : sql`desc`;
     const rawPage = parseInt(searchParams.get("page") || "1");
     const rawLimit = parseInt(searchParams.get("limit") || "50");
@@ -122,7 +122,9 @@ export const GET = async (req: NextRequest) => {
             ? sql`${overpaidCases.opLtrReceived} ${dir} NULLS LAST`
             : sort === "assignedTo"
               ? sql`${feeRecords.assignedTo} ${dir} NULLS LAST`
-              : sql`${overpaidCases.overpaidAmount} ${dir} NULLS LAST`;
+              : sort === "overpaidAmount"
+                ? sql`${overpaidCases.overpaidAmount} ${dir} NULLS LAST`
+                : sql`${cases.createdAt} ${dir} NULLS LAST`;
 
     const rows = await db
       .select({

--- a/src/components/overpaid-cases/OverpaidCases.tsx
+++ b/src/components/overpaid-cases/OverpaidCases.tsx
@@ -50,20 +50,20 @@ interface OverpaidCaseRow {
 }
 
 type CheckboxKey = "checksCleared";
-type SortKey = "claimant" | "feesReceived" | "overpaidAmount" | "opLtrDate" | "assignedTo";
+type SortKey = "claimant" | "feesReceived" | "overpaidAmount" | "opLtrDate" | "assignedTo" | "createdAt";
 type SortDir = "asc" | "desc";
 type LtrFilter = "" | "none";
 
 // ---------- helpers ----------
 const PAGE_SIZE_OPTIONS = [25, 50, 100, 200];
-const SORT_KEYS: SortKey[] = ["claimant", "feesReceived", "overpaidAmount", "opLtrDate", "assignedTo"];
+const SORT_KEYS: SortKey[] = ["claimant", "feesReceived", "overpaidAmount", "opLtrDate", "assignedTo", "createdAt"];
 const DEFAULTS = {
   search: "",
   agent: "",
   ltr: "" as LtrFilter,
   minAmount: "",
   maxAmount: "",
-  sort: "overpaidAmount" as SortKey,
+  sort: "createdAt" as SortKey,
   dir: "desc" as SortDir,
   page: 1,
   pageSize: 50,


### PR DESCRIPTION
Changes the default sort on the Overpaid Cases page from **Overpaid Amount** to **Date Added** (`cases.created_at DESC`), so newly added overpaid cases appear at the top of the list.

Same pattern as Fee Petitions (#282): adds `createdAt` as a valid sort key in both the API route and client component; the Overpaid Amount column header still works as a manual sort override.