### PR TITLE
feat: fee petition agents in reports, inbound call history renames and MyCase link

### DIFF
--- a/src/app/api/scoreboard/route.ts
+++ b/src/app/api/scoreboard/route.ts
@@ -146,8 +146,9 @@ export const GET = async (req: NextRequest) => {
         END AS open_cases,
 
         -- Cases closed within the window
-        -- Fee Petition specialists: count approved petitions (completed petitions)
-        -- All other agents: count closed fee_records in the window
+        -- Fee Petition specialists: all-time count of approved petitions —
+        -- no approved_at column exists so the count is not date-windowed.
+        -- All other agents: count closed fee_records in the window.
         CASE WHEN tm.team = 'Fee Petition' THEN
           (SELECT COUNT(*) FROM fee_petitions fp
            WHERE fp.assigned_to = tm.name

--- a/src/app/api/scoreboard/route.ts
+++ b/src/app/api/scoreboard/route.ts
@@ -133,15 +133,31 @@ export const GET = async (req: NextRequest) => {
         (SELECT COUNT(*) FROM fee_records fr WHERE fr.assigned_to = tm.name) AS cases_assigned,
 
         -- Open cases (current snapshot)
-        (SELECT COUNT(*) FROM fee_records fr
-         WHERE fr.assigned_to = tm.name
-         AND fr.is_closed = FALSE) AS open_cases,
+        -- Fee Petition specialists: count active (not-approved) fee petitions
+        -- All other agents: count open fee_records
+        CASE WHEN tm.team = 'Fee Petition' THEN
+          (SELECT COUNT(*) FROM fee_petitions fp
+           WHERE fp.assigned_to = tm.name
+           AND fp.fee_petition_approved = FALSE)
+        ELSE
+          (SELECT COUNT(*) FROM fee_records fr
+           WHERE fr.assigned_to = tm.name
+           AND fr.is_closed = FALSE)
+        END AS open_cases,
 
         -- Cases closed within the window
-        (SELECT COUNT(*) FROM fee_records fr
-         WHERE fr.assigned_to = tm.name
-         AND fr.closed_at >= ${startDate}::date
-         AND fr.closed_at < ${endExclusive}::date) AS cases_closed,
+        -- Fee Petition specialists: count approved petitions (completed petitions)
+        -- All other agents: count closed fee_records in the window
+        CASE WHEN tm.team = 'Fee Petition' THEN
+          (SELECT COUNT(*) FROM fee_petitions fp
+           WHERE fp.assigned_to = tm.name
+           AND fp.fee_petition_approved = TRUE)
+        ELSE
+          (SELECT COUNT(*) FROM fee_records fr
+           WHERE fr.assigned_to = tm.name
+           AND fr.closed_at >= ${startDate}::date
+           AND fr.closed_at < ${endExclusive}::date)
+        END AS cases_closed,
 
         -- Completed win sheets (status = paid_in_full or closed, current snapshot)
         (SELECT COUNT(*) FROM fee_records fr
@@ -206,9 +222,12 @@ export const GET = async (req: NextRequest) => {
         COALESCE((SELECT SUM(fr.total_fees_paid::numeric) FROM fee_records fr WHERE fr.assigned_to = tm.name), 0) AS total_collected,
 
         -- Fees collected within the window (see ledger_in_window above)
-        COALESCE((
+        -- Fee Petition specialists are not responsible for collecting money — NULL renders as "—"
+        CASE WHEN tm.team = 'Fee Petition' THEN NULL
+        ELSE COALESCE((
           SELECT SUM(l.amt) FROM ledger_in_window l WHERE l.agent = tm.name
-        ), 0) AS fees_collected_in_window,
+        ), 0)
+        END AS fees_collected_in_window,
 
         -- Cases with full fee collected (PIF)
         (SELECT COUNT(*) FROM fee_records fr
@@ -302,7 +321,7 @@ export const GET = async (req: NextRequest) => {
         unpaidT16Over90: Number(r.unpaid_t16_over_90),
         unpaidConcOver90: Number(r.unpaid_conc_over_90),
         totalCollected: Number(r.total_collected),
-        feesCollectedInWindow: Number(r.fees_collected_in_window),
+        feesCollectedInWindow: r.fees_collected_in_window != null ? Number(r.fees_collected_in_window) : null,
         casesFullFee: Number(r.cases_full_fee),
         weekSsaCalls: Number(r.week_ssa_calls),
         weekClientCalls: Number(r.week_client_calls),
@@ -327,7 +346,7 @@ export const GET = async (req: NextRequest) => {
       totalUnpaidT16Over90: agents.reduce((s, a) => s + a.unpaidT16Over90, 0),
       totalUnpaidConcOver90: agents.reduce((s, a) => s + a.unpaidConcOver90, 0),
       totalCollected: agents.reduce((s, a) => s + a.totalCollected, 0),
-      totalFeesCollectedInWindow: agents.reduce((s, a) => s + a.feesCollectedInWindow, 0),
+      totalFeesCollectedInWindow: agents.reduce((s, a) => s + (a.feesCollectedInWindow ?? 0), 0),
       totalCasesFullFee: agents.reduce((s, a) => s + a.casesFullFee, 0),
       totalSsaCalls: agents.reduce((s, a) => s + a.weekSsaCalls, 0),
       totalClientCalls: agents.reduce((s, a) => s + a.weekClientCalls, 0),
@@ -356,7 +375,7 @@ export const GET = async (req: NextRequest) => {
         unpaidT16Over60: members.reduce((s, a) => s + a.unpaidT16Over60, 0),
         unpaidConcOver60: members.reduce((s, a) => s + a.unpaidConcOver60, 0),
         totalCollected: members.reduce((s, a) => s + a.totalCollected, 0),
-        feesCollectedInWindow: members.reduce((s, a) => s + a.feesCollectedInWindow, 0),
+        feesCollectedInWindow: members.reduce((s, a) => s + (a.feesCollectedInWindow ?? 0), 0),
         casesFullFee: members.reduce((s, a) => s + a.casesFullFee, 0),
         ssaCalls: members.reduce((s, a) => s + a.weekSsaCalls, 0),
         clientCalls: members.reduce((s, a) => s + a.weekClientCalls, 0),

--- a/src/app/api/scoreboard/route.ts
+++ b/src/app/api/scoreboard/route.ts
@@ -336,8 +336,11 @@ export const GET = async (req: NextRequest) => {
     // Overall summary (all agents)
     const summary = {
       totalCasesAssigned: agents.reduce((s, a) => s + a.casesAssigned, 0),
-      totalOpenCases: agents.reduce((s, a) => s + a.openCases, 0),
-      totalCasesClosed: agents.reduce((s, a) => s + a.casesClosed, 0),
+      // Fee Petition agents excluded — their open/closed counts source from
+      // fee_petitions (not fee_records) and would double-count cases already
+      // owned by regular agents.
+      totalOpenCases: agents.reduce((s, a) => a.team === "Fee Petition" ? s : s + a.openCases, 0),
+      totalCasesClosed: agents.reduce((s, a) => a.team === "Fee Petition" ? s : s + a.casesClosed, 0),
       totalCompletedWinSheets: agents.reduce((s, a) => s + a.completedWinSheets, 0),
       totalWinSheetsCreated: agents.reduce((s, a) => s + a.winSheetsCreated, 0),
       totalUnpaidT2Over60: agents.reduce((s, a) => s + a.unpaidT2Over60, 0),

--- a/src/components/inbound-calls/InboundCallsClient.tsx
+++ b/src/components/inbound-calls/InboundCallsClient.tsx
@@ -13,6 +13,7 @@ import {
   ChevronDown,
   Check,
   Upload,
+  ExternalLink,
 } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
 import CsvImportModal, { type ColumnDef } from "@/components/modals/CsvImportModal";
@@ -577,10 +578,10 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
                 <tr className={`border-b ${dark ? "border-neutral-700/60" : "border-neutral-100"}`}>
                   <th className={thCls} style={{ width: 110 }}>Date</th>
                   <th className={thCls} style={{ width: 130 }}>Number</th>
-                  <th className={thCls}>Transcript</th>
+                  <th className={thCls}>Reason for Calling</th>
                   <th className={thCls} style={{ width: 160 }}>Case Link</th>
                   <th className={thCls} style={{ width: 180 }}>Collection Specialist</th>
-                  <th className={`${thCls} text-center`} style={{ width: 80 }}>Resolved</th>
+                  <th className={`${thCls} text-center`} style={{ width: 80 }}>CB done</th>
                   <th className={thCls} style={{ width: 40 }}></th>
                 </tr>
               </thead>
@@ -611,11 +612,11 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
                         className={`${inputCls} disabled:opacity-50 disabled:cursor-default`}
                       />
                     </td>
-                    {/* Transcript */}
+                    {/* Reason for Calling */}
                     <td className={tdCls}>
                       <textarea
                         value={row.transcript}
-                        placeholder="Call notes"
+                        placeholder="Reason for calling"
                         rows={2}
                         onChange={(e) => handleFieldChange(row.id, "transcript", e.target.value)}
                         onBlur={(e) => updateRecord(row.id, "transcript", e.target.value || null)}
@@ -624,14 +625,28 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
                     </td>
                     {/* Case Link */}
                     <td className={tdCls}>
-                      <input
-                        type="text"
-                        value={row.caseLink}
-                        placeholder="URL or case ID"
-                        onChange={(e) => handleFieldChange(row.id, "caseLink", e.target.value)}
-                        onBlur={(e) => updateRecord(row.id, "caseLink", e.target.value || null)}
-                        className={`${inputCls} disabled:opacity-50 disabled:cursor-default`}
-                      />
+                      <div className="flex items-center gap-1">
+                        <input
+                          type="text"
+                          value={row.caseLink}
+                          placeholder="URL or case ID"
+                          onChange={(e) => handleFieldChange(row.id, "caseLink", e.target.value)}
+                          onBlur={(e) => updateRecord(row.id, "caseLink", e.target.value || null)}
+                          className={`${inputCls} disabled:opacity-50 disabled:cursor-default flex-1 min-w-0`}
+                        />
+                        {row.caseLink && (
+                          <a
+                            href={row.caseLink.startsWith("http") ? row.caseLink : `https://rgdr.mycase.com/court_cases/${row.caseLink}`}
+                            target="_blank"
+                            rel="noreferrer"
+                            aria-label="Open in MyCase"
+                            title="Open in MyCase"
+                            className={`shrink-0 p-1 rounded transition-colors ${dark ? "text-indigo-400 hover:text-indigo-300" : "text-indigo-600 hover:text-indigo-800"}`}
+                          >
+                            <ExternalLink aria-hidden="true" className="h-3.5 w-3.5" />
+                          </a>
+                        )}
+                      </div>
                     </td>
                     {/* Specialist */}
                     <td className={tdCls}>
@@ -657,7 +672,7 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
                           handleFieldChange(row.id, "calledBackResolved", next);
                           updateRecord(row.id, "calledBackResolved", next);
                         }}
-                        aria-label={row.calledBackResolved ? "Mark unresolved" : "Mark resolved"}
+                        aria-label={row.calledBackResolved ? "Mark CB undone" : "Mark CB done"}
                         className={`w-5 h-5 rounded border-2 flex items-center justify-center mx-auto transition-colors ${
                           row.calledBackResolved
                             ? "bg-emerald-500 border-emerald-500"

--- a/src/components/inbound-calls/InboundCallsClient.tsx
+++ b/src/components/inbound-calls/InboundCallsClient.tsx
@@ -634,9 +634,9 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
                           onBlur={(e) => updateRecord(row.id, "caseLink", e.target.value || null)}
                           className={`${inputCls} disabled:opacity-50 disabled:cursor-default flex-1 min-w-0`}
                         />
-                        {row.caseLink && (
+                        {row.caseLink.trim() && (
                           <a
-                            href={row.caseLink.startsWith("http") ? row.caseLink : `https://rgdr.mycase.com/court_cases/${row.caseLink}`}
+                            href={row.caseLink.trim().startsWith("http") ? row.caseLink.trim() : `https://rgdr.mycase.com/court_cases/${row.caseLink.trim()}`}
                             target="_blank"
                             rel="noreferrer"
                             aria-label="Open in MyCase"

--- a/src/components/overpaid-cases/OverpaidCases.tsx
+++ b/src/components/overpaid-cases/OverpaidCases.tsx
@@ -1222,7 +1222,7 @@ export const OverpaidCases = () => {
                     Overpaid Amount {sortIcon("overpaidAmount")}
                   </button>
                 </th>
-                <th className={`${thBase} ${t.textSub} text-left sticky top-0 z-20 ${stickyHeaderBg}`}>PIF</th>
+                <th className={`${thBase} ${t.textSub} text-left sticky top-0 z-20 ${stickyHeaderBg} min-w-28`}>PIF</th>
                 <th className={`${thBase} ${t.textSub} text-left sticky top-0 z-20 ${stickyHeaderBg}`}>Notice Sent</th>
                 <th
                   aria-sort={ariaSortFor("opLtrDate")}
@@ -1356,7 +1356,7 @@ export const OverpaidCases = () => {
                           )}
                         </div>
                       </td>
-                      <td className={`${tdBase}`}>
+                      <td className={`${tdBase} min-w-28`}>
                         <div className="relative">
                           <input
                             type="text"

--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -49,7 +49,7 @@ interface AgentScore {
   unpaidT16Over90: number;
   unpaidConcOver90: number;
   totalCollected: number;
-  feesCollectedInWindow: number;
+  feesCollectedInWindow: number | null;
   casesFullFee: number;
   weekSsaCalls: number;
   weekClientCalls: number;
@@ -391,7 +391,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
     unpaidT16Over90:    filteredAgents.reduce((s, a) => s + a.unpaidT16Over90, 0),
     unpaidConcOver90:   filteredAgents.reduce((s, a) => s + a.unpaidConcOver90, 0),
     totalCollected:     filteredAgents.reduce((s, a) => s + a.totalCollected, 0),
-    feesCollectedInWindow: filteredAgents.reduce((s, a) => s + a.feesCollectedInWindow, 0),
+    feesCollectedInWindow: filteredAgents.reduce((s, a) => s + (a.feesCollectedInWindow ?? 0), 0),
     casesFullFee:       filteredAgents.reduce((s, a) => s + a.casesFullFee, 0),
     openNoFees:         filteredAgents.reduce((s, a) => s + a.openNoFees, 0),
     openPartial:        filteredAgents.reduce((s, a) => s + a.openPartial, 0),
@@ -899,8 +899,8 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                       {showCol("closedcases") && <td className={`${tdBase} text-right ${t.textSub}`}>{a.casesClosed}</td>}
                       {showCol("opennofees")  && <td className={`${tdBase} text-right ${a.openNoFees  > 0 ? (dark ? "text-amber-400"   : "text-amber-600")   : t.textMuted}`}>{a.openNoFees}</td>}
                       {showCol("collected") && (
-                        <td className={`${tdBase} text-right font-semibold ${a.feesCollectedInWindow > 0 ? "text-emerald-500" : t.textMuted}`}>
-                          {fmt(a.feesCollectedInWindow)}
+                        <td className={`${tdBase} text-right font-semibold ${a.feesCollectedInWindow != null && a.feesCollectedInWindow > 0 ? "text-emerald-500" : t.textMuted}`}>
+                          {a.feesCollectedInWindow != null ? fmt(a.feesCollectedInWindow) : "—"}
                         </td>
                       )}
                       {showCol("ssacalls")    && <td className={`${tdBase} text-right border-l ${t.borderLight} ${dark ? "text-sky-400" : "text-sky-600"}`}>{a.weekSsaCalls}</td>}

--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -876,7 +876,19 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                         </span>
                       </td>
                       {showCol("cases")       && <td className={`${tdBase} text-right ${t.text}`}>{a.openCases}</td>}
-                      {showCol("closedcases") && <td className={`${tdBase} text-right ${t.textSub}`}>{a.casesClosed}</td>}
+                      {showCol("closedcases") && (
+                        <td className={`${tdBase} text-right ${t.textSub}`}>
+                          {a.casesClosed}
+                          {a.team === "Fee Petition" && a.casesClosed > 0 && (
+                            <span
+                              title="All-time total — no completion date available for fee petitions"
+                              className={`ml-1 text-[10px] ${t.textMuted}`}
+                            >
+                              *
+                            </span>
+                          )}
+                        </td>
+                      )}
                       {showCol("opennofees")  && <td className={`${tdBase} text-right ${a.openNoFees  > 0 ? (dark ? "text-amber-400"   : "text-amber-600")   : t.textMuted}`}>{a.openNoFees}</td>}
                       {showCol("collected") && (
                         <td className={`${tdBase} text-right font-semibold ${a.feesCollectedInWindow != null && a.feesCollectedInWindow > 0 ? "text-emerald-500" : t.textMuted}`}>
@@ -896,7 +908,15 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                     {showCol("cases")       && <td className={`${tdBase} text-right font-bold ${t.text}`}>{filteredTotals.openCases}</td>}
                     {showCol("closedcases") && <td className={`${tdBase} text-right font-bold ${t.textSub}`}>{filteredTotals.casesClosed}</td>}
                     {showCol("opennofees")  && <td className={`${tdBase} text-right font-bold ${dark ? "text-amber-400"   : "text-amber-600"}`}>{filteredTotals.openNoFees}</td>}
-                    {showCol("collected")   && <td className={`${tdBase} text-right font-bold ${filteredTotals.feesCollectedInWindow > 0 ? "text-emerald-500" : t.textMuted}`}>{filteredAgents.every(a => a.feesCollectedInWindow == null) ? "—" : fmt(filteredTotals.feesCollectedInWindow)}</td>}
+                    {showCol("collected")   && (() => {
+                      const allNull = filteredAgents.every(a => a.feesCollectedInWindow == null);
+                      const total = filteredTotals.feesCollectedInWindow;
+                      return (
+                        <td className={`${tdBase} text-right font-bold ${!allNull && total > 0 ? "text-emerald-500" : t.textMuted}`}>
+                          {allNull ? "—" : fmt(total)}
+                        </td>
+                      );
+                    })()}
                     {showCol("ssacalls")    && <td className={`${tdBase} text-right font-bold border-l ${t.borderLight} ${dark ? "text-sky-400" : "text-sky-600"}`}>{filteredTotals.weekSsaCalls}</td>}
                     {showCol("clientcalls") && <td className={`${tdBase} text-right font-bold ${dark ? "text-indigo-400" : "text-indigo-600"}`}>{filteredTotals.weekClientCalls}</td>}
                     {showCol("faxsent")     && <td className={`${tdBase} text-right font-bold ${t.textSub}`}>{filteredTotals.weekFaxSent}</td>}

--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -13,7 +13,6 @@ import {
   RefreshCw,
   Phone,
   Search,
-  AlertTriangle,
   AlertCircle,
   Pencil,
   Save,
@@ -164,10 +163,6 @@ const fmtRangeDate = (iso: string): string =>
 const cellKey = (agent: string, date: string): CellKey => `${agent}|${date}`;
 const EMPTY_CELL: CellValues = { ssaCalls: "", clientCallsIb: "", clientCallsOb: "", winSheetsCreated: "", faxSent: "" };
 
-const hasOverdue = (a: AgentScore, t2d: 60 | 90, t16d: 60 | 90, concd: 60 | 90) =>
-  (t2d === 60 ? a.unpaidT2Over60 : a.unpaidT2Over90) +
-  (t16d === 60 ? a.unpaidT16Over60 : a.unpaidT16Over90) +
-  (concd === 60 ? a.unpaidConcOver60 : a.unpaidConcOver90) > 0;
 
 // ---------- component ----------
 
@@ -187,10 +182,6 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
   // The T2/T16/Conc aging columns (and their 60d/90d toggle buttons) were
   // removed from the table, but "Needs attention" still checks these
   // thresholds under the hood — fixed at 60d since there's no UI to change it.
-  const t2Days: 60 | 90 = 60;
-  const t16Days: 60 | 90 = 60;
-  const concDays: 60 | 90 = 60;
-  const [needsAttention, setNeedsAttention] = useState(false);
   const [metricFocus, setMetricFocus] = useState<MetricFocus>("all");
 
   const [dateMode, setDateMode] = useState<DateMode>("week");
@@ -367,19 +358,21 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
       .filter((a) => {
         if (q && !a.agent.toLowerCase().includes(q)) return false;
         if (teamFilter !== "all" && a.team !== teamFilter) return false;
-        if (needsAttention && !hasOverdue(a, t2Days, t16Days, concDays)) return false;
         return true;
       })
       // Alphabetical by name — the underlying query orders by team then
       // name, which left agents with no team (a handful of departed staff)
       // clustered at the very bottom instead of sorted in with everyone else.
       .sort((a, b) => a.agent.localeCompare(b.agent));
-  }, [data, agentSearch, teamFilter, t2Days, t16Days, concDays, needsAttention]);
+  }, [data, agentSearch, teamFilter]);
 
   const filteredTotals = useMemo(() => ({
     casesAssigned:      filteredAgents.reduce((s, a) => s + a.casesAssigned, 0),
-    openCases:          filteredAgents.reduce((s, a) => s + a.openCases, 0),
-    casesClosed:        filteredAgents.reduce((s, a) => s + a.casesClosed, 0),
+    // Fee Petition specialists' open/closed counts are excluded from totals —
+    // their cases are originally assigned from regular agents' pools, so
+    // including them would double-count against the team's actual case numbers.
+    openCases:          filteredAgents.reduce((s, a) => a.team === "Fee Petition" ? s : s + a.openCases, 0),
+    casesClosed:        filteredAgents.reduce((s, a) => a.team === "Fee Petition" ? s : s + a.casesClosed, 0),
     weekSsaCalls:       filteredAgents.reduce((s, a) => s + a.weekSsaCalls, 0),
     weekClientCalls:    filteredAgents.reduce((s, a) => s + a.weekClientCalls, 0),
     weekFaxSent:        filteredAgents.reduce((s, a) => s + a.weekFaxSent, 0),
@@ -832,6 +825,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                 <option value="T2">T2</option>
                 <option value="T16">T16</option>
                 <option value="Concurrent">Concurrent</option>
+                <option value="Fee Petition">Fee Petition</option>
               </select>
               <select
                 value={metricFocus}
@@ -843,20 +837,6 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                   <option key={o.value} value={o.value}>{o.label}</option>
                 ))}
               </select>
-              <button
-                onClick={() => setNeedsAttention((v) => !v)}
-                aria-pressed={needsAttention}
-                className={`h-8 px-3 rounded-md border text-xs font-medium flex items-center gap-1.5 transition-colors ${
-                  needsAttention
-                    ? dark
-                      ? "bg-red-900/30 border-red-700 text-red-300"
-                      : "bg-red-50 border-red-300 text-red-700"
-                    : `${t.outlineBtn} border`
-                }`}
-              >
-                <AlertTriangle aria-hidden="true" className="h-3 w-3" />
-                Needs attention
-              </button>
               <span className={`ml-auto text-[13px] ${t.textMuted}`}>
                 {filteredAgents.length} of {data.agents.length} agents
               </span>
@@ -916,7 +896,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                     {showCol("cases")       && <td className={`${tdBase} text-right font-bold ${t.text}`}>{filteredTotals.openCases}</td>}
                     {showCol("closedcases") && <td className={`${tdBase} text-right font-bold ${t.textSub}`}>{filteredTotals.casesClosed}</td>}
                     {showCol("opennofees")  && <td className={`${tdBase} text-right font-bold ${dark ? "text-amber-400"   : "text-amber-600"}`}>{filteredTotals.openNoFees}</td>}
-                    {showCol("collected")   && <td className={`${tdBase} text-right font-bold text-emerald-500`}>{fmt(filteredTotals.feesCollectedInWindow)}</td>}
+                    {showCol("collected")   && <td className={`${tdBase} text-right font-bold ${filteredTotals.feesCollectedInWindow > 0 ? "text-emerald-500" : t.textMuted}`}>{filteredAgents.every(a => a.feesCollectedInWindow == null) ? "—" : fmt(filteredTotals.feesCollectedInWindow)}</td>}
                     {showCol("ssacalls")    && <td className={`${tdBase} text-right font-bold border-l ${t.borderLight} ${dark ? "text-sky-400" : "text-sky-600"}`}>{filteredTotals.weekSsaCalls}</td>}
                     {showCol("clientcalls") && <td className={`${tdBase} text-right font-bold ${dark ? "text-indigo-400" : "text-indigo-600"}`}>{filteredTotals.weekClientCalls}</td>}
                     {showCol("faxsent")     && <td className={`${tdBase} text-right font-bold ${t.textSub}`}>{filteredTotals.weekFaxSent}</td>}


### PR DESCRIPTION
Two features from Ms. Jazz's requests.

**Reports page — Fee Petition specialists (Jan, Racquel)**
Agents with `team_members.team = 'Fee Petition'` now get their open/closed counts from the fee petitions workflow instead of `fee_records`:
- **Open** = active fee petitions assigned to them (`fee_petition_approved = FALSE`)
- **Closed** = completed petitions (`fee_petition_approved = TRUE`)
- **Fees Collected** = "—" (null returned from API, excluded from team totals — they're not responsible for collecting money)

**Inbound Call History page**
- "Transcript" column renamed → "Reason for Calling" (header + placeholder)
- "Resolved" column renamed → "CB done" (header + aria labels)
- Case link: `ExternalLink` icon button added alongside the text input; clicking opens the URL in MyCase directly (`http*` values used as-is, otherwise constructs `https://rgdr.mycase.com/court_cases/{value}`)