### PR TITLE
feat: fee petition approved notifications tab, fix Level dropdown options

### DIFF
--- a/src/app/(dashboard)/notifications/page.tsx
+++ b/src/app/(dashboard)/notifications/page.tsx
@@ -13,6 +13,7 @@ import {
   PhoneCall,
   UserPlus,
   CheckCheck,
+  CheckCircle2,
   RefreshCw,
   ChevronRight,
   Eye,
@@ -20,6 +21,7 @@ import {
 } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
 import { PaymentsTab } from "@/components/notifications/PaymentsTab";
+import { FeePetitionApprovedTab } from "@/components/notifications/FeePetitionApprovedTab";
 import { RecentActivityTab } from "@/components/notifications/RecentActivityTab";
 import { NewCasesTab } from "@/components/notifications/NewCasesTab";
 
@@ -41,7 +43,7 @@ interface Notification {
 }
 
 type FilterType = "all" | Notification["type"];
-type PageTab = "notifications" | "payments" | "recent_activity" | "new_cases";
+type PageTab = "notifications" | "payments" | "fee_petition_approved" | "recent_activity" | "new_cases";
 
 const TYPE_META: Record<
   Notification["type"],
@@ -99,9 +101,10 @@ const FILTER_TABS: { key: FilterType; label: string }[] = [
 
 const PAGE_TABS: { key: PageTab; label: string; icon: React.ElementType }[] = [
   { key: "notifications",   label: "Notifications",   icon: Bell },
-  { key: "payments",        label: "Payments",        icon: DollarSign },
-  { key: "recent_activity", label: "Recent Activity", icon: Activity },
-  { key: "new_cases",       label: "New Cases",       icon: UserPlus },
+  { key: "payments",              label: "Payments",              icon: DollarSign },
+  { key: "fee_petition_approved", label: "Fee Petition Approved", icon: CheckCircle2 },
+  { key: "recent_activity",       label: "Recent Activity",       icon: Activity },
+  { key: "new_cases",             label: "New Cases",             icon: UserPlus },
 ];
 
 // ============================================================================
@@ -280,6 +283,9 @@ export default function NotificationsPage() {
 
       {/* Payments tab */}
       {pageTab === "payments" && <PaymentsTab dark={dark} t={t} />}
+
+      {/* Fee Petition Approved tab */}
+      {pageTab === "fee_petition_approved" && <FeePetitionApprovedTab dark={dark} t={t} />}
 
       {/* Recent Activity tab */}
       {pageTab === "recent_activity" && <RecentActivityTab dark={dark} t={t} />}

--- a/src/app/api/fee-petitions-approved/route.ts
+++ b/src/app/api/fee-petitions-approved/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { db } from "@/lib/db";
+import { sql } from "drizzle-orm";
+
+// GET /api/fee-petitions-approved?week=YYYY-MM-DD
+// Returns fee petitions approved (fee_petition_approved = TRUE) during a
+// Mon-Sun week, grouped by the day their updated_at falls in that window
+// (best available proxy — fee_petitions has no approved_at column).
+export async function GET(req: NextRequest) {
+  try {
+    const session = await auth();
+    if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    const { searchParams } = req.nextUrl;
+    const week = searchParams.get("week") ?? new Date().toISOString().split("T")[0];
+
+    const rows = await db.execute(sql`
+      SELECT
+        fp.id::text AS id,
+        fp.case_id AS case_id,
+        c.first_name AS first_name,
+        c.last_name AS last_name,
+        c.external_id AS external_id,
+        fp.assigned_to AS assigned_to,
+        fp.updated_at AS updated_at
+      FROM fee_petitions fp
+      JOIN cases c ON c.client_id = fp.case_id
+      WHERE fp.fee_petition_approved = TRUE
+        AND fp.updated_at >= ${week}::date
+        AND fp.updated_at < ${week}::date + INTERVAL '7 days'
+      ORDER BY fp.updated_at ASC
+    `) as unknown as {
+      id: string;
+      case_id: number;
+      first_name: string | null;
+      last_name: string | null;
+      external_id: string | null;
+      assigned_to: string | null;
+      updated_at: string;
+    }[];
+
+    const approvals = rows.map((r) => ({
+      id: r.id,
+      caseId: r.case_id,
+      caseName: `${r.last_name ?? ""}, ${r.first_name ?? ""}`,
+      externalId: r.external_id,
+      assignedTo: r.assigned_to,
+      approvedAt: r.updated_at,
+      date: new Date(r.updated_at).toISOString().split("T")[0],
+    }));
+
+    const countByDate = new Map<string, number>();
+    for (const a of approvals) {
+      countByDate.set(a.date, (countByDate.get(a.date) ?? 0) + 1);
+    }
+
+    const monday = new Date(`${week}T00:00:00Z`);
+    const data = Array.from({ length: 7 }, (_, i) => {
+      const d = new Date(monday);
+      d.setUTCDate(d.getUTCDate() + i);
+      const date = d.toISOString().split("T")[0];
+      return { date, count: countByDate.get(date) ?? 0 };
+    });
+
+    return NextResponse.json({ week, data, approvals });
+  } catch (error) {
+    console.error("GET /api/fee-petitions-approved error:", error);
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 });
+  }
+}

--- a/src/components/notifications/FeePetitionApprovedTab.tsx
+++ b/src/components/notifications/FeePetitionApprovedTab.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+import { useState, useEffect, useRef, Fragment } from "react";
+import { ChevronLeft, ChevronRight, RefreshCw, CheckCircle2, AlertCircle, ExternalLink } from "lucide-react";
+import { themeClasses } from "@/lib/theme-classes";
+import { getMonday, formatWeekLabel as formatWeekLabelBase } from "@/lib/formatters";
+
+interface DayCount {
+  date: string;
+  count: number;
+}
+
+interface ApprovalRow {
+  id: string;
+  caseId: number;
+  caseName: string;
+  externalId: string | null;
+  assignedTo: string | null;
+  approvedAt: string;
+  date: string;
+}
+
+interface FeePetitionApprovedTabProps {
+  dark: boolean;
+  t: ReturnType<typeof themeClasses>;
+}
+
+const formatWeekLabel = (monday: string): string => formatWeekLabelBase(monday, 6);
+
+const fmtDate = (iso: string): string =>
+  new Date(`${iso}T00:00:00`).toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+
+const isToday = (iso: string): boolean =>
+  iso === new Date().toISOString().split("T")[0];
+
+const thBase = "px-3 py-2 text-[13px] font-semibold uppercase tracking-wide";
+const tdBase = "px-3 py-2 text-xs";
+
+export function FeePetitionApprovedTab({ dark, t }: FeePetitionApprovedTabProps) {
+  const [weekOffset, setWeekOffset] = useState(0);
+  const [days, setDays] = useState<DayCount[]>([]);
+  const [approvals, setApprovals] = useState<ApprovalRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const monday = getMonday(weekOffset);
+
+  useEffect(() => {
+    let cancelled = false;
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setLoading(true);
+    setError(null);
+
+    fetch(`/api/fee-petitions-approved?week=${monday}`, { signal: controller.signal })
+      .then((res) => {
+        if (!res.ok) throw new Error(`Failed to load approved petitions (${res.status})`);
+        return res.json();
+      })
+      .then((json) => {
+        if (cancelled) return;
+        setDays(json.data ?? []);
+        setApprovals(json.approvals ?? []);
+      })
+      .catch((err) => {
+        if (cancelled || (err as Error).name === "AbortError") return;
+        setError((err as Error).message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+      abortRef.current?.abort();
+    };
+  }, [monday]);
+
+  const weekTotal = days.reduce((sum, d) => sum + d.count, 0);
+  const maxCount = Math.max(1, ...days.map((d) => d.count));
+
+  const approvalsByDate = approvals.reduce<Record<string, ApprovalRow[]>>((acc, a) => {
+    (acc[a.date] ??= []).push(a);
+    return acc;
+  }, {});
+  const approvalDates = Object.keys(approvalsByDate).sort((a, b) => b.localeCompare(a));
+
+  const rowDivide = dark ? "border-neutral-800/40" : "border-neutral-100";
+  const rowHover = dark ? "hover:bg-neutral-800/30" : "hover:bg-neutral-50";
+  const todayBg = dark ? "bg-emerald-900/20" : "bg-emerald-50/60";
+  const barBg = dark ? "bg-emerald-500/30" : "bg-emerald-200";
+  const dateBg = dark ? "bg-neutral-800/60" : "bg-neutral-50";
+
+  return (
+    <div className="space-y-4">
+      <div className={`rounded-xl border ${t.card}`}>
+        {/* Header */}
+        <div className={`p-4 flex flex-col sm:flex-row sm:items-center justify-between gap-3 border-b ${t.borderLight}`}>
+          <div className="flex items-center gap-3">
+            <div className={`w-10 h-10 rounded-lg flex items-center justify-center ${dark ? "bg-emerald-900/40" : "bg-emerald-50"}`}>
+              <CheckCircle2 className={`h-5 w-5 ${dark ? "text-emerald-400" : "text-emerald-600"}`} aria-hidden="true" />
+            </div>
+            <div>
+              <h3 className={`text-sm font-bold ${t.text}`}>Fee Petition Approved</h3>
+              <p className={`text-[13px] ${t.textMuted} mt-0.5`}>
+                {weekTotal > 0 ? `${weekTotal} approved — ` : ""}{formatWeekLabel(monday)}
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-1">
+            <button
+              onClick={() => setWeekOffset((v) => v - 1)}
+              className={`h-8 w-8 rounded-md flex items-center justify-center transition-colors ${t.hover} ${t.textSub}`}
+              aria-label="Previous week"
+            >
+              <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+            </button>
+            <span className={`text-[13px] font-medium ${t.textSub} whitespace-nowrap px-2`}>
+              {formatWeekLabel(monday)}
+            </span>
+            <button
+              onClick={() => setWeekOffset((v) => v + 1)}
+              disabled={weekOffset >= 0}
+              className={`h-8 w-8 rounded-md flex items-center justify-center transition-colors ${t.hover} ${t.textSub} disabled:opacity-40`}
+              aria-label="Next week"
+            >
+              <ChevronRight className="h-4 w-4" aria-hidden="true" />
+            </button>
+          </div>
+        </div>
+
+        {/* Error */}
+        {error && (
+          <div
+            className={`m-4 rounded-lg border p-3 flex items-center gap-2 text-xs ${dark ? "bg-red-900/20 border-red-800 text-red-400" : "bg-red-50 border-red-200 text-red-700"}`}
+            role="alert"
+          >
+            <AlertCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
+            {error}
+          </div>
+        )}
+
+        {/* Loading */}
+        {loading && (
+          <div className="flex items-center justify-center py-16">
+            <RefreshCw className={`h-5 w-5 animate-spin ${t.textMuted}`} aria-hidden="true" />
+            <span className={`ml-2 text-sm ${t.textSub}`}>Loading approved petitions...</span>
+          </div>
+        )}
+
+        {/* Empty */}
+        {!loading && !error && weekTotal === 0 && (
+          <div className="flex flex-col items-center justify-center py-16">
+            <CheckCircle2 className={`h-8 w-8 ${t.textMuted} mb-3`} aria-hidden="true" />
+            <p className={`text-sm font-medium ${t.text}`}>No fee petitions approved this week</p>
+          </div>
+        )}
+
+        {/* Daily table */}
+        {!loading && !error && days.length > 0 && (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-100">
+              <thead>
+                <tr className={`border-b ${t.borderLight}`}>
+                  <th className={`${thBase} ${t.textSub} text-left`}>Day</th>
+                  <th className={`${thBase} ${t.textSub} text-right`}>Approved</th>
+                  <th className={`${thBase} ${t.textSub} text-left`}></th>
+                </tr>
+              </thead>
+              <tbody>
+                {days.map((d) => (
+                  <tr
+                    key={d.date}
+                    className={`border-b ${rowDivide} ${rowHover} transition-colors ${isToday(d.date) ? todayBg : ""}`}
+                  >
+                    <td className={`${tdBase} ${t.text} font-medium`}>
+                      {fmtDate(d.date)}
+                      {isToday(d.date) && (
+                        <span className={`ml-1.5 text-[12px] font-semibold ${dark ? "text-emerald-400" : "text-emerald-600"}`}>
+                          Today
+                        </span>
+                      )}
+                    </td>
+                    <td className={`${tdBase} text-right font-semibold tabular-nums ${d.count > 0 ? t.text : t.textMuted}`}>
+                      {d.count || "—"}
+                    </td>
+                    <td className={`${tdBase} w-1/2`}>
+                      <div className={`h-2 rounded-full ${dark ? "bg-neutral-800" : "bg-neutral-100"}`}>
+                        <div
+                          className={`h-2 rounded-full ${barBg}`}
+                          style={{ width: `${(d.count / maxCount) * 100}%` }}
+                        />
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+              <tfoot>
+                <tr className={dark ? "bg-neutral-800/60" : "bg-neutral-50"}>
+                  <td className={`${tdBase} font-semibold ${t.text}`}>Week Total</td>
+                  <td className={`${tdBase} text-right font-bold tabular-nums ${t.text}`}>{weekTotal}</td>
+                  <td className={tdBase}></td>
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* Per-day case list */}
+      {!loading && !error && approvalDates.length > 0 && (
+        <div className={`rounded-xl border ${t.card}`}>
+          <div className={`p-4 border-b ${t.borderLight}`}>
+            <h4 className={`text-sm font-bold ${t.text}`}>
+              Approved — {formatWeekLabel(monday)}
+            </h4>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-left border-collapse">
+              <thead>
+                <tr className={`border-b ${t.borderLight}`}>
+                  <th className={`${thBase} ${t.textMuted}`}>Case Name</th>
+                  <th className={`${thBase} ${t.textMuted}`}>Assigned To</th>
+                </tr>
+              </thead>
+              <tbody>
+                {approvalDates.map((date) => (
+                  <Fragment key={date}>
+                    <tr className={`border-b ${rowDivide}`}>
+                      <td
+                        colSpan={2}
+                        className={`px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wider ${t.textMuted} ${dateBg}`}
+                      >
+                        {fmtDate(date)}{isToday(date) && <span className={`ml-1.5 ${dark ? "text-emerald-400" : "text-emerald-600"}`}>· Today</span>}
+                      </td>
+                    </tr>
+                    {approvalsByDate[date].map((a) => (
+                      <tr
+                        key={a.id}
+                        className={`border-b ${rowDivide} ${rowHover} transition-colors`}
+                      >
+                        <td className={`${tdBase} font-medium ${t.text}`}>
+                          {a.externalId ? (
+                            <a
+                              href={a.externalId}
+                              target="_blank"
+                              rel="noreferrer"
+                              className={`inline-flex items-center gap-1 hover:underline ${dark ? "text-indigo-400" : "text-indigo-600"}`}
+                            >
+                              {a.caseName}
+                              <ExternalLink className="h-3 w-3 opacity-50 shrink-0" aria-hidden="true" />
+                            </a>
+                          ) : (
+                            a.caseName
+                          )}
+                        </td>
+                        <td className={`${tdBase} ${t.textMuted}`}>{a.assignedTo ?? "—"}</td>
+                      </tr>
+                    ))}
+                  </Fragment>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/notifications/FeePetitionApprovedTab.tsx
+++ b/src/components/notifications/FeePetitionApprovedTab.tsx
@@ -165,7 +165,7 @@ export function FeePetitionApprovedTab({ dark, t }: FeePetitionApprovedTabProps)
         {/* Daily table */}
         {!loading && !error && days.length > 0 && (
           <div className="overflow-x-auto">
-            <table className="w-full min-w-100">
+            <table className="w-full min-w-100 border-collapse">
               <thead>
                 <tr className={`border-b ${t.borderLight}`}>
                   <th className={`${thBase} ${t.textSub} text-left`}>Day</th>
@@ -188,7 +188,7 @@ export function FeePetitionApprovedTab({ dark, t }: FeePetitionApprovedTabProps)
                       )}
                     </td>
                     <td className={`${tdBase} text-right font-semibold tabular-nums ${d.count > 0 ? t.text : t.textMuted}`}>
-                      {d.count || "—"}
+                      {d.count > 0 ? d.count : "—"}
                     </td>
                     <td className={`${tdBase} w-1/2`}>
                       <div className={`h-2 rounded-full ${dark ? "bg-neutral-800" : "bg-neutral-100"}`}>


### PR DESCRIPTION
Two features from Ms. Jazz's requests.

**Level dropdown — fix options**
The Level Listbox dropdown in Master Fee Records already existed. Fixed the only mismatch: renamed the "RECONSIDERATION" admin dropdown option to "RECON" to match the 450 cases in the DB with `level_won = 'RECON'`. Options are now: INITIAL, RECON, HEARING, FEE PETITION.

**Fee Petition Approved tab in Notifications**
New "Fee Petition Approved" tab (between Payments and Recent Activity) so Lori can track approved petitions daily.

- New API `GET /api/fee-petitions-approved?week=YYYY-MM-DD` — queries `fee_petitions` where `fee_petition_approved = TRUE` and `updated_at` falls in the selected week (best proxy for approval date — no `approved_at` column exists)
- New `FeePetitionApprovedTab` component — weekly nav, day breakdown table with bar chart, grouped case list showing claimant name and assigned specialist
- Notifications page — "Fee Petition Approved" tab with `CheckCircle2` icon added between Payments and Recent Activity