### PR TITLE
fix: add aria-hidden to decorative icons across 8 components

### DIFF
--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -322,6 +322,7 @@ export default function SettingsPage() {
           <div className="flex items-center gap-3">
             <Settings
               className={`h-5 w-5 ${dark ? "text-indigo-400" : "text-indigo-500"}`}
+              aria-hidden="true"
             />
             <div>
               <h3 className={`text-sm font-bold ${t.text}`}>Settings</h3>
@@ -337,9 +338,9 @@ export default function SettingsPage() {
               className={`h-8 px-4 rounded-md text-xs font-semibold flex items-center gap-1.5 ${t.ctaBtn} disabled:opacity-40`}
             >
               {saving ? (
-                <RefreshCw className="h-3 w-3 animate-spin" />
+                <RefreshCw className="h-3 w-3 animate-spin" aria-hidden="true" />
               ) : (
-                <Save className="h-3 w-3" />
+                <Save className="h-3 w-3" aria-hidden="true" />
               )}
               Save Changes
             </button>
@@ -368,7 +369,7 @@ export default function SettingsPage() {
                       : "text-neutral-500 hover:text-neutral-700 hover:bg-neutral-50"
                 }`}
               >
-                <m.icon className="h-3 w-3" />
+                <m.icon className="h-3 w-3" aria-hidden="true" />
                 {m.label}
               </button>
             );
@@ -415,7 +416,7 @@ export default function SettingsPage() {
         <div
           className={`${sectionCard} flex items-center justify-center py-16`}
         >
-          <RefreshCw className={`h-5 w-5 animate-spin ${t.textMuted}`} />
+          <RefreshCw className={`h-5 w-5 animate-spin ${t.textMuted}`} aria-hidden="true" />
           <span className={`ml-2 text-sm ${t.textSub}`}>
             Loading settings...
           </span>
@@ -433,7 +434,7 @@ export default function SettingsPage() {
                   <h4
                     className={`text-xs font-bold ${t.text} flex items-center gap-2`}
                   >
-                    <DollarSign className="h-3.5 w-3.5" /> Fee Defaults
+                    <DollarSign className="h-3.5 w-3.5" aria-hidden="true" /> Fee Defaults
                   </h4>
                 </div>
                 <div className="p-4 space-y-4">
@@ -488,7 +489,7 @@ export default function SettingsPage() {
                   <h4
                     className={`text-xs font-bold ${t.text} flex items-center gap-2`}
                   >
-                    <Calendar className="h-3.5 w-3.5" /> SSA Fee Cap History
+                    <Calendar className="h-3.5 w-3.5" aria-hidden="true" /> SSA Fee Cap History
                   </h4>
                   <span className={`text-[12px] ${t.textMuted}`}>
                     {feeCaps.length} entries
@@ -551,9 +552,9 @@ export default function SettingsPage() {
                       className={`h-9 px-4 rounded-lg text-xs font-semibold flex items-center gap-1.5 shrink-0 ${t.ctaBtn} disabled:opacity-40`}
                     >
                       {addingCap ? (
-                        <RefreshCw className="h-3 w-3 animate-spin" />
+                        <RefreshCw className="h-3 w-3 animate-spin" aria-hidden="true" />
                       ) : (
-                        <Plus className="h-3 w-3" />
+                        <Plus className="h-3 w-3" aria-hidden="true" />
                       )}
                       Add
                     </button>
@@ -626,7 +627,7 @@ export default function SettingsPage() {
                   <h4
                     className={`text-xs font-bold ${t.text} flex items-center gap-2`}
                   >
-                    <Shield className="h-3.5 w-3.5" /> Service Connections
+                    <Shield className="h-3.5 w-3.5" aria-hidden="true" /> Service Connections
                   </h4>
                   <p className={`text-[13px] ${t.textMuted} mt-0.5`}>
                     API keys and URLs are managed via environment variables in
@@ -639,9 +640,9 @@ export default function SettingsPage() {
                   className={`h-8 px-3 rounded-md text-xs font-medium flex items-center gap-1.5 border ${t.outlineBtn} disabled:opacity-40`}
                 >
                   {testing ? (
-                    <Loader2 className="h-3 w-3 animate-spin" />
+                    <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
                   ) : (
-                    <Wifi className="h-3 w-3" />
+                    <Wifi className="h-3 w-3" aria-hidden="true" />
                   )}
                   Test Connections
                 </button>
@@ -664,7 +665,7 @@ export default function SettingsPage() {
                         <span
                           className={`text-[11px] font-semibold px-2 py-0.5 rounded-full border flex items-center gap-1 ${colorClass}`}
                         >
-                          <StatusIcon className="h-2.5 w-2.5" />
+                          <StatusIcon className="h-2.5 w-2.5" aria-hidden="true" />
                           {conn.status === "connected"
                             ? "Connected"
                             : conn.status === "error"
@@ -680,7 +681,7 @@ export default function SettingsPage() {
 
                       <div className={`mt-2 flex flex-wrap items-center gap-3`}>
                         <div className="flex items-center gap-1.5">
-                          <Key className={`h-3 w-3 ${t.textMuted}`} />
+                          <Key className={`h-3 w-3 ${t.textMuted}`} aria-hidden="true" />
                           <span className={`text-[12px] ${t.textMuted}`}>
                             <code
                               className={`px-1 py-0.5 rounded ${dark ? "bg-neutral-800" : "bg-neutral-100"}`}
@@ -704,7 +705,7 @@ export default function SettingsPage() {
                         </div>
                         {conn.baseUrl && (
                           <div className="flex items-center gap-1.5">
-                            <Link2 className={`h-3 w-3 ${t.textMuted}`} />
+                            <Link2 className={`h-3 w-3 ${t.textMuted}`} aria-hidden="true" />
                             <span className={`text-[12px] ${t.textMuted}`}>
                               {conn.baseUrl}
                             </span>
@@ -737,7 +738,7 @@ export default function SettingsPage() {
                 <h4
                   className={`text-xs font-bold ${t.text} flex items-center gap-2`}
                 >
-                  <Target className="h-3.5 w-3.5" /> Daily Call Targets
+                  <Target className="h-3.5 w-3.5" aria-hidden="true" /> Daily Call Targets
                 </h4>
                 <p className={`text-[13px] ${t.textMuted} mt-0.5`}>
                   Agents below these thresholds trigger &qout;Missed Calls&qout;
@@ -778,7 +779,7 @@ export default function SettingsPage() {
                 <h4
                   className={`text-xs font-bold ${t.text} flex items-center gap-2`}
                 >
-                  <Bell className="h-3.5 w-3.5" /> Notification Settings
+                  <Bell className="h-3.5 w-3.5" aria-hidden="true" /> Notification Settings
                 </h4>
               </div>
               <div className="p-4 space-y-4">

--- a/src/components/cases/AcknowledgeAndCloseDialog.tsx
+++ b/src/components/cases/AcknowledgeAndCloseDialog.tsx
@@ -126,7 +126,7 @@ export function AcknowledgeAndCloseDialog({
             disabled={submitting !== null}
           >
             {submitting === "keep" && (
-              <Loader2 className="h-4 w-4 animate-spin" />
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
             )}
             No, keep on dashboard
           </Button>
@@ -136,9 +136,9 @@ export function AcknowledgeAndCloseDialog({
             disabled={submitting !== null}
           >
             {submitting === "close" ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
             ) : (
-              <CheckCircle2 className="h-4 w-4" />
+              <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
             )}
             Yes, mark closed
           </Button>

--- a/src/components/cases/FeeEditModal.tsx
+++ b/src/components/cases/FeeEditModal.tsx
@@ -247,9 +247,9 @@ export default function FeeEditModal({
             className={`h-8 px-4 rounded-md text-xs font-semibold flex items-center gap-1.5 ${t.ctaBtn} disabled:opacity-50`}
           >
             {saving ? (
-              <RefreshCw className="h-3 w-3 animate-spin" />
+              <RefreshCw className="h-3 w-3 animate-spin" aria-hidden="true" />
             ) : (
-              <Save className="h-3 w-3" />
+              <Save className="h-3 w-3" aria-hidden="true" />
             )}{" "}
             Save All Fees
           </button>

--- a/src/components/layout/ChangePasswordDialog.tsx
+++ b/src/components/layout/ChangePasswordDialog.tsx
@@ -91,7 +91,7 @@ export function ChangePasswordDialog({
 
         {done ? (
           <div className="flex items-center gap-2 rounded-md border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-700 dark:border-emerald-800 dark:bg-emerald-900/20 dark:text-emerald-300">
-            <CheckCircle2 className="h-4 w-4 shrink-0" />
+            <CheckCircle2 className="h-4 w-4 shrink-0" aria-hidden="true" />
             Password updated. Signing you out…
           </div>
         ) : (
@@ -156,7 +156,7 @@ export function ChangePasswordDialog({
                 Cancel
               </Button>
               <Button type="submit" disabled={submitting}>
-                {submitting && <Loader2 className="h-4 w-4 animate-spin" />}
+                {submitting && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
                 {submitting ? "Updating…" : "Update password"}
               </Button>
             </DialogFooter>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -472,7 +472,7 @@ export const Sidebar = ({ open, onToggle, onMobileClose }: SidebarProps) => {
             onClick={(e) => e.stopPropagation()}
           >
             <div className="flex items-center gap-3 px-4 py-3">
-              <Search className={`h-4 w-4 shrink-0 ${t.textMuted}`} />
+              <Search className={`h-4 w-4 shrink-0 ${t.textMuted}`} aria-hidden="true" />
               <input
                 ref={searchInputRef}
                 value={searchQuery}
@@ -486,9 +486,10 @@ export const Sidebar = ({ open, onToggle, onMobileClose }: SidebarProps) => {
                     setSearchQuery("");
                     setSearchResults([]);
                   }}
+                  aria-label="Clear search"
                   className={t.textMuted}
                 >
-                  <X className="h-4 w-4" />
+                  <X className="h-4 w-4" aria-hidden="true" />
                 </button>
               )}
             </div>

--- a/src/components/modals/AddCaseModal.tsx
+++ b/src/components/modals/AddCaseModal.tsx
@@ -228,7 +228,7 @@ export default function AddCaseModal({
               className={`rounded-lg border p-5 ${dark ? "bg-emerald-900/20 border-emerald-800 text-emerald-300" : "bg-emerald-50 border-emerald-200 text-emerald-800"}`}
             >
               <div className="flex items-start gap-3">
-                <CheckCircle2 className="h-5 w-5 mt-0.5 shrink-0" />
+                <CheckCircle2 className="h-5 w-5 mt-0.5 shrink-0" aria-hidden="true" />
                 <div className="text-[15px]">
                   <p className="font-bold">
                     Case created for {form.firstName} {form.lastName}.
@@ -277,7 +277,7 @@ export default function AddCaseModal({
                       className={`absolute right-2 top-1/2 -translate-y-1/2 ${t.textSub} hover:opacity-80`}
                       title="Open in MyCase"
                     >
-                      <ExternalLink className="h-4 w-4" />
+                      <ExternalLink className="h-4 w-4" aria-hidden="true" />
                     </a>
                   )}
                 </div>
@@ -297,7 +297,7 @@ export default function AddCaseModal({
                       className={`absolute right-2 top-1/2 -translate-y-1/2 ${t.textSub} hover:opacity-80`}
                       title="Open in Chronicle"
                     >
-                      <ExternalLink className="h-4 w-4" />
+                      <ExternalLink className="h-4 w-4" aria-hidden="true" />
                     </a>
                   )}
                 </div>
@@ -488,9 +488,9 @@ export default function AddCaseModal({
                 className={`h-8 px-4 rounded-md text-xs font-semibold flex items-center gap-1.5 ${t.ctaBtn} disabled:opacity-50`}
               >
                 {busy ? (
-                  <RefreshCw className="h-3.5 w-3.5 animate-spin" />
+                  <RefreshCw className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
                 ) : (
-                  <Plus className="h-3.5 w-3.5" />
+                  <Plus className="h-3.5 w-3.5" aria-hidden="true" />
                 )}
                 Create Case
               </button>

--- a/src/components/modals/ImportCasesModal.tsx
+++ b/src/components/modals/ImportCasesModal.tsx
@@ -280,7 +280,7 @@ export default function ImportCasesModal({
           {step === 1 && (
             <div>
               <div className="flex items-center gap-2 mb-1">
-                <Folder className={`h-4 w-4 ${t.textSub}`} />
+                <Folder className={`h-4 w-4 ${t.textSub}`} aria-hidden="true" />
                 <h4 className={`text-sm font-semibold ${t.text}`}>
                   Upload Spreadsheet
                 </h4>
@@ -325,7 +325,7 @@ export default function ImportCasesModal({
                     if (f) void acceptFile(f);
                   }}
                 />
-                <FileText className={`h-8 w-8 mx-auto mb-3 ${t.textMuted}`} />
+                <FileText className={`h-8 w-8 mx-auto mb-3 ${t.textMuted}`} aria-hidden="true" />
                 <p className={`text-sm font-semibold ${t.text}`}>
                   {file ? file.name : "Drag & drop your file here, or click to browse"}
                 </p>
@@ -337,6 +337,7 @@ export default function ImportCasesModal({
                 {busy === "preview" && (
                   <RefreshCw
                     className={`h-4 w-4 animate-spin mx-auto mt-3 ${t.textMuted}`}
+                    aria-hidden="true"
                   />
                 )}
               </div>
@@ -427,7 +428,7 @@ export default function ImportCasesModal({
                   className={`mt-4 rounded-md border p-3 text-[13px] ${dark ? "bg-amber-900/20 border-amber-800 text-amber-300" : "bg-amber-50 border-amber-200 text-amber-800"}`}
                 >
                   <div className="flex items-center gap-1.5 font-semibold mb-1">
-                    <AlertTriangle className="h-3.5 w-3.5" />
+                    <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
                     {preview.summary.warnings.length} warning
                     {preview.summary.warnings.length === 1 ? "" : "s"}
                   </div>
@@ -568,7 +569,7 @@ export default function ImportCasesModal({
                 className={`max-w-md mx-auto rounded-lg border p-5 ${dark ? "bg-emerald-900/20 border-emerald-800 text-emerald-300" : "bg-emerald-50 border-emerald-200 text-emerald-800"}`}
               >
                 <div className="flex items-start gap-3">
-                  <CheckCircle2 className="h-5 w-5 mt-0.5 shrink-0" />
+                  <CheckCircle2 className="h-5 w-5 mt-0.5 shrink-0" aria-hidden="true" />
                   <div className="text-[15px]">
                     <p className="font-bold">
                       Imported {result.inserted.toLocaleString()} case
@@ -599,7 +600,7 @@ export default function ImportCasesModal({
             }}
             className={`h-8 px-3 text-xs font-medium ${t.textSub} hover:underline flex items-center gap-1`}
           >
-            <ArrowLeft className="h-3 w-3" />
+            <ArrowLeft className="h-3 w-3" aria-hidden="true" />
             {step === 1 ? "Back to Import" : "Back"}
           </button>
 
@@ -610,7 +611,7 @@ export default function ImportCasesModal({
               className={`h-8 px-4 rounded-md text-xs font-semibold flex items-center gap-1.5 ${t.ctaBtn} disabled:opacity-50`}
             >
               Next: {STEPS[step].subtitle}
-              <ArrowRight className="h-3 w-3" />
+              <ArrowRight className="h-3 w-3" aria-hidden="true" />
             </button>
           ) : !result ? (
             <div className="flex items-center gap-2">
@@ -631,9 +632,9 @@ export default function ImportCasesModal({
                 className={`h-8 px-4 rounded-md text-xs font-semibold flex items-center gap-1.5 ${t.ctaBtn} disabled:opacity-50`}
               >
                 {busy === "append" ? (
-                  <RefreshCw className="h-3 w-3 animate-spin" />
+                  <RefreshCw className="h-3 w-3 animate-spin" aria-hidden="true" />
                 ) : (
-                  <Upload className="h-3 w-3" />
+                  <Upload className="h-3 w-3" aria-hidden="true" />
                 )}
                 Import Selected ({selected.size.toLocaleString()})
               </button>
@@ -732,7 +733,7 @@ const PreviewTable = ({
                     onClick={(e) => e.stopPropagation()}
                     className={`ml-1 inline-flex ${t.textMuted} hover:${t.text}`}
                   >
-                    <ExternalLink className="h-3 w-3 inline" />
+                    <ExternalLink className="h-3 w-3 inline" aria-hidden="true" />
                   </a>
                 )}
               </td>
@@ -750,7 +751,7 @@ const PreviewTable = ({
                     className={`text-[13px] underline ${dark ? "text-blue-400" : "text-blue-600"} inline-flex items-center gap-1`}
                   >
                     {r.winSheetLinkText ?? "Open"}
-                    <ExternalLink className="h-3 w-3" />
+                    <ExternalLink className="h-3 w-3" aria-hidden="true" />
                   </a>
                 ) : (
                   <span className={`text-[13px] ${t.textMuted}`}>

--- a/src/components/team/TeamManagement.tsx
+++ b/src/components/team/TeamManagement.tsx
@@ -249,7 +249,7 @@ export const TeamManagement = () => {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-20">
-        <RefreshCw className={`h-6 w-6 animate-spin ${t.textMuted}`} />
+        <RefreshCw className={`h-6 w-6 animate-spin ${t.textMuted}`} aria-hidden="true" />
         <span className={`ml-3 text-sm ${t.textSub}`}>Loading team...</span>
       </div>
     );
@@ -260,7 +260,7 @@ export const TeamManagement = () => {
       <div
         className={`rounded-xl border p-4 flex items-center gap-3 ${dark ? "bg-red-900/20 border-red-800 text-red-400" : "bg-red-50 border-red-200 text-red-700"}`}
       >
-        <AlertCircle className="h-4 w-4 shrink-0" />
+        <AlertCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
         <span className="text-sm">Failed to load team data: {error}</span>
         <button
           onClick={fetchMembers}
@@ -278,7 +278,7 @@ export const TeamManagement = () => {
       <div className="flex items-center justify-between">
         <div>
           <h2 className={`text-lg font-bold ${t.text} flex items-center gap-2`}>
-            <Users className="h-5 w-5 text-indigo-500" />
+            <Users className="h-5 w-5 text-indigo-500" aria-hidden="true" />
             Team Management
           </h2>
           <p className={`text-xs ${t.textMuted} mt-0.5`}>
@@ -289,7 +289,7 @@ export const TeamManagement = () => {
           onClick={openAddDialog}
           className={`h-8 px-3 rounded-lg text-xs font-semibold inline-flex items-center gap-1.5 ${t.ctaBtn}`}
         >
-          <Plus className="h-3.5 w-3.5" />
+          <Plus className="h-3.5 w-3.5" aria-hidden="true" />
           Add Member
         </button>
       </div>
@@ -339,6 +339,7 @@ export const TeamManagement = () => {
                 className={`h-4.5 w-4.5 ${
                   dark ? `text-${card.color}-400` : `text-${card.color}-600`
                 }`}
+                aria-hidden="true"
               />
             </div>
             <div>
@@ -352,7 +353,7 @@ export const TeamManagement = () => {
       {/* ---- Filters ---- */}
       <div className="flex items-center gap-3">
         <div className="relative flex-1 max-w-xs">
-          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-neutral-400" />
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-neutral-400" aria-hidden="true" />
           <input
             type="text"
             placeholder="Search name or role..."
@@ -363,9 +364,10 @@ export const TeamManagement = () => {
           {search && (
             <button
               onClick={() => setSearch("")}
+              aria-label="Clear search"
               className="absolute right-2.5 top-1/2 -translate-y-1/2"
             >
-              <X className={`h-3 w-3 ${t.textMuted}`} />
+              <X className={`h-3 w-3 ${t.textMuted}`} aria-hidden="true" />
             </button>
           )}
         </div>
@@ -671,7 +673,7 @@ export const TeamManagement = () => {
                       : "bg-red-50 border border-red-200 text-red-700"
                   }`}
                 >
-                  <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+                  <AlertCircle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
                   {formError}
                 </div>
               )}
@@ -689,7 +691,7 @@ export const TeamManagement = () => {
                 disabled={saving}
                 className={`h-8 px-4 rounded-lg text-xs font-semibold inline-flex items-center gap-1.5 ${t.ctaBtn} disabled:opacity-50`}
               >
-                {saving && <Loader2 className="h-3 w-3 animate-spin" />}
+                {saving && <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />}
                 {editingMember ? "Save Changes" : "Add Member"}
               </button>
             </div>
@@ -732,7 +734,7 @@ export const TeamManagement = () => {
                 disabled={deactivating}
                 className="h-8 px-4 rounded-lg text-xs font-semibold inline-flex items-center gap-1.5 bg-red-600 text-white hover:bg-red-700 disabled:opacity-50 transition-colors"
               >
-                {deactivating && <Loader2 className="h-3 w-3 animate-spin" />}
+                {deactivating && <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />}
                 Deactivate
               </button>
             </div>


### PR DESCRIPTION
## Summary
- Adds `aria-hidden="true"` to decorative Lucide icons across 8 components so screen readers skip them
- Adds `aria-label="Clear search"` to icon-only X buttons in Sidebar and TeamManagement that were missing accessible labels

## Files changed
- `src/app/(dashboard)/settings/page.tsx` — 13 icons
- `src/components/layout/Sidebar.tsx` — Search icon + X clear button
- `src/components/cases/FeeEditModal.tsx` — RefreshCw / Save spinner pair
- `src/components/modals/AddCaseModal.tsx` — CheckCircle2, ExternalLink ×2, RefreshCw / Plus pair
- `src/components/modals/ImportCasesModal.tsx` — Folder, FileText, RefreshCw, AlertTriangle, CheckCircle2, ArrowLeft, ArrowRight, Upload, ExternalLink ×2
- `src/components/team/TeamManagement.tsx` — 10 icons + X clear button
- `src/components/layout/ChangePasswordDialog.tsx` — CheckCircle2, Loader2
- `src/components/cases/AcknowledgeAndCloseDialog.tsx` — Loader2 ×2, CheckCircle2