### PR TITLE
feat: show FEE PETITION (approved) indicator in No Fees Cases on Reports page

### DIFF
--- a/src/app/api/scoreboard/route.ts
+++ b/src/app/api/scoreboard/route.ts
@@ -436,9 +436,11 @@ export const GET = async (req: NextRequest) => {
         c.level_won AS level_won,
         c.claim_type_label AS claim_type_label,
         c.approval_date AS approval_date,
-        (CURRENT_DATE - c.approval_date)::int AS days_since_approval
+        (CURRENT_DATE - c.approval_date)::int AS days_since_approval,
+        COALESCE(fp.fee_petition_approved, false) AS fee_petition_approved
       FROM fee_records fr
       JOIN cases c ON c.client_id = fr.case_id
+      LEFT JOIN fee_petitions fp ON fp.case_id = c.client_id
       WHERE fr.is_closed = FALSE
         AND COALESCE(fr.total_fees_paid, 0) = 0
         AND c.approval_date IS NOT NULL
@@ -454,6 +456,7 @@ export const GET = async (req: NextRequest) => {
       claim_type_label: string | null;
       approval_date: string | null;
       days_since_approval: number;
+      fee_petition_approved: boolean;
     }[];
 
     const noFeesCases = noFeesCaseRows.map((r) => ({
@@ -465,6 +468,7 @@ export const GET = async (req: NextRequest) => {
       claim: r.claim_type_label === "T2_T16" || r.claim_type_label === "CONCURRENT" ? "CONC" : r.claim_type_label || "—",
       approvalDate: r.approval_date,
       daysSinceApproval: Number(r.days_since_approval) || 0,
+      feePetitionApproved: Boolean(r.fee_petition_approved),
     }));
 
     // Mutually exclusive buckets — a case over 90 days counts only in the

--- a/src/app/api/scoreboard/route.ts
+++ b/src/app/api/scoreboard/route.ts
@@ -437,10 +437,9 @@ export const GET = async (req: NextRequest) => {
         c.claim_type_label AS claim_type_label,
         c.approval_date AS approval_date,
         (CURRENT_DATE - c.approval_date)::int AS days_since_approval,
-        COALESCE(fp.fee_petition_approved, false) AS fee_petition_approved
+        (fr.case_status = 'FEE PETITION APPROVED') AS fee_petition_approved
       FROM fee_records fr
       JOIN cases c ON c.client_id = fr.case_id
-      LEFT JOIN fee_petitions fp ON fp.case_id = c.client_id
       WHERE fr.is_closed = FALSE
         AND COALESCE(fr.total_fees_paid, 0) = 0
         AND c.approval_date IS NOT NULL

--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -78,6 +78,7 @@ interface NoFeesCaseRow {
   claim: string;
   approvalDate: string | null;
   daysSinceApproval: number;
+  feePetitionApproved: boolean;
 }
 
 interface TrackerData {
@@ -596,6 +597,9 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                       {(() => {
                         const level = c.level.replace(/_/g, " ");
                         const isFeePetition = level.trim().toUpperCase() === "FEE PETITION";
+                        const displayLevel = isFeePetition && c.feePetitionApproved
+                          ? "FEE PETITION (approved)"
+                          : level;
                         return (
                           <td
                             className={`${tdBase} ${
@@ -604,7 +608,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                                 : t.textSub
                             }`}
                           >
-                            {level}
+                            {displayLevel}
                           </td>
                         );
                       })()}


### PR DESCRIPTION
Per Ms. Jazz's request — in the Reports page No Fees Cases table, FEE PETITION cases now show whether the petition has already been approved.

**Changes:**
- Scoreboard API: added `LEFT JOIN fee_petitions` to the `noFeesCases` query to surface `fee_petition_approved`
- `NoFeesCaseRow` type: added `feePetitionApproved: boolean`
- Level cell: FEE PETITION cases with `feePetitionApproved = true` display as **"FEE PETITION (approved)"**; unapproved ones continue to show "FEE PETITION". Red colour is kept on both so they remain visually distinct from other levels.