### PR TITLE
feat: add copy-row button to Scoreboard and Reports, make numbers and names selectable

### DIFF
--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -876,7 +876,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                           className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 ${teamBadgeClasses(a.team, dark)}`}
                         >
                           <span className="w-1.5 h-1.5 rounded-full bg-current shrink-0" aria-hidden="true" />
-                          {a.agent}
+                          <span className="select-all cursor-text">{a.agent}</span>
                         </span>
                       </td>
                       {showCol("cases")       && <td className={`${tdBase} text-right ${t.text}`}>{a.openCases}</td>}

--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -186,6 +186,11 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
   // thresholds under the hood — fixed at 60d since there's no UI to change it.
   const [metricFocus, setMetricFocus] = useState<MetricFocus>("all");
   const [copiedRow, setCopiedRow] = useState<string | null>(null);
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => {
+    if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+  }, []);
 
   const copyAgentRow = (a: AgentScore) => {
     const parts = [a.agent];
@@ -199,7 +204,8 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
     if (showCol("winsheets"))   parts.push(`Win Sheets: ${a.completedWinSheets}`);
     navigator.clipboard.writeText(parts.join(" | ")).then(() => {
       setCopiedRow(a.agent);
-      setTimeout(() => setCopiedRow(null), 1500);
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+      copyTimerRef.current = setTimeout(() => setCopiedRow(null), 1500);
     });
   };
 
@@ -927,7 +933,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                           onClick={() => copyAgentRow(a)}
                           aria-label={`Copy ${a.agent} row`}
                           title="Copy row"
-                          className={`p-1 rounded transition-colors opacity-0 group-hover/row:opacity-100 ${copiedRow === a.agent ? (dark ? "text-emerald-400" : "text-emerald-600") : t.textMuted} hover:${dark ? "text-neutral-200" : "text-neutral-700"}`}
+                          className={`p-1 rounded transition-colors opacity-0 group-hover/row:opacity-100 ${copiedRow === a.agent ? (dark ? "text-emerald-400" : "text-emerald-600") : t.textMuted} ${dark ? "hover:text-neutral-200" : "hover:text-neutral-700"}`}
                         >
                           {copiedRow === a.agent
                             ? <Check aria-hidden="true" className="h-3.5 w-3.5" />

--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -19,6 +19,7 @@ import {
   X,
   Check,
   ExternalLink,
+  Clipboard,
 } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { themeClasses } from "@/lib/theme-classes";
@@ -184,6 +185,23 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
   // removed from the table, but "Needs attention" still checks these
   // thresholds under the hood — fixed at 60d since there's no UI to change it.
   const [metricFocus, setMetricFocus] = useState<MetricFocus>("all");
+  const [copiedRow, setCopiedRow] = useState<string | null>(null);
+
+  const copyAgentRow = (a: AgentScore) => {
+    const parts = [a.agent];
+    if (showCol("cases"))       parts.push(`Open: ${a.openCases}`);
+    if (showCol("closedcases")) parts.push(`Closed: ${a.casesClosed}`);
+    if (showCol("opennofees"))  parts.push(`No Fees: ${a.openNoFees}`);
+    if (showCol("collected"))   parts.push(`Collected: ${a.feesCollectedInWindow != null ? fmt(a.feesCollectedInWindow) : "—"}`);
+    if (showCol("ssacalls"))    parts.push(`SSA: ${a.weekSsaCalls}`);
+    if (showCol("clientcalls")) parts.push(`CL Calls: ${a.weekClientCalls}`);
+    if (showCol("faxsent"))     parts.push(`Fax: ${a.weekFaxSent}`);
+    if (showCol("winsheets"))   parts.push(`Win Sheets: ${a.completedWinSheets}`);
+    navigator.clipboard.writeText(parts.join(" | ")).then(() => {
+      setCopiedRow(a.agent);
+      setTimeout(() => setCopiedRow(null), 1500);
+    });
+  };
 
   const [dateMode, setDateMode] = useState<DateMode>("week");
   const nowForInit = new Date();
@@ -860,6 +878,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                     {showCol("clientcalls") && <th className={`${thBase} text-right ${dark ? "text-indigo-400" : "text-indigo-600"}`}>Client Calls</th>}
                     {showCol("faxsent")     && <th className={`${thBase} ${t.textSub} text-right`}>Fax Sent</th>}
                     {showCol("winsheets")   && <th className={`${thBase} ${t.textSub} text-right`}>Win Sheets</th>}
+                    <th className={`${thBase} w-8`}></th>
                   </tr>
                 </thead>
                 <tbody>
@@ -870,7 +889,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                       </td>
                     </tr>
                   ) : filteredAgents.map((a) => (
-                    <tr key={a.agent} className={`border-b ${rowBorder} ${rowHover} transition-colors`}>
+                    <tr key={a.agent} className={`group/row border-b ${rowBorder} ${rowHover} transition-colors`}>
                       <td className={`${tdBase} ${t.text} font-semibold`}>
                         <span
                           className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 ${teamBadgeClasses(a.team, dark)}`}
@@ -903,6 +922,19 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                       {showCol("clientcalls") && <td className={`${tdBase} text-right ${dark ? "text-indigo-400" : "text-indigo-600"}`}>{a.weekClientCalls}</td>}
                       {showCol("faxsent")     && <td className={`${tdBase} text-right ${t.textSub}`}>{a.weekFaxSent}</td>}
                       {showCol("winsheets")   && <td className={`${tdBase} text-right ${t.text}`}>{a.completedWinSheets}</td>}
+                      <td className={`${tdBase} text-center`}>
+                        <button
+                          onClick={() => copyAgentRow(a)}
+                          aria-label={`Copy ${a.agent} row`}
+                          title="Copy row"
+                          className={`p-1 rounded transition-colors opacity-0 group-hover/row:opacity-100 ${copiedRow === a.agent ? (dark ? "text-emerald-400" : "text-emerald-600") : t.textMuted} hover:${dark ? "text-neutral-200" : "text-neutral-700"}`}
+                        >
+                          {copiedRow === a.agent
+                            ? <Check aria-hidden="true" className="h-3.5 w-3.5" />
+                            : <Clipboard aria-hidden="true" className="h-3.5 w-3.5" />
+                          }
+                        </button>
+                      </td>
                     </tr>
                   ))}
                 </tbody>
@@ -925,6 +957,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                     {showCol("clientcalls") && <td className={`${tdBase} text-right font-bold ${dark ? "text-indigo-400" : "text-indigo-600"}`}>{filteredTotals.weekClientCalls}</td>}
                     {showCol("faxsent")     && <td className={`${tdBase} text-right font-bold ${t.textSub}`}>{filteredTotals.weekFaxSent}</td>}
                     {showCol("winsheets")   && <td className={`${tdBase} text-right font-bold ${t.text}`}>{filteredTotals.completedWinSheets}</td>}
+                    <td className={tdBase}></td>
                   </tr>
                 </tfoot>
               </table>

--- a/src/components/scoreboard/Scoreboard.tsx
+++ b/src/components/scoreboard/Scoreboard.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useReducer, useEffect } from "react";
 import { useTheme } from "next-themes";
-import { RefreshCw, ChevronLeft, ChevronRight, Upload, Trophy } from "lucide-react";
+import { RefreshCw, ChevronLeft, ChevronRight, Upload, Trophy, Clipboard, Check } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
 import CsvImportModal, { type ColumnDef } from "@/components/modals/CsvImportModal";
 import { bulkImportDailyMetrics } from "@/app/(dashboard)/scoreboard/actions";
@@ -107,6 +107,7 @@ export const Scoreboard = () => {
 
   const [weekOffset, setWeekOffset] = useState(0);
   const [csvImportOpen, setCsvImportOpen] = useState(false);
+  const [copiedRow, setCopiedRow] = useState<string | null>(null);
   const [{ weeks, loading, error }, dispatch] = useReducer(fetchReducer, {
     weeks: [],
     loading: true,
@@ -299,6 +300,7 @@ export const Scoreboard = () => {
                               {w.label}
                             </th>
                           ))}
+                          <th className="w-8"></th>
                         </tr>
                       </thead>
                       <tbody>
@@ -313,7 +315,7 @@ export const Scoreboard = () => {
                           return (
                           <tr
                             key={row.agent}
-                            className={`border-b ${t.borderLight} ${rowIdx % 2 !== 0 ? (dark ? "bg-neutral-800/20" : "bg-neutral-50/50") : ""}`}
+                            className={`group/row border-b ${t.borderLight} ${rowIdx % 2 !== 0 ? (dark ? "bg-neutral-800/20" : "bg-neutral-50/50") : ""}`}
                           >
                             <td className={`py-2.5 px-4 text-[14px] font-medium ${t.text}`}>
                               <span
@@ -353,6 +355,25 @@ export const Scoreboard = () => {
                               </td>
                               );
                             })}
+                            <td className="py-2.5 px-2 text-center">
+                              <button
+                                onClick={() => {
+                                  const parts = [row.agent, ...row.weekValues.map((v, i) => `${weeks[i]?.label ?? `W${i+1}`}: ${v}`)];
+                                  navigator.clipboard.writeText(parts.join(" | ")).then(() => {
+                                    setCopiedRow(row.agent);
+                                    setTimeout(() => setCopiedRow(null), 1500);
+                                  });
+                                }}
+                                aria-label={`Copy ${row.agent} row`}
+                                title="Copy row"
+                                className={`p-1 rounded transition-colors opacity-0 group-hover/row:opacity-100 ${copiedRow === row.agent ? (dark ? "text-emerald-400" : "text-emerald-600") : (dark ? "text-neutral-500" : "text-neutral-400")} ${dark ? "hover:text-neutral-200" : "hover:text-neutral-700"}`}
+                              >
+                                {copiedRow === row.agent
+                                  ? <Check aria-hidden="true" className="h-3.5 w-3.5" />
+                                  : <Clipboard aria-hidden="true" className="h-3.5 w-3.5" />
+                                }
+                              </button>
+                            </td>
                           </tr>
                           );
                         })}

--- a/src/components/scoreboard/Scoreboard.tsx
+++ b/src/components/scoreboard/Scoreboard.tsx
@@ -320,7 +320,7 @@ export const Scoreboard = () => {
                                 className="inline-flex items-center gap-1.5"
                                 title={isTopScorer ? "Top scorer this week" : undefined}
                               >
-                                {row.agent}
+                                <span className="select-all cursor-text">{row.agent}</span>
                                 {isTopScorer && (
                                   <Trophy aria-hidden="true" className="h-3.5 w-3.5 text-amber-500 shrink-0" />
                                 )}

--- a/src/components/scoreboard/Scoreboard.tsx
+++ b/src/components/scoreboard/Scoreboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useReducer, useEffect } from "react";
+import { useState, useReducer, useEffect, useRef } from "react";
 import { useTheme } from "next-themes";
 import { RefreshCw, ChevronLeft, ChevronRight, Upload, Trophy, Clipboard, Check } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
@@ -108,6 +108,11 @@ export const Scoreboard = () => {
   const [weekOffset, setWeekOffset] = useState(0);
   const [csvImportOpen, setCsvImportOpen] = useState(false);
   const [copiedRow, setCopiedRow] = useState<string | null>(null);
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => {
+    if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+  }, []);
   const [{ weeks, loading, error }, dispatch] = useReducer(fetchReducer, {
     weeks: [],
     loading: true,
@@ -361,7 +366,8 @@ export const Scoreboard = () => {
                                   const parts = [row.agent, ...row.weekValues.map((v, i) => `${weeks[i]?.label ?? `W${i+1}`}: ${v}`)];
                                   navigator.clipboard.writeText(parts.join(" | ")).then(() => {
                                     setCopiedRow(row.agent);
-                                    setTimeout(() => setCopiedRow(null), 1500);
+                                    if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+                                    copyTimerRef.current = setTimeout(() => setCopiedRow(null), 1500);
                                   });
                                 }}
                                 aria-label={`Copy ${row.agent} row`}

--- a/src/components/scoreboard/Scoreboard.tsx
+++ b/src/components/scoreboard/Scoreboard.tsx
@@ -339,12 +339,12 @@ export const Scoreboard = () => {
                                 >
                                   {i === 0 ? (
                                     <span
-                                      className={`inline-block min-w-8 rounded px-2 py-0.5 text-[14px] font-semibold ${thisWeekCellColor(val, currentWeekMax)}`}
+                                      className={`inline-block min-w-8 rounded px-2 py-0.5 text-[14px] font-semibold select-all cursor-text ${thisWeekCellColor(val, currentWeekMax)}`}
                                     >
                                       {val}
                                     </span>
                                   ) : (
-                                    <span className={`text-[14px] ${t.textSub}`}>{val}</span>
+                                    <span className={`text-[14px] select-all cursor-text ${t.textSub}`}>{val}</span>
                                   )}
                                   {isTopForColumn && (
                                     <Trophy aria-hidden="true" className="h-3 w-3 text-amber-500 shrink-0" />


### PR DESCRIPTION
Allows staff to copy row data from the Scoreboard and Reports pages for sharing in group chats.

**Scoreboard page**
- Numbers and agent names now have `select-all cursor-text` for individual cell selection
- Clipboard icon appears on row hover — copies e.g. `"Aaron | This Week: 18 | Jul W1: 14 | Jul W2: 14"`
- Icon turns green (✓) for 1.5s to confirm copy

**Reports page (ScoreboardTracker)**
- `select-all cursor-text` added to `tdBase` — all number cells are single-click selectable
- Agent names wrapped in `select-all cursor-text` span
- Clipboard icon appears on row hover — copies e.g. `"Aaron | Open: 22 | Closed: 5 | Collected: $4,500 | SSA: 11 | CL Calls: 7 | Win Sheets: 8"` (respects current metric focus filter)
- Empty column added to totals row to maintain alignment