### PR TITLE
feat: add POC to inbound calls specialist dropdown, add Level filter to Master Fees

### DIFF
--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -287,6 +287,7 @@ export const FeeRecordsTable = ({
   const [feesConfFilter, setFeesConfFilter] = useState("all");
   const [claimFilter, setClaimFilter] = useState("all");
   const [caseStatusFilter, setCaseStatusFilter] = useState("all");
+  const [levelFilter, setLevelFilter] = useState("all");
   // Minimized T16/T2/AUX column groups — collapses a claim type's 5 editable
   // columns down to a single read-only Fee Due glance, so staff working a
   // single claim type can't mistakenly enter Retro/Fee Due on the wrong one.
@@ -535,6 +536,9 @@ export const FeeRecordsTable = ({
       d = d.filter((c) => c.claim === claimFilter);
     if (caseStatusFilter !== "all")
       d = d.filter((c) => c.caseStatus === caseStatusFilter);
+    if (levelFilter !== "all")
+      // Normalize FEE PETITION / FEE_PETITION variants stored in older records
+      d = d.filter((c) => c.level === levelFilter || c.level === levelFilter.replace(/ /g, "_"));
 
     d.sort((a, b) => {
       let av: string | number, bv: string | number;
@@ -595,6 +599,7 @@ export const FeeRecordsTable = ({
     feesConfFilter,
     claimFilter,
     caseStatusFilter,
+    levelFilter,
     sortKey,
     sortDir,
     dateRange,
@@ -1094,6 +1099,17 @@ export const FeeRecordsTable = ({
             <option value="T2">T2</option>
             <option value="T16">T16</option>
             <option value="CONC">CONC</option>
+          </select>
+          <select
+            value={levelFilter}
+            onChange={(e) => setLevelFilter(e.target.value)}
+            className={`h-8 px-2 rounded-md border text-xs outline-none cursor-pointer ${t.inputBg}`}
+          >
+            <option value="all">All Levels</option>
+            <option value="HEARING">Hearing</option>
+            <option value="INITIAL">Initial</option>
+            <option value="RECON">Recon</option>
+            <option value="FEE PETITION">Fee Petition</option>
           </select>
           <select
             value={statusFilter}

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -50,7 +50,7 @@ import { ArchiveConfirmDialog } from "./ArchiveConfirmDialog";
 import { FeesClosedConfirmDialog } from "./FeesClosedConfirmDialog";
 import { BulkFeesClosedConfirmDialog } from "./BulkFeesClosedConfirmDialog";
 import { Listbox } from "@/components/shared/Listbox";
-import { caseLevelVisual } from "@/lib/case-level-icons";
+import { caseLevelVisual, normalizeCaseLevel } from "@/lib/case-level-icons";
 import { buildListboxOptions } from "@/lib/listbox-options";
 import { teamRowTint } from "@/lib/team-colors";
 import { memberRowTint } from "@/lib/member-colors";
@@ -537,8 +537,7 @@ export const FeeRecordsTable = ({
     if (caseStatusFilter !== "all")
       d = d.filter((c) => c.caseStatus === caseStatusFilter);
     if (levelFilter !== "all")
-      // Normalize FEE PETITION / FEE_PETITION variants stored in older records
-      d = d.filter((c) => c.level === levelFilter || c.level === levelFilter.replace(/ /g, "_"));
+      d = d.filter((c) => normalizeCaseLevel(c.level) === normalizeCaseLevel(levelFilter));
 
     d.sort((a, b) => {
       let av: string | number, bv: string | number;
@@ -1106,10 +1105,9 @@ export const FeeRecordsTable = ({
             className={`h-8 px-2 rounded-md border text-xs outline-none cursor-pointer ${t.inputBg}`}
           >
             <option value="all">All Levels</option>
-            <option value="HEARING">Hearing</option>
-            <option value="INITIAL">Initial</option>
-            <option value="RECON">Recon</option>
-            <option value="FEE PETITION">Fee Petition</option>
+            {caseLevelOptions.map((o) => (
+              <option key={o.name} value={o.name}>{o.name}</option>
+            ))}
           </select>
           <select
             value={statusFilter}

--- a/src/components/inbound-calls/InboundCallsClient.tsx
+++ b/src/components/inbound-calls/InboundCallsClient.tsx
@@ -659,6 +659,7 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
                         className={`${inputCls} cursor-pointer disabled:opacity-50 disabled:cursor-default`}
                       >
                         <option value="">— Assign —</option>
+                        {/* POC = Point of Contact — non-agent assignment for general inbound tracking */}
                         <option value="POC">POC</option>
                         {teamMembers.map((name) => (
                           <option key={name} value={name}>{name}</option>

--- a/src/components/inbound-calls/InboundCallsClient.tsx
+++ b/src/components/inbound-calls/InboundCallsClient.tsx
@@ -659,6 +659,7 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
                         className={`${inputCls} cursor-pointer disabled:opacity-50 disabled:cursor-default`}
                       >
                         <option value="">— Assign —</option>
+                        <option value="POC">POC</option>
                         {teamMembers.map((name) => (
                           <option key={name} value={name}>{name}</option>
                         ))}

--- a/src/lib/case-level-icons.ts
+++ b/src/lib/case-level-icons.ts
@@ -32,9 +32,11 @@ const VISUALS: Record<
 // dropdown_options.case_level rows are free-text (admin-managed in Settings),
 // so normalize before matching — seed data uses "FEE PETITION" but the list
 // could just as easily contain "Fee_Petition" or "fee petition".
-function normalize(level: string): string {
+export function normalizeCaseLevel(level: string): string {
   return level.trim().toUpperCase().replace(/[_\s]+/g, " ");
 }
+// Internal alias kept for existing callers in this file
+const normalize = normalizeCaseLevel;
 
 // Returns null for anything unrecognized (a level an admin added that isn't
 // one of the seeded ones) — callers should render without an icon chip


### PR DESCRIPTION
Two small features from Ms. Jazz.

**Inbound Call History — POC option**
Added "POC" as the first option in the Collection Specialist dropdown, before the agent names. Verified the value saves and round-trips correctly via the API.

**Master Fee Records — Level filter**
Added a new "All Levels" filter dropdown in the toolbar with options: Hearing, Initial, Recon, Fee Petition. Filters client-side on `c.level` (`cases.level_won`). Handles both "FEE PETITION" and the legacy "FEE_PETITION" (underscore) variant stored in older records.