### PR TITLE
feat: accept $ and commas in fee amount inputs for MyCase paste

### DIFF
--- a/src/app/cases/[id]/page.tsx
+++ b/src/app/cases/[id]/page.tsx
@@ -36,6 +36,7 @@ import {
   fmtClaim,
   STATUS_LABELS_DETAIL,
   getStatusColor,
+  parseCurrencyInput,
 } from "@/lib/formatters";
 import type { WinSheetStatus, ApprovedByOption } from "@/types";
 import type { DropdownOptionsByCategory } from "@/hooks/useDashboard";
@@ -237,14 +238,14 @@ const FeeSection = memo(
         const feeFields: Record<string, number | string | null> = {};
         const changes: string[] = [];
 
-        const newRetro = parseFloat(fields.lr) || 0;
+        const newRetro = parseCurrencyInput(fields.lr) || 0;
         // An empty box means "didn't touch it" — treat as unchanged rather
         // than coercing to 0, which would wrongly turn an untouched (null)
         // Fee Due into an explicit $0.00 on every save. A literal "-" is the
         // deliberate gesture to clear an already-set Fee Due back to null.
         const dueTrimmed = fields.ld.trim();
-        const newDue = dueTrimmed === "" ? due : dueTrimmed === "-" ? null : parseFloat(fields.ld) || 0;
-        const newReceived = parseFloat(fields.lrcv) || 0;
+        const newDue = dueTrimmed === "" ? due : dueTrimmed === "-" ? null : parseCurrencyInput(fields.ld) || 0;
+        const newReceived = parseCurrencyInput(fields.lrcv) || 0;
 
         if (newRetro !== retro) {
           feeFields[`${prefix}Retro`] = newRetro;
@@ -337,8 +338,8 @@ const FeeSection = memo(
               <div>
                 <p className={lbl}>Retro Amount</p>
                 <input
-                  type="number"
-                  step="0.01"
+                  type="text"
+                  inputMode="decimal"
                   value={fields.lr}
                   onChange={(e) => setField("lr", e.target.value)}
                   className={inpCls}
@@ -360,8 +361,8 @@ const FeeSection = memo(
               <div>
                 <p className={lbl}>Fee Received</p>
                 <input
-                  type="number"
-                  step="0.01"
+                  type="text"
+                  inputMode="decimal"
                   value={fields.lrcv}
                   onChange={(e) => setField("lrcv", e.target.value)}
                   className={inpCls}
@@ -644,7 +645,7 @@ const CaseDetailPage = () => {
         changes.push(`Fee method → ${editFeeMethod.replace("_", " ")}`);
       }
       if (editFeeCap !== String(caseData.applicableFeeCap || 9200)) {
-        feeFields.applicableFeeCap = parseFloat(editFeeCap) || 9200;
+        feeFields.applicableFeeCap = parseCurrencyInput(editFeeCap) || 9200;
         changes.push(`Fee cap → $${editFeeCap}`);
       }
       if (editApprovedBy !== (caseData.approvedBy || "")) {
@@ -1183,8 +1184,8 @@ const CaseDetailPage = () => {
                     <p className={lbl}>Fee Cap</p>
                     {editing ? (
                       <input
-                        type="number"
-                        step="0.01"
+                        type="text"
+                        inputMode="decimal"
                         value={editFeeCap}
                         onChange={(e) => setEditFeeCap(e.target.value)}
                         className={inp}

--- a/src/components/cases/FeeAmountCell.tsx
+++ b/src/components/cases/FeeAmountCell.tsx
@@ -47,13 +47,13 @@ export function FeeAmountCell({
     return (
       <div className="flex flex-col items-end gap-1 min-w-[110px]">
         <div className="flex items-center gap-0.5">
-          {/* Fee Due uses type="text" — a native number input sanitizes a
-              bare "-" straight to "" before onChange ever sees it, which
-              would silently break the clear-to-null gesture below. */}
+          {/* Always text+inputMode="decimal" — allows pasting values like
+              "$1,234.56" from MyCase documents without retyping, and avoids
+              a native number input sanitizing a bare "-" to "" before
+              onChange sees it (which breaks the Fee Due clear-to-null gesture). */}
           <input
-            {...(allowExplicitZero
-              ? { type: "text" as const, inputMode: "decimal" as const }
-              : { type: "number" as const, min: "0", step: "0.01" })}
+            type="text"
+            inputMode="decimal"
             value={draft} autoFocus
             onChange={(e) => onDraftChange(e.target.value)}
             onKeyDown={(e) => { if (e.key === "Enter") onSave(); if (e.key === "Escape") onCancel(); }}

--- a/src/components/cases/FeeEditModal.tsx
+++ b/src/components/cases/FeeEditModal.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { RefreshCw, Save, X } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
+import { parseCurrencyInput } from "@/lib/formatters";
 
 const toStr = (v: number) => (v > 0 ? String(v) : "");
 // Fee Due can be null (never touched) as well as a real 0 — collapse both
@@ -81,7 +82,7 @@ export default function FeeEditModal({
         // A literal "-" is the deliberate gesture to clear an already-set
         // Fee Due back to null — distinct from leaving the box empty, which
         // means "didn't touch it."
-        const nv = trimmed === "" ? ov : trimmed === "-" ? null : parseFloat(rawStr) || 0;
+        const nv = trimmed === "" ? ov : trimmed === "-" ? null : parseCurrencyInput(rawStr) || 0;
         if (nv !== ov) {
           feeFields[key] = nv;
           changes.push(`${label}: ${ov == null ? "—" : `$${ov}`} → ${nv == null ? "—" : `$${nv}`}`);
@@ -99,19 +100,19 @@ export default function FeeEditModal({
         }
       };
 
-      chk(parseFloat(f.t16Retro) || 0, orig.t16Retro, "t16Retro", "T16 Retro");
+      chk(parseCurrencyInput(f.t16Retro) || 0, orig.t16Retro, "t16Retro", "T16 Retro");
       chkFeeDue(f.t16Due, orig.t16FeeDue, "t16FeeDue", "T16 Fee Due");
-      chk(parseFloat(f.t16Rcv) || 0, orig.t16FeeReceived, "t16FeeReceived", "T16 Received");
+      chk(parseCurrencyInput(f.t16Rcv) || 0, orig.t16FeeReceived, "t16FeeReceived", "T16 Received");
       chkDt(f.t16Dt, orig.t16FeeReceivedDate, "t16FeeReceivedDate", "T16 Date");
 
-      chk(parseFloat(f.t2Retro) || 0, orig.t2Retro, "t2Retro", "T2 Retro");
+      chk(parseCurrencyInput(f.t2Retro) || 0, orig.t2Retro, "t2Retro", "T2 Retro");
       chkFeeDue(f.t2Due, orig.t2FeeDue, "t2FeeDue", "T2 Fee Due");
-      chk(parseFloat(f.t2Rcv) || 0, orig.t2FeeReceived, "t2FeeReceived", "T2 Received");
+      chk(parseCurrencyInput(f.t2Rcv) || 0, orig.t2FeeReceived, "t2FeeReceived", "T2 Received");
       chkDt(f.t2Dt, orig.t2FeeReceivedDate, "t2FeeReceivedDate", "T2 Date");
 
-      chk(parseFloat(f.auxRetro) || 0, orig.auxRetro, "auxRetro", "AUX Retro");
+      chk(parseCurrencyInput(f.auxRetro) || 0, orig.auxRetro, "auxRetro", "AUX Retro");
       chkFeeDue(f.auxDue, orig.auxFeeDue, "auxFeeDue", "AUX Fee Due");
-      chk(parseFloat(f.auxRcv) || 0, orig.auxFeeReceived, "auxFeeReceived", "AUX Received");
+      chk(parseCurrencyInput(f.auxRcv) || 0, orig.auxFeeReceived, "auxFeeReceived", "AUX Received");
       chkDt(f.auxDt, orig.auxFeeReceivedDate, "auxFeeReceivedDate", "AUX Date");
 
       if (changes.length === 0) {
@@ -195,9 +196,9 @@ export default function FeeEditModal({
               T16 (SSI)
             </h4>
             <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-              {field("Retro Amount", f.t16Retro, set("t16Retro"))}
+              {field("Retro Amount", f.t16Retro, set("t16Retro"), "decimal")}
               {field("Fee Due", f.t16Due, set("t16Due"), "decimal", FEE_DUE_HINT)}
-              {field("Fee Received", f.t16Rcv, set("t16Rcv"))}
+              {field("Fee Received", f.t16Rcv, set("t16Rcv"), "decimal")}
               {field("Date Received", f.t16Dt, set("t16Dt"), "date")}
             </div>
           </div>
@@ -210,9 +211,9 @@ export default function FeeEditModal({
               T2 (SSDI)
             </h4>
             <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-              {field("Retro Amount", f.t2Retro, set("t2Retro"))}
+              {field("Retro Amount", f.t2Retro, set("t2Retro"), "decimal")}
               {field("Fee Due", f.t2Due, set("t2Due"), "decimal", FEE_DUE_HINT)}
-              {field("Fee Received", f.t2Rcv, set("t2Rcv"))}
+              {field("Fee Received", f.t2Rcv, set("t2Rcv"), "decimal")}
               {field("Date Received", f.t2Dt, set("t2Dt"), "date")}
             </div>
           </div>
@@ -225,9 +226,9 @@ export default function FeeEditModal({
               AUX (Auxiliary)
             </h4>
             <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-              {field("Retro Amount", f.auxRetro, set("auxRetro"))}
+              {field("Retro Amount", f.auxRetro, set("auxRetro"), "decimal")}
               {field("Fee Due", f.auxDue, set("auxDue"), "decimal", FEE_DUE_HINT)}
-              {field("Fee Received", f.auxRcv, set("auxRcv"))}
+              {field("Fee Received", f.auxRcv, set("auxRcv"), "decimal")}
               {field("Date Received", f.auxDt, set("auxDt"), "date")}
             </div>
           </div>

--- a/src/components/cases/FeePaymentPanel.tsx
+++ b/src/components/cases/FeePaymentPanel.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { createPortal } from "react-dom";
 import { Plus, Trash2, Loader2, ChevronDown } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
-import { fmtFull, fmtDate } from "@/lib/formatters";
+import { fmtFull, fmtDate, parseCurrencyInput } from "@/lib/formatters";
 import type { FeePayment } from "@/types";
 
 interface FeePaymentPanelProps {
@@ -93,7 +93,7 @@ export function FeePaymentPanel({
   };
 
   const handleAdd = async () => {
-    const amount = parseFloat(newAmount);
+    const amount = parseCurrencyInput(newAmount);
     if (!newDate || isNaN(amount) || amount <= 0) {
       setAddError("Enter a valid date and positive amount.");
       return;
@@ -221,9 +221,8 @@ export function FeePaymentPanel({
                 aria-label="Payment date"
               />
               <input
-                type="number"
-                min="0.01"
-                step="0.01"
+                type="text"
+                inputMode="decimal"
                 value={newAmount}
                 onChange={(e) => setNewAmount(e.target.value)}
                 placeholder="Amount"

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -31,6 +31,7 @@ import {
   fmtFull,
   fmtDate,
   fmtClaimLong,
+  parseCurrencyInput,
 } from "@/lib/formatters";
 import type { CaseRow, ApprovedByOption } from "@/types";
 import type { DropdownOptionsByCategory } from "@/hooks/useDashboard";
@@ -763,7 +764,7 @@ export const FeeRecordsTable = ({
     // input, not a clear-to-null gesture.
     const isFeeDue = field.endsWith("FeeDue");
     const clearing = isFeeDue && feeAmountEdit.draft.trim() === "-";
-    const parsed = parseFloat(feeAmountEdit.draft);
+    const parsed = parseCurrencyInput(feeAmountEdit.draft);
     if (!clearing && (isNaN(parsed) || parsed < 0)) {
       setFeeAmountError(
         isFeeDue ? "Enter a valid amount (0 or more), or \"-\" to clear." : "Enter a valid amount (0 or more).",

--- a/src/components/fee-petitions/FeePetitions.tsx
+++ b/src/components/fee-petitions/FeePetitions.tsx
@@ -22,7 +22,7 @@ import {
   MessageSquare,
 } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
-import { fmt, fmtDate } from "@/lib/formatters";
+import { fmt, fmtDate, parseCurrencyInput } from "@/lib/formatters";
 import { upsertFeePetition, bulkMarkComplete, bulkRestoreChecklists, bulkImportFeePetitions } from "@/app/(dashboard)/fee-petitions/actions";
 import { CompletedPetitions } from "./CompletedPetitions";
 import CsvImportModal, { type ColumnDef } from "@/components/modals/CsvImportModal";
@@ -505,7 +505,7 @@ export const FeePetitions = () => {
 
   const saveFeeAmount = useCallback(async () => {
     if (!feeAmountEdit || feeAmountSaving) return;
-    const amount = parseFloat(feeAmountEdit.draft);
+    const amount = parseCurrencyInput(feeAmountEdit.draft);
     if (isNaN(amount) || amount < 0) {
       setFeeAmountError("Enter a valid amount (0 or more).");
       return;

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -26,6 +26,12 @@ export const fmtFull = (n: number) =>
     n,
   );
 
+// Drop-in replacement for parseFloat on user-typed fee fields. Strips a
+// leading "$" and thousands commas so staff can paste values like "$1,234.56"
+// copied from MyCase documents without retyping them.
+export const parseCurrencyInput = (raw: string): number =>
+  parseFloat(raw.trim().replace(/^\$/, "").replace(/,/g, ""));
+
 export const fmtDate = (d: string | null | undefined): string => {
   if (!d) return "—";
   const [y, m, day] = d.split("-");


### PR DESCRIPTION
## Summary

- Added `parseCurrencyInput` utility to `src/lib/formatters.ts` that strips a leading `$` and thousands commas before parsing, so values like `$1,234.56` copied from MyCase documents are accepted without retyping
- Changed all fee amount inputs from `type="number"` to `type="text" inputMode="decimal"` so browsers don't reject the characters on paste (number inputs sanitize before `onChange` fires)
- Threaded `parseCurrencyInput` into all six call sites: `FeeEditModal`, `FeeAmountCell`, `FeePaymentPanel`, `FeeRecordsTable`, `FeePetitions`, and the case detail inline editor — automated Pending computation (Fee Due − Received) is unaffected as it runs server-side on the stored number