### PR TITLE
feat: add undo toast after marking cases overpaid

### DIFF
--- a/src/app/(dashboard)/overpaid-cases/actions.ts
+++ b/src/app/(dashboard)/overpaid-cases/actions.ts
@@ -184,6 +184,30 @@ export async function bulkMarkOverpaid(input: {
   }
 }
 
+// Reverses bulkMarkOverpaid within the undo window — sets markedOverpaid back
+// to false. Does not touch overpaidDismissedAt since the case was never
+// committed to the Overpaid Cases view (the mark was immediately undone).
+export async function bulkUnmarkOverpaid(input: {
+  caseIds: number[];
+}): Promise<Result> {
+  try {
+    const guard = await requireCapability("case.finalize");
+    if (!guard.ok) return { ok: false, error: "You don't have permission." };
+    if (!input.caseIds.length) return { ok: false, error: "No cases selected" };
+    if (input.caseIds.length > 500) return { ok: false, error: "Too many cases (max 500)" };
+    if (!input.caseIds.every((id) => Number.isFinite(id))) return { ok: false, error: "Invalid case IDs" };
+
+    await db
+      .update(feeRecords)
+      .set({ markedOverpaid: false, updatedAt: new Date() })
+      .where(inArray(feeRecords.caseId, input.caseIds));
+    return { ok: true };
+  } catch (error) {
+    console.error("bulkUnmarkOverpaid error:", error);
+    return { ok: false, error: "Server error" };
+  }
+}
+
 // Marks a single case overpaid directly — for old cases that never came
 // through Master Fees and shouldn't be added there just to flag them here.
 // The normal path is bulkMarkOverpaid (the "Add to Overpaid Cases" batch

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -57,7 +57,8 @@ import { caseLevelVisual, normalizeCaseLevel } from "@/lib/case-level-icons";
 import { buildListboxOptions } from "@/lib/listbox-options";
 import { teamRowTint } from "@/lib/team-colors";
 import { memberRowTint } from "@/lib/member-colors";
-import { bulkMarkOverpaid } from "@/app/(dashboard)/overpaid-cases/actions";
+import { bulkMarkOverpaid, bulkUnmarkOverpaid } from "@/app/(dashboard)/overpaid-cases/actions";
+import { toast } from "sonner";
 
 const CLAIM_TYPE_COLORS: Record<string, { badge: string; badgeDark: string }> = {
   "T16":  { badge: "bg-blue-50 text-blue-700 border-blue-300",     badgeDark: "bg-blue-900/40 text-blue-300 border-blue-700"     },
@@ -503,6 +504,26 @@ export const FeeRecordsTable = ({
         return next;
       });
       setSelectedIds(new Set());
+      const label = ids.length === 1 ? "1 case" : `${ids.length} cases`;
+      toast.success(`${label} marked overpaid`, {
+        duration: 8000,
+        action: {
+          label: "Undo",
+          onClick: async () => {
+            const undo = await bulkUnmarkOverpaid({ caseIds: ids });
+            if (undo.ok) {
+              setRowOverrides((prev) => {
+                const next = { ...prev };
+                for (const id of ids) next[id] = { ...next[id], markedOverpaid: false };
+                return next;
+              });
+              toast.success("Undone — cases unmarked");
+            } else {
+              toast.error("Could not undo. Please refresh the page.");
+            }
+          },
+        },
+      });
     } catch (err) {
       setBulkOverpaidError((err as Error).message);
     } finally {


### PR DESCRIPTION
## Summary
- After bulk-marking cases overpaid, a Sonner toast appears for 8 seconds with an **Undo** button
- Clicking Undo calls `bulkUnmarkOverpaid` (new server action) and reverses the optimistic row override
- If undo fails, a follow-up error toast prompts a page refresh
- Adds `bulkUnmarkOverpaid` server action to `overpaid-cases/actions.ts`

## How to test
1. Log in as admin
2. Go to Master Fees, select one or more cases via checkbox
3. Click "Add to Overpaid Cases" in the floating batch pill
4. A green toast should appear: "X cases marked overpaid · Undo"
5. Click Undo within 8 seconds — cases should revert

## Note
Parked pending Ms. Jazz testing on the live dashboard. Requires admin role to trigger.