### PR TITLE
feat: make fee amount cells selectable for copy-paste

### DIFF
--- a/src/components/cases/FeeAmountCell.tsx
+++ b/src/components/cases/FeeAmountCell.tsx
@@ -79,7 +79,7 @@ export function FeeAmountCell({
   }
   return (
     <div className="flex items-center justify-end gap-1">
-      <span>{currency(value, allowExplicitZero)}</span>
+      <span className="select-all cursor-text" onClick={(e) => e.stopPropagation()}>{currency(value, allowExplicitZero)}</span>
       {canEdit && (
         <button type="button" onClick={onEdit} className={`${pencilRevealClass} transition-colors p-0.5 rounded ${hoverCls}`} aria-label={`Edit ${saveLabel}`}>
           <Pencil className={`h-3 w-3 ${textMuted}`} aria-hidden="true" />

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -194,7 +194,14 @@ const patchSingleField = async (
   }
 };
 
-const currency = (v: number) => (v > 0 ? fmtFull(v) : "—");
+const currency = (v: number) => (
+  <span
+    className="select-all cursor-text"
+    onClick={(e) => e.stopPropagation()}
+  >
+    {v > 0 ? fmtFull(v) : "—"}
+  </span>
+);
 // Pending can go negative (overpaid) now that it's auto-calculated as Fee
 // Due minus Rec'd — unlike currency() above, a negative value here is real
 // signal (the PIF "Overpaid" badge is the primary flag, but the exact

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -194,12 +194,12 @@ const patchSingleField = async (
   }
 };
 
-const currency = (v: number) => (
+const currency = (v: number | null) => (
   <span
     className="select-all cursor-text"
     onClick={(e) => e.stopPropagation()}
   >
-    {v > 0 ? fmtFull(v) : "—"}
+    {(v ?? 0) > 0 ? fmtFull(v as number) : "—"}
   </span>
 );
 // Pending can go negative (overpaid) now that it's auto-calculated as Fee
@@ -2247,7 +2247,7 @@ export const FeeRecordsTable = ({
                         className={`${tdBase} text-right tabular-nums ${t.textMuted} ${groupBorder}`}
                         title="Minimized — expand T16 to edit"
                       >
-                        {c.t16FeeDue != null ? currency(c.t16FeeDue) : "—"}
+                        {currency(c.t16FeeDue)}
                       </td>
                     ) : (
                       <>
@@ -2321,7 +2321,7 @@ export const FeeRecordsTable = ({
                         className={`${tdBase} text-right tabular-nums ${t.textMuted} ${groupBorder}`}
                         title="Minimized — expand T2 to edit"
                       >
-                        {c.t2FeeDue != null ? currency(c.t2FeeDue) : "—"}
+                        {currency(c.t2FeeDue)}
                       </td>
                     ) : (
                       <>
@@ -2395,7 +2395,7 @@ export const FeeRecordsTable = ({
                         className={`${tdBase} text-right tabular-nums ${t.textMuted} ${groupBorder}`}
                         title="Minimized — expand AUX to edit"
                       >
-                        {c.auxFeeDue != null ? currency(c.auxFeeDue) : "—"}
+                        {currency(c.auxFeeDue)}
                       </td>
                     ) : (
                       <>


### PR DESCRIPTION
Per Ms. Jazz's request — fee numbers in Master Fee Records can now be selected with a single click (select-all) and copied with Ctrl+C or right-click → Copy.

**Changes:**
- `FeeRecordsTable.tsx`: `currency()` helper now wraps values in `<span className="select-all cursor-text">` with `stopPropagation` so clicking to select doesn't accidentally open the Win Sheet quick look
- `FeeAmountCell.tsx`: same `select-all cursor-text` + `stopPropagation` on the display span

Covers all fee display cells: Rec'd, Retro, Fee Due, Pending, totals, and editable fee amount cells.