### PR TITLE
feat: bulk reassign cases and saved filter presets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4",
         "@testing-library/react": "^16.3.2",
         "@types/bcryptjs": "^2.4.6",
@@ -3239,6 +3240,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -13278,6 +13295,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4",
     "@testing-library/react": "^16.3.2",
     "@types/bcryptjs": "^2.4.6",

--- a/src/app/(dashboard)/master-fees/actions.ts
+++ b/src/app/(dashboard)/master-fees/actions.ts
@@ -1,0 +1,31 @@
+"use server";
+
+import { db } from "@/lib/db";
+import { feeRecords } from "@/lib/db/schema";
+import { inArray } from "drizzle-orm";
+import { requireCapability } from "@/lib/auth-helpers";
+
+type Result = { ok: true } | { ok: false; error: string };
+
+export async function bulkReassign(input: {
+  caseIds: number[];
+  assignedTo: string;
+}): Promise<Result> {
+  try {
+    const guard = await requireCapability("case.update");
+    if (!guard.ok) return { ok: false, error: "You don't have permission to reassign cases." };
+    if (!input.caseIds.length) return { ok: false, error: "No cases selected" };
+    if (input.caseIds.length > 500) return { ok: false, error: "Too many cases (max 500)" };
+    if (!input.caseIds.every((id) => Number.isFinite(id))) return { ok: false, error: "Invalid case IDs" };
+    if (!input.assignedTo.trim()) return { ok: false, error: "Agent name required" };
+
+    await db
+      .update(feeRecords)
+      .set({ assignedTo: input.assignedTo === "—" ? "" : input.assignedTo, updatedAt: new Date() })
+      .where(inArray(feeRecords.caseId, input.caseIds));
+    return { ok: true };
+  } catch (error) {
+    console.error("bulkReassign error:", error);
+    return { ok: false, error: "Server error" };
+  }
+}

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -213,6 +213,8 @@ const currency = (v: number | null) => (
 const pendingDisplay = (v: number) => (v === 0 ? "—" : fmtFull(v));
 const dateStr = (d: string | null) => (d ? fmtDate(d) : "—");
 
+type FilterPreset = { id: string; name: string; params: string };
+
 const timeAgo = (date: Date): string => {
   const diff = Math.floor((Date.now() - date.getTime()) / 1000);
   if (diff < 60) return "just now";
@@ -356,7 +358,6 @@ export const FeeRecordsTable = ({
   const [addOpen, setAddOpen] = useState(false);
 
   // ── Filter presets ────────────────────────────────────────────────────────
-  type FilterPreset = { id: string; name: string; params: string };
   const PRESET_KEY = `fee-records-presets-${mode}`;
   const [presets, setPresets] = useState<FilterPreset[]>(() => {
     if (typeof window === "undefined") return [];

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -22,6 +22,9 @@ import {
   RefreshCw,
   Minimize2,
   Maximize2,
+  Bookmark,
+  BookmarkCheck,
+  Trash2,
 } from "lucide-react";
 
 import { themeClasses } from "@/lib/theme-classes";
@@ -58,6 +61,7 @@ import { buildListboxOptions } from "@/lib/listbox-options";
 import { teamRowTint } from "@/lib/team-colors";
 import { memberRowTint } from "@/lib/member-colors";
 import { bulkMarkOverpaid } from "@/app/(dashboard)/overpaid-cases/actions";
+import { bulkReassign } from "@/app/(dashboard)/master-fees/actions";
 
 const CLAIM_TYPE_COLORS: Record<string, { badge: string; badgeDark: string }> = {
   "T16":  { badge: "bg-blue-50 text-blue-700 border-blue-300",     badgeDark: "bg-blue-900/40 text-blue-300 border-blue-700"     },
@@ -350,6 +354,75 @@ export const FeeRecordsTable = ({
   const [selectedCaseId, setSelectedCaseId] = useState<number | null>(null);
   const [importOpen, setImportOpen] = useState(false);
   const [addOpen, setAddOpen] = useState(false);
+
+  // ── Filter presets ────────────────────────────────────────────────────────
+  type FilterPreset = { id: string; name: string; params: string };
+  const PRESET_KEY = `fee-records-presets-${mode}`;
+  const [presets, setPresets] = useState<FilterPreset[]>(() => {
+    if (typeof window === "undefined") return [];
+    try { return JSON.parse(localStorage.getItem(PRESET_KEY) ?? "[]"); }
+    catch { return []; }
+  });
+  const [presetName, setPresetName] = useState("");
+  const [presetsOpen, setPresetsOpen] = useState(false);
+  const presetsRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!presetsOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (presetsRef.current && !presetsRef.current.contains(e.target as Node))
+        setPresetsOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [presetsOpen]);
+
+  const savePreset = () => {
+    const name = presetName.trim();
+    if (!name) return;
+    const params = new URLSearchParams();
+    if (search) params.set("q", search);
+    if (statusFilter !== "all") params.set("status", statusFilter);
+    if (assignedFilter !== "all") params.set("assigned", assignedFilter);
+    if (feesConfFilter !== "all") params.set("pif", feesConfFilter);
+    if (claimFilter !== "all") params.set("claim", claimFilter);
+    if (caseStatusFilter !== "all") params.set("cs", caseStatusFilter);
+    if (levelFilter !== "all") params.set("level", levelFilter);
+    if (approverFilter !== "all") params.set("approver", approverFilter);
+    if (sortKey !== defaultSortKey) params.set("sort", sortKey);
+    if (sortDir !== "desc") params.set("dir", sortDir);
+    const next: FilterPreset[] = [
+      ...presets.filter((p) => p.name !== name),
+      { id: crypto.randomUUID(), name, params: params.toString() },
+    ];
+    setPresets(next);
+    localStorage.setItem(PRESET_KEY, JSON.stringify(next));
+    setPresetName("");
+    setPresetsOpen(false);
+  };
+
+  const applyPreset = (preset: FilterPreset) => {
+    const p = new URLSearchParams(preset.params);
+    setSearch(p.get("q") ?? "");
+    setStatusFilter(p.get("status") ?? "all");
+    setAssignedFilter(p.get("assigned") ?? "all");
+    setFeesConfFilter(p.get("pif") ?? "all");
+    setClaimFilter(p.get("claim") ?? "all");
+    setCaseStatusFilter(p.get("cs") ?? "all");
+    setLevelFilter(p.get("level") ?? "all");
+    setApproverFilter(p.get("approver") ?? "all");
+    const s = p.get("sort") as SortKey | null;
+    if (s && VALID_SORT_KEYS.includes(s)) setSortKey(s);
+    else setSortKey(defaultSortKey);
+    setSortDir(p.get("dir") === "asc" ? "asc" : "desc");
+    setPageIndex(0);
+    setPresetsOpen(false);
+  };
+
+  const deletePreset = (id: string) => {
+    const next = presets.filter((p) => p.id !== id);
+    setPresets(next);
+    localStorage.setItem(PRESET_KEY, JSON.stringify(next));
+  };
   const [syncOpen, setSyncOpen] = useState(false);
   const [myCaseSyncOpen, setMyCaseSyncOpen] = useState(false);
   const [notesFor, setNotesFor] = useState<{ id: number; name: string } | null>(
@@ -366,6 +439,8 @@ export const FeeRecordsTable = ({
   >("active_sheet");
   const [bulkOverpaidSaving, setBulkOverpaidSaving] = useState(false);
   const [bulkOverpaidError, setBulkOverpaidError] = useState<string | null>(null);
+  const [bulkReassignSaving, setBulkReassignSaving] = useState(false);
+  const [bulkReassignError, setBulkReassignError] = useState<string | null>(null);
   const [bulkCloseConfirmOpen, setBulkCloseConfirmOpen] = useState(false);
   const [bulkClosePendingIds, setBulkClosePendingIds] = useState<number[]>([]);
   // Optimistic overrides for fee payment totals after panel add/delete.
@@ -470,6 +545,27 @@ export const FeeRecordsTable = ({
     setSelectedIds(
       allSelected ? new Set() : new Set(filtered.map((c) => c.id)),
     );
+  };
+
+  const handleBulkReassign = async (assignedTo: string) => {
+    if (selectedIds.size === 0 || bulkReassignSaving) return;
+    setBulkReassignSaving(true);
+    setBulkReassignError(null);
+    const ids = Array.from(selectedIds);
+    try {
+      const result = await bulkReassign({ caseIds: ids, assignedTo });
+      if (!result.ok) throw new Error(result.error);
+      setRowOverrides((prev) => {
+        const next = { ...prev };
+        for (const id of ids) next[id] = { ...next[id], assigned: assignedTo === "" ? "—" : assignedTo };
+        return next;
+      });
+      setSelectedIds(new Set());
+    } catch (err) {
+      setBulkReassignError((err as Error).message);
+    } finally {
+      setBulkReassignSaving(false);
+    }
   };
 
   const handleBatchArchive = () => {
@@ -1116,11 +1212,73 @@ export const FeeRecordsTable = ({
       <div
         className={`p-4 flex flex-col sm:flex-row sm:items-center justify-between gap-3 border-b ${t.borderLight} sticky top-0 z-40 rounded-t-xl ${stickyBg}`}
       >
-        <div>
-          <h3 className={`text-sm font-bold ${t.text}`}>{title}</h3>
-          <p className={`text-[13px] ${t.textMuted} mt-0.5`}>
-            {filtered.length} of {cases.length} cases · Last updated {timeAgo(lastUpdatedAt)}
-          </p>
+        <div className="flex items-center gap-3">
+          <div>
+            <h3 className={`text-sm font-bold ${t.text}`}>{title}</h3>
+            <p className={`text-[13px] ${t.textMuted} mt-0.5`}>
+              {filtered.length} of {cases.length} cases · Last updated {timeAgo(lastUpdatedAt)}
+            </p>
+          </div>
+          {/* Filter presets */}
+          <div className="relative" ref={presetsRef}>
+            <button
+              onClick={() => setPresetsOpen((o) => !o)}
+              aria-label="Filter presets"
+              title="Filter presets"
+              className={`h-7 w-7 rounded-md flex items-center justify-center transition-colors ${presetsOpen ? (dark ? "bg-indigo-700 text-white" : "bg-indigo-100 text-indigo-700") : `${t.hover} ${t.textMuted}`}`}
+            >
+              {presets.length > 0
+                ? <BookmarkCheck className="h-3.5 w-3.5" aria-hidden="true" />
+                : <Bookmark className="h-3.5 w-3.5" aria-hidden="true" />
+              }
+            </button>
+            {presetsOpen && (
+              <div className={`absolute left-0 top-9 z-50 w-64 rounded-xl border shadow-xl ${dark ? "bg-neutral-900 border-neutral-700" : "bg-white border-neutral-200"}`}>
+                <div className={`p-3 border-b ${t.borderLight}`}>
+                  <p className={`text-[11px] font-semibold uppercase tracking-wider ${t.textMuted} mb-2`}>Save current filters</p>
+                  <div className="flex gap-1.5">
+                    <input
+                      value={presetName}
+                      onChange={(e) => setPresetName(e.target.value)}
+                      onKeyDown={(e) => e.key === "Enter" && savePreset()}
+                      placeholder="Preset name…"
+                      className={`flex-1 h-7 px-2 rounded-md border text-xs outline-none ${t.inputBg}`}
+                    />
+                    <button
+                      onClick={savePreset}
+                      disabled={!presetName.trim()}
+                      className={`h-7 px-2 rounded-md text-xs font-semibold ${t.ctaBtn} disabled:opacity-40`}
+                    >
+                      Save
+                    </button>
+                  </div>
+                </div>
+                {presets.length > 0 ? (
+                  <ul className="py-1 max-h-48 overflow-y-auto">
+                    {presets.map((preset) => (
+                      <li key={preset.id} className={`flex items-center gap-1 px-2 py-1 ${dark ? "hover:bg-neutral-800" : "hover:bg-neutral-50"}`}>
+                        <button
+                          onClick={() => applyPreset(preset)}
+                          className={`flex-1 text-left text-xs ${t.text} truncate`}
+                        >
+                          {preset.name}
+                        </button>
+                        <button
+                          onClick={() => deletePreset(preset.id)}
+                          aria-label={`Delete preset ${preset.name}`}
+                          className={`shrink-0 p-0.5 rounded ${dark ? "hover:bg-neutral-700 text-neutral-500" : "hover:bg-neutral-100 text-neutral-400"}`}
+                        >
+                          <Trash2 className="h-3 w-3" aria-hidden="true" />
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className={`text-[13px] ${t.textMuted} p-3`}>No saved presets yet.</p>
+                )}
+              </div>
+            )}
+          </div>
         </div>
         <div className="flex items-center gap-2 flex-wrap">
           <div className="relative flex-1 sm:flex-none">
@@ -1254,16 +1412,16 @@ export const FeeRecordsTable = ({
       </div>
 
       {/* Floating batch action pill — fixed to the viewport bottom. Fees
-          Closed, Archive, and "Add to Overpaid Cases" (at will, independent
-          of the automatic PIF detection) are the batch actions. */}
+          Closed, Archive, "Add to Overpaid Cases", and Reassign are the
+          batch actions. */}
       {selectedIds.size > 0 && isAdmin && (
         <div className="pointer-events-none fixed bottom-6 left-0 right-0 z-50 flex flex-col items-center gap-2">
-          {bulkOverpaidError && (
+          {(bulkOverpaidError || bulkReassignError) && (
             <div
               role="alert"
               className="pointer-events-auto rounded-full bg-red-600 px-3 py-1 text-[12px] font-medium text-white shadow-lg"
             >
-              {bulkOverpaidError}
+              {bulkOverpaidError ?? bulkReassignError}
             </div>
           )}
           <div className="pointer-events-auto flex items-center gap-2 rounded-full bg-gray-900 px-4 py-2.5 shadow-2xl ring-1 ring-white/10 dark:bg-gray-800">
@@ -1293,6 +1451,22 @@ export const FeeRecordsTable = ({
                 )}
                 Add to Overpaid Cases
               </button>
+            )}
+            {assignedOptions.length > 0 && (
+              <select
+                value=""
+                onChange={(e) => { if (e.target.value) void handleBulkReassign(e.target.value); }}
+                disabled={bulkReassignSaving}
+                aria-label="Reassign selected cases"
+                className="h-7 px-2 rounded-full text-[13px] font-semibold bg-blue-600 hover:bg-blue-500 text-white border-0 outline-none cursor-pointer disabled:opacity-50 transition-colors"
+              >
+                <option value="" disabled>
+                  {bulkReassignSaving ? "Reassigning…" : "Reassign to…"}
+                </option>
+                {assignedOptions.filter((o) => o.isActive).map((o) => (
+                  <option key={o.id} value={o.name}>{o.name}</option>
+                ))}
+              </select>
             )}
             <button
               onClick={handleBatchArchive}

--- a/src/components/cases/__tests__/FeeRecordsTable.column-parity.test.tsx
+++ b/src/components/cases/__tests__/FeeRecordsTable.column-parity.test.tsx
@@ -44,9 +44,13 @@ vi.mock("next-themes", () => ({
   useTheme: () => ({ resolvedTheme: "light" }),
 }));
 
-// Server action — imports DB client with "use server"; must be mocked in tests.
+// Server actions — import DB client with "use server"; must be mocked in tests.
 vi.mock("@/app/(dashboard)/overpaid-cases/actions", () => ({
   bulkMarkOverpaid: vi.fn(),
+}));
+
+vi.mock("@/app/(dashboard)/master-fees/actions", () => ({
+  bulkReassign: vi.fn(),
 }));
 
 // Modals/dialogs are conditionally rendered and have complex deps not relevant


### PR DESCRIPTION
## Summary
- Adds a **Reassign to…** dropdown to the batch action pill — admins can select multiple cases and reassign them all in one click; optimistic row overrides update immediately
- Adds a **bookmark icon** next to the table title for named filter presets — saves the current filter/sort combination to localStorage, restores it in one click, survives page reloads
- New `bulkReassign` server action in `master-fees/actions.ts` (gated on `case.update`)
- Presets stored per-mode (`fee-records-presets-active` / `fee-records-presets-closed`) so Master Fees and Fees Closed have independent preset lists

## Verified
Playwright headless run confirmed: preset save/apply/delete/persist, reassign dropdown with 34 agents, all existing pill buttons intact, pill count updates correctly for multi-select.