### PR TITLE
feat: empty state guidance and sync step progress

### DIFF
--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -589,6 +589,8 @@ export const FeeRecordsTable = ({
     setCaseStatusFilter("all");
     setLevelFilter("all");
     setApproverFilter("all");
+    setSortKey(defaultSortKey);
+    setSortDir("desc");
     setPageIndex(0);
   };
 

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -572,6 +572,7 @@ export const FeeRecordsTable = ({
 
   const hasActiveFilters =
     !!search ||
+    !!dateRange ||
     statusFilter !== "all" ||
     assignedFilter !== "all" ||
     feesConfFilter !== "all" ||

--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -25,6 +25,7 @@ import {
   Bookmark,
   BookmarkCheck,
   Trash2,
+  SearchX,
 } from "lucide-react";
 
 import { themeClasses } from "@/lib/theme-classes";
@@ -567,6 +568,28 @@ export const FeeRecordsTable = ({
     } finally {
       setBulkReassignSaving(false);
     }
+  };
+
+  const hasActiveFilters =
+    !!search ||
+    statusFilter !== "all" ||
+    assignedFilter !== "all" ||
+    feesConfFilter !== "all" ||
+    claimFilter !== "all" ||
+    caseStatusFilter !== "all" ||
+    levelFilter !== "all" ||
+    approverFilter !== "all";
+
+  const clearFilters = () => {
+    setSearch("");
+    setStatusFilter("all");
+    setAssignedFilter("all");
+    setFeesConfFilter("all");
+    setClaimFilter("all");
+    setCaseStatusFilter("all");
+    setLevelFilter("all");
+    setApproverFilter("all");
+    setPageIndex(0);
   };
 
   const handleBatchArchive = () => {
@@ -2909,8 +2932,26 @@ export const FeeRecordsTable = ({
       )}
 
       {filtered.length === 0 && (
-        <div className={`py-12 text-center text-sm ${t.textMuted}`}>
-          No cases match your filters.
+        <div className="py-16 flex flex-col items-center gap-3">
+          <SearchX className={`h-9 w-9 opacity-25 ${t.textMuted}`} aria-hidden="true" />
+          {hasActiveFilters ? (
+            <>
+              <div className="text-center">
+                <p className={`text-sm font-semibold ${t.textSub}`}>No cases match your filters</p>
+                <p className={`text-[13px] mt-1 ${t.textMuted}`}>
+                  {cases.length} case{cases.length !== 1 ? "s" : ""} exist{cases.length === 1 ? "s" : ""} — try adjusting or clearing your filters.
+                </p>
+              </div>
+              <button
+                onClick={clearFilters}
+                className={`h-8 px-4 rounded-md text-xs font-semibold border ${t.outlineBtn}`}
+              >
+                Clear all filters
+              </button>
+            </>
+          ) : (
+            <p className={`text-sm ${t.textMuted}`}>No cases yet.</p>
+          )}
         </div>
       )}
 

--- a/src/components/modals/SheetSyncModal.tsx
+++ b/src/components/modals/SheetSyncModal.tsx
@@ -505,6 +505,39 @@ export default function SheetSyncModal({
 
   const lblCls = `text-[12px] font-semibold uppercase tracking-wider ${t.textMuted}`;
 
+  const syncProgressStrip = (() => {
+    if (!syncing && !fcSyncing) return null;
+    const elapsed = syncing ? syncElapsed : fcSyncElapsed;
+    const phases = [
+      { label: "Fetching from Sheets", done: elapsed >= 20 },
+      { label: "Comparing with database", done: elapsed >= 42 },
+      { label: "Upserting records", done: false },
+    ];
+    const activeIdx = phases.findLastIndex((p) => !p.done);
+    return (
+      <div role="status" aria-live="polite" className={`px-5 py-2.5 border-t ${t.borderLight} flex items-center justify-center gap-3 flex-wrap`}>
+        {phases.map((phase, i) => (
+          <div key={i} className="flex items-center gap-1.5">
+            {phase.done ? (
+              <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500 shrink-0" aria-hidden="true" />
+            ) : i === activeIdx ? (
+              <RefreshCw className="h-3.5 w-3.5 animate-spin text-blue-500 shrink-0" aria-hidden="true" />
+            ) : (
+              <div className="h-3.5 w-3.5 rounded-full border-2 border-neutral-300 dark:border-neutral-600 shrink-0" />
+            )}
+            <span className={`text-[12px] ${phase.done ? "text-emerald-600 dark:text-emerald-400" : i === activeIdx ? t.text : t.textMuted}`}>
+              {phase.label}
+            </span>
+            {i < phases.length - 1 && (
+              <ArrowRight className={`h-3 w-3 ml-1.5 shrink-0 ${t.textMuted}`} aria-hidden="true" />
+            )}
+          </div>
+        ))}
+        <span className={`text-[12px] ${t.textMuted}`}>({elapsed}s)</span>
+      </div>
+    );
+  })();
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center"
@@ -1149,37 +1182,7 @@ export default function SheetSyncModal({
         </div>
 
         {/* Sync progress strip — visible while either sync is running */}
-        {(syncing || fcSyncing) && (() => {
-          const elapsed = syncing ? syncElapsed : fcSyncElapsed;
-          const phases = [
-            { label: "Fetching from Sheets", done: elapsed >= 20 },
-            { label: "Comparing with database", done: elapsed >= 42 },
-            { label: "Upserting records", done: false },
-          ];
-          const activeIdx = phases.findLastIndex((p) => !p.done);
-          return (
-            <div role="status" aria-live="polite" className={`px-5 py-2.5 border-t ${t.borderLight} flex items-center justify-center gap-3 flex-wrap`}>
-              {phases.map((phase, i) => (
-                <div key={i} className="flex items-center gap-1.5">
-                  {phase.done ? (
-                    <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500 shrink-0" aria-hidden="true" />
-                  ) : i === activeIdx ? (
-                    <RefreshCw className="h-3.5 w-3.5 animate-spin text-blue-500 shrink-0" aria-hidden="true" />
-                  ) : (
-                    <div className="h-3.5 w-3.5 rounded-full border-2 border-neutral-300 dark:border-neutral-600 shrink-0" />
-                  )}
-                  <span className={`text-[12px] ${phase.done ? "text-emerald-600 dark:text-emerald-400" : i === activeIdx ? t.text : t.textMuted}`}>
-                    {phase.label}
-                  </span>
-                  {i < phases.length - 1 && (
-                    <ArrowRight className={`h-3 w-3 ml-1.5 shrink-0 ${t.textMuted}`} aria-hidden="true" />
-                  )}
-                </div>
-              ))}
-              <span className={`text-[12px] ${t.textMuted}`}>({elapsed}s)</span>
-            </div>
-          );
-        })()}
+        {syncProgressStrip}
 
         {/* Footer */}
         <div className={`flex items-center justify-between px-5 py-3 border-t ${t.borderLight}`}>

--- a/src/components/modals/SheetSyncModal.tsx
+++ b/src/components/modals/SheetSyncModal.tsx
@@ -1148,6 +1148,39 @@ export default function SheetSyncModal({
           )}
         </div>
 
+        {/* Sync progress strip — visible while either sync is running */}
+        {(syncing || fcSyncing) && (() => {
+          const elapsed = syncing ? syncElapsed : fcSyncElapsed;
+          const phases = [
+            { label: "Fetching from Sheets", done: elapsed >= 20 },
+            { label: "Comparing with database", done: elapsed >= 42 },
+            { label: "Upserting records", done: false },
+          ];
+          const activeIdx = phases.findLastIndex((p) => !p.done);
+          return (
+            <div role="status" aria-live="polite" className={`px-5 py-2.5 border-t ${t.borderLight} flex items-center justify-center gap-3 flex-wrap`}>
+              {phases.map((phase, i) => (
+                <div key={i} className="flex items-center gap-1.5">
+                  {phase.done ? (
+                    <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500 shrink-0" aria-hidden="true" />
+                  ) : i === activeIdx ? (
+                    <RefreshCw className="h-3.5 w-3.5 animate-spin text-blue-500 shrink-0" aria-hidden="true" />
+                  ) : (
+                    <div className="h-3.5 w-3.5 rounded-full border-2 border-neutral-300 dark:border-neutral-600 shrink-0" />
+                  )}
+                  <span className={`text-[12px] ${phase.done ? "text-emerald-600 dark:text-emerald-400" : i === activeIdx ? t.text : t.textMuted}`}>
+                    {phase.label}
+                  </span>
+                  {i < phases.length - 1 && (
+                    <ArrowRight className={`h-3 w-3 ml-1.5 shrink-0 ${t.textMuted}`} aria-hidden="true" />
+                  )}
+                </div>
+              ))}
+              <span className={`text-[12px] ${t.textMuted}`}>({elapsed}s)</span>
+            </div>
+          );
+        })()}
+
         {/* Footer */}
         <div className={`flex items-center justify-between px-5 py-3 border-t ${t.borderLight}`}>
           <button

--- a/src/components/modals/SheetSyncModal.tsx
+++ b/src/components/modals/SheetSyncModal.tsx
@@ -523,7 +523,7 @@ export default function SheetSyncModal({
             ) : i === activeIdx ? (
               <RefreshCw className="h-3.5 w-3.5 animate-spin text-blue-500 shrink-0" aria-hidden="true" />
             ) : (
-              <div className="h-3.5 w-3.5 rounded-full border-2 border-neutral-300 dark:border-neutral-600 shrink-0" />
+              <div aria-hidden="true" className="h-3.5 w-3.5 rounded-full border-2 border-neutral-300 dark:border-neutral-600 shrink-0" />
             )}
             <span className={`text-[12px] ${phase.done ? "text-emerald-600 dark:text-emerald-400" : i === activeIdx ? t.text : t.textMuted}`}>
               {phase.label}


### PR DESCRIPTION
## Summary

### #9 — Empty state with guidance (FeeRecordsTable)
- Replaces the bare "No cases match your filters" text with a contextual empty state
- When filters are active: shows a `SearchX` icon, count of total cases, and a **"Clear all filters"** button that resets all filters at once
- When no filters are active and the table is genuinely empty: shows "No cases yet."

### #10 — Sync step progress (SheetSyncModal)
- Adds a three-phase progress strip above the modal footer during Sheets sync
- Phases advance based on elapsed seconds: **Fetching from Sheets** (0–20s) → **Comparing with database** (20–42s) → **Upserting records** (42s+)
- Completed phases show a green checkmark; active phase shows a spinner; pending phases show an empty circle
- Includes `role="status"` and `aria-live="polite"` for screen readers