### PR TITLE
feat: copy table as Sheets (TSV) or Chat (monospace block) on Reports and Scoreboard

### DIFF
--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -20,10 +20,12 @@ import {
   Check,
   ExternalLink,
   Clipboard,
+  Table2,
+  MessageSquare,
 } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { themeClasses } from "@/lib/theme-classes";
-import { fmt, fmtDate, namesMatch, getMonday, formatWeekLabel } from "@/lib/formatters";
+import { fmt, fmtDate, namesMatch, getMonday, formatWeekLabel, toChatBlock } from "@/lib/formatters";
 import { teamBadgeClasses } from "@/lib/team-colors";
 import { useCapabilities } from "@/hooks/useCapabilities";
 import {
@@ -187,9 +189,12 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
   const [metricFocus, setMetricFocus] = useState<MetricFocus>("all");
   const [copiedRow, setCopiedRow] = useState<string | null>(null);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [copiedTable, setCopiedTable] = useState<string | null>(null);
+  const tableCopyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => () => {
     if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+    if (tableCopyTimerRef.current) clearTimeout(tableCopyTimerRef.current);
   }, []);
 
   const copyAgentRow = (a: AgentScore) => {
@@ -206,6 +211,77 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
       setCopiedRow(a.agent);
       if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
       copyTimerRef.current = setTimeout(() => setCopiedRow(null), 1500);
+    });
+  };
+
+  const copyNoFeesTable = (format: "sheets" | "chat") => {
+    const header = format === "sheets"
+      ? ["Case Name", "Assigned", "Level", "Claim", "Approval", "Days"]
+      : ["Case", "Agent", "Level", "Claim", "Approved", "Days"];
+    const rows = (data?.noFeesCases ?? []).map((c) => {
+      const level = c.level.replace(/_/g, " ");
+      const isFeePetition = level.trim().toUpperCase() === "FEE PETITION";
+      const fullLevel = isFeePetition && c.feePetitionApproved ? "FEE PETITION (approved)" : level;
+      const displayLevel = format === "chat" && isFeePetition && c.feePetitionApproved
+        ? "FP (approved)"
+        : fullLevel;
+      const caseName = format === "chat" && c.name.length > 20
+        ? c.name.slice(0, 19) + "…"
+        : c.name;
+      return [caseName, c.assigned, displayLevel, c.claim, fmtDate(c.approvalDate) ?? "—", c.daysSinceApproval];
+    });
+    const text = format === "sheets"
+      ? [header, ...rows].map((r) => r.join("\t")).join("\n")
+      : toChatBlock("No Fees Cases", header, rows);
+    navigator.clipboard.writeText(text).then(() => {
+      setCopiedTable(`noFees-${format}`);
+      if (tableCopyTimerRef.current) clearTimeout(tableCopyTimerRef.current);
+      tableCopyTimerRef.current = setTimeout(() => setCopiedTable(null), 1500);
+    });
+  };
+
+  const copyAgentTable = (format: "sheets" | "chat") => {
+    const chat = format === "chat";
+    const headers: string[] = ["Agent"];
+    if (showCol("cases"))       headers.push("Open");
+    if (showCol("closedcases")) headers.push("Closed");
+    if (showCol("opennofees"))  headers.push("No Fees");
+    if (showCol("collected"))   headers.push("Collected");
+    if (showCol("ssacalls"))    headers.push(chat ? "SSA" : "SSA Calls");
+    if (showCol("clientcalls")) headers.push(chat ? "CL Calls" : "Client Calls");
+    if (showCol("faxsent"))     headers.push(chat ? "Fax" : "Fax Sent");
+    if (showCol("winsheets"))   headers.push(chat ? "Wins" : "Win Sheets");
+    const dataRows = filteredAgents.map((a) => {
+      const cols: (string | number)[] = [a.agent];
+      if (showCol("cases"))       cols.push(a.openCases);
+      if (showCol("closedcases")) cols.push(a.casesClosed);
+      if (showCol("opennofees"))  cols.push(a.openNoFees);
+      if (showCol("collected"))   cols.push(a.feesCollectedInWindow != null ? fmt(a.feesCollectedInWindow) : "—");
+      if (showCol("ssacalls"))    cols.push(a.weekSsaCalls);
+      if (showCol("clientcalls")) cols.push(a.weekClientCalls);
+      if (showCol("faxsent"))     cols.push(a.weekFaxSent);
+      if (showCol("winsheets"))   cols.push(a.completedWinSheets);
+      return cols;
+    });
+    const totalsRow: (string | number)[] = ["TOTAL"];
+    if (showCol("cases"))       totalsRow.push(filteredTotals.openCases);
+    if (showCol("closedcases")) totalsRow.push(filteredTotals.casesClosed);
+    if (showCol("opennofees"))  totalsRow.push(filteredTotals.openNoFees);
+    if (showCol("collected")) {
+      const allNull = filteredAgents.every((a) => a.feesCollectedInWindow == null);
+      totalsRow.push(allNull ? "—" : fmt(filteredTotals.feesCollectedInWindow));
+    }
+    if (showCol("ssacalls"))    totalsRow.push(filteredTotals.weekSsaCalls);
+    if (showCol("clientcalls")) totalsRow.push(filteredTotals.weekClientCalls);
+    if (showCol("faxsent"))     totalsRow.push(filteredTotals.weekFaxSent);
+    if (showCol("winsheets"))   totalsRow.push(filteredTotals.completedWinSheets);
+    const text = format === "sheets"
+      ? [headers, ...dataRows, totalsRow].map((r) => r.join("\t")).join("\n")
+      : toChatBlock(`Agent Tracking — ${windowLabel}`, headers, [...dataRows, totalsRow]);
+    navigator.clipboard.writeText(text).then(() => {
+      setCopiedTable(`agents-${format}`);
+      if (tableCopyTimerRef.current) clearTimeout(tableCopyTimerRef.current);
+      tableCopyTimerRef.current = setTimeout(() => setCopiedTable(null), 1500);
     });
   };
 
@@ -578,11 +654,37 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
         <div className={`rounded-xl border ${t.card} overflow-hidden`}>
           <div className={`px-4 py-2.5 flex items-center justify-between border-b ${t.borderLight}`}>
             <span className={`text-xs font-bold ${t.text}`}>No Fees Cases</span>
-            <span className="text-[13px] font-medium tabular-nums">
-              <span className={dark ? "text-amber-400" : "text-amber-600"}>{data.noFeesAging.over60} 60–90 days</span>
-              <span className={t.textMuted}> · </span>
-              <span className={dark ? "text-red-400" : "text-red-600"}>{data.noFeesAging.over90} over 90 days</span>
-            </span>
+            <div className="flex items-center gap-3">
+              <span className="text-[13px] font-medium tabular-nums">
+                <span className={dark ? "text-amber-400" : "text-amber-600"}>{data.noFeesAging.over60} 60–90 days</span>
+                <span className={t.textMuted}> · </span>
+                <span className={dark ? "text-red-400" : "text-red-600"}>{data.noFeesAging.over90} over 90 days</span>
+              </span>
+              <div className="flex items-center gap-1">
+                <button
+                  onClick={() => copyNoFeesTable("sheets")}
+                  aria-label="Copy No Fees Cases for Google Sheets"
+                  title="Copy for Google Sheets (tab-separated)"
+                  className={`flex items-center gap-1 px-2 py-1 rounded-md text-[12px] font-medium border transition-colors ${copiedTable === "noFees-sheets" ? (dark ? "border-emerald-700 text-emerald-400" : "border-emerald-300 text-emerald-600") : (dark ? "border-neutral-700 text-neutral-400 hover:bg-neutral-800" : "border-neutral-200 text-neutral-500 hover:bg-neutral-50")}`}
+                >
+                  {copiedTable === "noFees-sheets"
+                    ? <><Check aria-hidden="true" className="h-3 w-3" />Copied</>
+                    : <><Table2 aria-hidden="true" className="h-3 w-3" />Sheets</>
+                  }
+                </button>
+                <button
+                  onClick={() => copyNoFeesTable("chat")}
+                  aria-label="Copy No Fees Cases for Google Chat"
+                  title="Copy for Google Chat (monospace code block)"
+                  className={`flex items-center gap-1 px-2 py-1 rounded-md text-[12px] font-medium border transition-colors ${copiedTable === "noFees-chat" ? (dark ? "border-emerald-700 text-emerald-400" : "border-emerald-300 text-emerald-600") : (dark ? "border-neutral-700 text-neutral-400 hover:bg-neutral-800" : "border-neutral-200 text-neutral-500 hover:bg-neutral-50")}`}
+                >
+                  {copiedTable === "noFees-chat"
+                    ? <><Check aria-hidden="true" className="h-3 w-3" />Copied</>
+                    : <><MessageSquare aria-hidden="true" className="h-3 w-3" />Chat</>
+                  }
+                </button>
+              </div>
+            </div>
           </div>
           {data.noFeesCases.length === 0 ? (
             <div className={`py-6 text-center text-xs ${t.textMuted}`}>No aging no-fee cases.</div>
@@ -865,9 +967,33 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                   <option key={o.value} value={o.value}>{o.label}</option>
                 ))}
               </select>
-              <span className={`ml-auto text-[13px] ${t.textMuted}`}>
-                {filteredAgents.length} of {data.agents.length} agents
-              </span>
+              <div className="ml-auto flex items-center gap-2">
+                <span className={`text-[13px] ${t.textMuted}`}>
+                  {filteredAgents.length} of {data.agents.length} agents
+                </span>
+                <button
+                  onClick={() => copyAgentTable("sheets")}
+                  aria-label="Copy Agent Tracking for Google Sheets"
+                  title="Copy for Google Sheets (tab-separated)"
+                  className={`flex items-center gap-1 px-2 py-1 rounded-md text-[12px] font-medium border transition-colors ${copiedTable === "agents-sheets" ? (dark ? "border-emerald-700 text-emerald-400" : "border-emerald-300 text-emerald-600") : (dark ? "border-neutral-700 text-neutral-400 hover:bg-neutral-800" : "border-neutral-200 text-neutral-500 hover:bg-neutral-50")}`}
+                >
+                  {copiedTable === "agents-sheets"
+                    ? <><Check aria-hidden="true" className="h-3 w-3" />Copied</>
+                    : <><Table2 aria-hidden="true" className="h-3 w-3" />Sheets</>
+                  }
+                </button>
+                <button
+                  onClick={() => copyAgentTable("chat")}
+                  aria-label="Copy Agent Tracking for Google Chat"
+                  title="Copy for Google Chat (monospace code block)"
+                  className={`flex items-center gap-1 px-2 py-1 rounded-md text-[12px] font-medium border transition-colors ${copiedTable === "agents-chat" ? (dark ? "border-emerald-700 text-emerald-400" : "border-emerald-300 text-emerald-600") : (dark ? "border-neutral-700 text-neutral-400 hover:bg-neutral-800" : "border-neutral-200 text-neutral-500 hover:bg-neutral-50")}`}
+                >
+                  {copiedTable === "agents-chat"
+                    ? <><Check aria-hidden="true" className="h-3 w-3" />Copied</>
+                    : <><MessageSquare aria-hidden="true" className="h-3 w-3" />Chat</>
+                  }
+                </button>
+              </div>
             </div>
 
             {/* Agent table */}

--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -168,6 +168,49 @@ const cellKey = (agent: string, date: string): CellKey => `${agent}|${date}`;
 const EMPTY_CELL: CellValues = { ssaCalls: "", clientCallsIb: "", clientCallsOb: "", winSheetsCreated: "", faxSent: "" };
 
 
+// ---------- sub-components ----------
+
+interface CopyButtonsProps {
+  label: string;
+  sheetsActive: boolean;
+  chatActive: boolean;
+  onSheets: () => void;
+  onChat: () => void;
+  dark: boolean;
+}
+
+function CopyButtons({ label, sheetsActive, chatActive, onSheets, onChat, dark }: CopyButtonsProps) {
+  const base = `flex items-center gap-1 px-2 py-1 rounded-md text-[12px] font-medium border transition-colors`;
+  const active = dark ? "border-emerald-700 text-emerald-400" : "border-emerald-300 text-emerald-600";
+  const idle = dark ? "border-neutral-700 text-neutral-400 hover:bg-neutral-800" : "border-neutral-200 text-neutral-500 hover:bg-neutral-50";
+  return (
+    <div className="flex items-center gap-1">
+      <button
+        onClick={onSheets}
+        aria-label={`Copy ${label} for Google Sheets`}
+        title="Copy for Google Sheets (tab-separated)"
+        className={`${base} ${sheetsActive ? active : idle}`}
+      >
+        {sheetsActive
+          ? <><Check aria-hidden="true" className="h-3 w-3" />Copied</>
+          : <><Table2 aria-hidden="true" className="h-3 w-3" />Sheets</>
+        }
+      </button>
+      <button
+        onClick={onChat}
+        aria-label={`Copy ${label} for Google Chat`}
+        title="Copy for Google Chat (monospace code block)"
+        className={`${base} ${chatActive ? active : idle}`}
+      >
+        {chatActive
+          ? <><Check aria-hidden="true" className="h-3 w-3" />Copied</>
+          : <><MessageSquare aria-hidden="true" className="h-3 w-3" />Chat</>
+        }
+      </button>
+    </div>
+  );
+}
+
 // ---------- component ----------
 
 interface ScoreboardTrackerProps {
@@ -189,7 +232,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
   const [metricFocus, setMetricFocus] = useState<MetricFocus>("all");
   const [copiedRow, setCopiedRow] = useState<string | null>(null);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [copiedTable, setCopiedTable] = useState<string | null>(null);
+  const [copiedTable, setCopiedTable] = useState<"noFees-sheets" | "noFees-chat" | "agents-sheets" | "agents-chat" | null>(null);
   const tableCopyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => () => {
@@ -660,30 +703,14 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                 <span className={t.textMuted}> · </span>
                 <span className={dark ? "text-red-400" : "text-red-600"}>{data.noFeesAging.over90} over 90 days</span>
               </span>
-              <div className="flex items-center gap-1">
-                <button
-                  onClick={() => copyNoFeesTable("sheets")}
-                  aria-label="Copy No Fees Cases for Google Sheets"
-                  title="Copy for Google Sheets (tab-separated)"
-                  className={`flex items-center gap-1 px-2 py-1 rounded-md text-[12px] font-medium border transition-colors ${copiedTable === "noFees-sheets" ? (dark ? "border-emerald-700 text-emerald-400" : "border-emerald-300 text-emerald-600") : (dark ? "border-neutral-700 text-neutral-400 hover:bg-neutral-800" : "border-neutral-200 text-neutral-500 hover:bg-neutral-50")}`}
-                >
-                  {copiedTable === "noFees-sheets"
-                    ? <><Check aria-hidden="true" className="h-3 w-3" />Copied</>
-                    : <><Table2 aria-hidden="true" className="h-3 w-3" />Sheets</>
-                  }
-                </button>
-                <button
-                  onClick={() => copyNoFeesTable("chat")}
-                  aria-label="Copy No Fees Cases for Google Chat"
-                  title="Copy for Google Chat (monospace code block)"
-                  className={`flex items-center gap-1 px-2 py-1 rounded-md text-[12px] font-medium border transition-colors ${copiedTable === "noFees-chat" ? (dark ? "border-emerald-700 text-emerald-400" : "border-emerald-300 text-emerald-600") : (dark ? "border-neutral-700 text-neutral-400 hover:bg-neutral-800" : "border-neutral-200 text-neutral-500 hover:bg-neutral-50")}`}
-                >
-                  {copiedTable === "noFees-chat"
-                    ? <><Check aria-hidden="true" className="h-3 w-3" />Copied</>
-                    : <><MessageSquare aria-hidden="true" className="h-3 w-3" />Chat</>
-                  }
-                </button>
-              </div>
+              <CopyButtons
+                label="No Fees Cases"
+                sheetsActive={copiedTable === "noFees-sheets"}
+                chatActive={copiedTable === "noFees-chat"}
+                onSheets={() => copyNoFeesTable("sheets")}
+                onChat={() => copyNoFeesTable("chat")}
+                dark={dark}
+              />
             </div>
           </div>
           {data.noFeesCases.length === 0 ? (
@@ -971,28 +998,14 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                 <span className={`text-[13px] ${t.textMuted}`}>
                   {filteredAgents.length} of {data.agents.length} agents
                 </span>
-                <button
-                  onClick={() => copyAgentTable("sheets")}
-                  aria-label="Copy Agent Tracking for Google Sheets"
-                  title="Copy for Google Sheets (tab-separated)"
-                  className={`flex items-center gap-1 px-2 py-1 rounded-md text-[12px] font-medium border transition-colors ${copiedTable === "agents-sheets" ? (dark ? "border-emerald-700 text-emerald-400" : "border-emerald-300 text-emerald-600") : (dark ? "border-neutral-700 text-neutral-400 hover:bg-neutral-800" : "border-neutral-200 text-neutral-500 hover:bg-neutral-50")}`}
-                >
-                  {copiedTable === "agents-sheets"
-                    ? <><Check aria-hidden="true" className="h-3 w-3" />Copied</>
-                    : <><Table2 aria-hidden="true" className="h-3 w-3" />Sheets</>
-                  }
-                </button>
-                <button
-                  onClick={() => copyAgentTable("chat")}
-                  aria-label="Copy Agent Tracking for Google Chat"
-                  title="Copy for Google Chat (monospace code block)"
-                  className={`flex items-center gap-1 px-2 py-1 rounded-md text-[12px] font-medium border transition-colors ${copiedTable === "agents-chat" ? (dark ? "border-emerald-700 text-emerald-400" : "border-emerald-300 text-emerald-600") : (dark ? "border-neutral-700 text-neutral-400 hover:bg-neutral-800" : "border-neutral-200 text-neutral-500 hover:bg-neutral-50")}`}
-                >
-                  {copiedTable === "agents-chat"
-                    ? <><Check aria-hidden="true" className="h-3 w-3" />Copied</>
-                    : <><MessageSquare aria-hidden="true" className="h-3 w-3" />Chat</>
-                  }
-                </button>
+                <CopyButtons
+                  label="Agent Tracking"
+                  sheetsActive={copiedTable === "agents-sheets"}
+                  chatActive={copiedTable === "agents-chat"}
+                  onSheets={() => copyAgentTable("sheets")}
+                  onChat={() => copyAgentTable("chat")}
+                  dark={dark}
+                />
               </div>
             </div>
 

--- a/src/components/scoreboard/Scoreboard.tsx
+++ b/src/components/scoreboard/Scoreboard.tsx
@@ -2,14 +2,14 @@
 
 import { useState, useReducer, useEffect, useRef } from "react";
 import { useTheme } from "next-themes";
-import { RefreshCw, ChevronLeft, ChevronRight, Upload, Trophy, Clipboard, Check } from "lucide-react";
+import { RefreshCw, ChevronLeft, ChevronRight, Upload, Trophy, Clipboard, Check, Table2, MessageSquare } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
 import CsvImportModal, { type ColumnDef } from "@/components/modals/CsvImportModal";
 import { bulkImportDailyMetrics } from "@/app/(dashboard)/scoreboard/actions";
 import { parseDate, parseNonNegativeInt } from "@/lib/import/csv-parser";
 import { teamHeaderBg } from "@/lib/team-colors";
 import { useCapabilities } from "@/hooks/useCapabilities";
-import { getMonday } from "@/lib/formatters";
+import { getMonday, toChatBlock } from "@/lib/formatters";
 
 // ---------- types ----------
 
@@ -109,9 +109,12 @@ export const Scoreboard = () => {
   const [csvImportOpen, setCsvImportOpen] = useState(false);
   const [copiedRow, setCopiedRow] = useState<string | null>(null);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [copiedTable, setCopiedTable] = useState<"sheets" | "chat" | null>(null);
+  const tableCopyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => () => {
     if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+    if (tableCopyTimerRef.current) clearTimeout(tableCopyTimerRef.current);
   }, []);
   const [{ weeks, loading, error }, dispatch] = useReducer(fetchReducer, {
     weeks: [],
@@ -168,6 +171,41 @@ export const Scoreboard = () => {
     1
   );
 
+  const copyAllTeams = (format: "sheets" | "chat") => {
+    const weekLabels = weeks.map((w) => w.label);
+    const teamBlocks = TEAMS.flatMap(({ key, label: teamLabel }) => {
+      const currentAgents = (weeks[0]?.agents ?? []).filter((a) => a.team === key && a.role !== "team_lead");
+      const rows = currentAgents
+        .map((a) => ({
+          agent: a.agent,
+          weekValues: weeks.map((w) => w.agents.find((x) => x.agent === a.agent)?.casesClosed ?? 0),
+        }))
+        .sort((a, b) => b.weekValues[0] - a.weekValues[0]);
+      if (rows.length === 0) return [];
+      return [{ teamLabel, header: ["Agent", ...weekLabels], rows: rows.map((r) => [r.agent, ...r.weekValues]) }];
+    });
+
+    let text: string;
+    if (format === "sheets") {
+      const lines: string[] = [];
+      for (const { teamLabel, header, rows } of teamBlocks) {
+        lines.push(teamLabel);
+        lines.push(header.join("\t"));
+        for (const row of rows) lines.push(row.join("\t"));
+        lines.push("");
+      }
+      text = lines.join("\n");
+    } else {
+      text = teamBlocks.map(({ teamLabel, header, rows }) => toChatBlock(teamLabel, header, rows)).join("\n\n");
+    }
+
+    navigator.clipboard.writeText(text).then(() => {
+      setCopiedTable(format);
+      if (tableCopyTimerRef.current) clearTimeout(tableCopyTimerRef.current);
+      tableCopyTimerRef.current = setTimeout(() => setCopiedTable(null), 1500);
+    });
+  };
+
   return (
     <>
     {csvImportOpen && (
@@ -206,6 +244,28 @@ export const Scoreboard = () => {
               Import
             </button>
           )}
+          <button
+            onClick={() => copyAllTeams("sheets")}
+            aria-label="Copy scoreboard for Google Sheets"
+            title="Copy for Google Sheets (tab-separated)"
+            className={`flex items-center gap-1 px-2 py-1 rounded-md text-[13px] font-medium border transition-colors ${copiedTable === "sheets" ? (dark ? "border-emerald-700 text-emerald-400" : "border-emerald-300 text-emerald-600") : (dark ? "border-neutral-700 text-neutral-300 hover:bg-neutral-800" : "border-neutral-200 text-neutral-600 hover:bg-neutral-50")}`}
+          >
+            {copiedTable === "sheets"
+              ? <><Check aria-hidden="true" className="h-3.5 w-3.5" />Copied</>
+              : <><Table2 aria-hidden="true" className="h-3.5 w-3.5" />Sheets</>
+            }
+          </button>
+          <button
+            onClick={() => copyAllTeams("chat")}
+            aria-label="Copy scoreboard for Google Chat"
+            title="Copy for Google Chat (monospace code block)"
+            className={`flex items-center gap-1 px-2 py-1 rounded-md text-[13px] font-medium border transition-colors ${copiedTable === "chat" ? (dark ? "border-emerald-700 text-emerald-400" : "border-emerald-300 text-emerald-600") : (dark ? "border-neutral-700 text-neutral-300 hover:bg-neutral-800" : "border-neutral-200 text-neutral-600 hover:bg-neutral-50")}`}
+          >
+            {copiedTable === "chat"
+              ? <><Check aria-hidden="true" className="h-3.5 w-3.5" />Copied</>
+              : <><MessageSquare aria-hidden="true" className="h-3.5 w-3.5" />Chat</>
+            }
+          </button>
           <button
             onClick={() => setWeekOffset(weekOffset - 1)}
             className={`flex items-center gap-1 px-2 py-1 rounded-md text-[13px] font-medium border transition-colors ${dark ? "border-neutral-700 text-neutral-300 hover:bg-neutral-800" : "border-neutral-200 text-neutral-600 hover:bg-neutral-50"}`}

--- a/src/components/scoreboard/ScoreboardSummaryCards.tsx
+++ b/src/components/scoreboard/ScoreboardSummaryCards.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
+import { Check, Table2, MessageSquare } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
-import { fmt } from "@/lib/formatters";
+import { fmt, toChatBlock } from "@/lib/formatters";
 import { teamCardClasses, teamAccentText, teamLabel } from "@/lib/team-colors";
 
 export interface ScoreboardSummary {
@@ -62,6 +63,36 @@ export function ScoreboardSummaryCards({
   const [t2Days, setT2Days] = useState<60 | 90>(60);
   const [t16Days, setT16Days] = useState<60 | 90>(60);
   const [concDays, setConcDays] = useState<60 | 90>(60);
+  const [byTeamCopied, setByTeamCopied] = useState<"sheets" | "chat" | null>(null);
+  const byTeamCopyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => {
+    if (byTeamCopyTimerRef.current) clearTimeout(byTeamCopyTimerRef.current);
+  }, []);
+
+  const copyByTeam = (format: "sheets" | "chat") => {
+    const header = format === "sheets"
+      ? ["Team", "Agents", "Fees Collected", "SSA Calls", "CL Calls", "Win Sheets", "Cases Closed", "Open Cases"]
+      : ["Team", "Agents", "Collected", "SSA", "CL Calls", "Wins", "Closed", "Open"];
+    const rows = teams.map((team) => [
+      teamLabel(team.team),
+      team.agentCount,
+      fmt(team.feesCollectedInWindow),
+      team.ssaCalls,
+      team.clientCalls,
+      team.winSheetsCreated,
+      team.casesClosed,
+      team.openCases,
+    ]);
+    const text = format === "sheets"
+      ? [header, ...rows].map((r) => r.join("\t")).join("\n")
+      : toChatBlock(`By Team — ${label}`, header, rows);
+    navigator.clipboard.writeText(text).then(() => {
+      setByTeamCopied(format);
+      if (byTeamCopyTimerRef.current) clearTimeout(byTeamCopyTimerRef.current);
+      byTeamCopyTimerRef.current = setTimeout(() => setByTeamCopied(null), 1500);
+    });
+  };
 
   // Quiet per-metric accent (border + tint) on the plain cards — not used on
   // the T2/T16/CONC toggle cards below, whose violet highlight is a state
@@ -147,9 +178,35 @@ export function ScoreboardSummaryCards({
       {/* Team breakdown */}
       {teams.length > 0 && (
         <div>
-          <p className={`text-[12px] font-semibold uppercase tracking-wider ${t.textMuted} mb-3`}>
-            By Team — {label}
-          </p>
+          <div className="flex items-center justify-between mb-3">
+            <p className={`text-[12px] font-semibold uppercase tracking-wider ${t.textMuted}`}>
+              By Team — {label}
+            </p>
+            <div className="flex items-center gap-1">
+              <button
+                onClick={() => copyByTeam("sheets")}
+                aria-label="Copy By Team for Google Sheets"
+                title="Copy for Google Sheets (tab-separated)"
+                className={`flex items-center gap-1 px-2 py-1 rounded-md text-[12px] font-medium border transition-colors ${byTeamCopied === "sheets" ? (dark ? "border-emerald-700 text-emerald-400" : "border-emerald-300 text-emerald-600") : (dark ? "border-neutral-700 text-neutral-400 hover:bg-neutral-800" : "border-neutral-200 text-neutral-500 hover:bg-neutral-50")}`}
+              >
+                {byTeamCopied === "sheets"
+                  ? <><Check aria-hidden="true" className="h-3 w-3" />Copied</>
+                  : <><Table2 aria-hidden="true" className="h-3 w-3" />Sheets</>
+                }
+              </button>
+              <button
+                onClick={() => copyByTeam("chat")}
+                aria-label="Copy By Team for Google Chat"
+                title="Copy for Google Chat (monospace code block)"
+                className={`flex items-center gap-1 px-2 py-1 rounded-md text-[12px] font-medium border transition-colors ${byTeamCopied === "chat" ? (dark ? "border-emerald-700 text-emerald-400" : "border-emerald-300 text-emerald-600") : (dark ? "border-neutral-700 text-neutral-400 hover:bg-neutral-800" : "border-neutral-200 text-neutral-500 hover:bg-neutral-50")}`}
+              >
+                {byTeamCopied === "chat"
+                  ? <><Check aria-hidden="true" className="h-3 w-3" />Copied</>
+                  : <><MessageSquare aria-hidden="true" className="h-3 w-3" />Chat</>
+                }
+              </button>
+            </div>
+          </div>
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
             {teams.map((team) => {
               const teamColor = teamCardClasses(team.team, dark);

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -111,9 +111,7 @@ export const fmtDateLong = (iso: string | null | undefined): string => {
   return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
 };
 
-// Formats tabular data as a monospace code block for pasting into Google Chat.
-// Each column is padded to its widest cell so values align in a fixed-width font.
-// An optional title line is prepended before the header row.
+// Google Chat renders ``` blocks in a fixed-width font — padding aligns columns.
 export const toChatBlock = (
   title: string,
   headers: string[],
@@ -125,7 +123,7 @@ export const toChatBlock = (
   );
   const table = all
     .map((row) =>
-      row.map((cell, ci) => cell.padEnd(widths[ci])).join("  ").trimEnd(),
+      widths.map((w, ci) => (row[ci] ?? "").padEnd(w)).join("  ").trimEnd(),
     )
     .join("\n");
   return "```\n" + title + "\n" + table + "\n```";

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -111,6 +111,26 @@ export const fmtDateLong = (iso: string | null | undefined): string => {
   return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
 };
 
+// Formats tabular data as a monospace code block for pasting into Google Chat.
+// Each column is padded to its widest cell so values align in a fixed-width font.
+// An optional title line is prepended before the header row.
+export const toChatBlock = (
+  title: string,
+  headers: string[],
+  rows: (string | number)[][],
+): string => {
+  const all: string[][] = [headers.map(String), ...rows.map((r) => r.map(String))];
+  const widths = headers.map((_, ci) =>
+    Math.max(...all.map((row) => (row[ci] ?? "").length)),
+  );
+  const table = all
+    .map((row) =>
+      row.map((cell, ci) => cell.padEnd(widths[ci])).join("  ").trimEnd(),
+    )
+    .join("\n");
+  return "```\n" + title + "\n" + table + "\n```";
+};
+
 // Claim type display: T2_T16 → CONC, T2/T16 → CONC, CONCURRENT → CONC.
 // CONCURRENT was a dropdown-option spelling briefly live in Settings that
 // wrote straight into claim_type_label — same "the dropdown drifted" class


### PR DESCRIPTION
Adds **Sheets** and **Chat** copy buttons to every table on the Reports and Scoreboard pages, so staff can paste data directly into Google Sheets or Google Chat without reformatting.

## What's included

**Four sections get copy buttons:**
- By Team (Reports)
- No Fees Cases (Reports)
- Agent Tracking (Reports)
- Scoreboard (all teams)

**Two formats per section:**
- **Sheets** — tab-separated values; paste into Google Sheets and each value lands in its own cell
- **Chat** — column-padded monospace block wrapped in triple backticks; renders as an aligned table in Google Chat

**Chat-specific optimisations to fit Google Chat's ~80-char code block width:**
- Agent Tracking: abbreviated headers (SSA Calls → SSA, Client Calls → CL Calls, Fax Sent → Fax, Win Sheets → Wins)
- By Team: abbreviated headers (Fees Collected → Collected, Cases Closed → Closed, Open Cases → Open, etc.)
- No Fees Cases: case names truncated to 20 chars, "FEE PETITION (approved)" → "FP (approved)"

## Audit fixes (second commit)
- Narrowed `copiedTable` state from `string | null` to the four literal values — typos now caught at compile time
- Extracted duplicated Sheets/Chat button pair into a `CopyButtons` sub-component in `ScoreboardTracker.tsx`
- Fixed `toChatBlock` to iterate over column widths rather than row cells — ragged rows no longer silently drop trailing columns
- Trimmed 3-line what-description comment to 1 why-line