### PR TITLE
feat: add Teams (HTML table) copy format to Reports and Scoreboard

### DIFF
--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -22,10 +22,11 @@ import {
   Clipboard,
   Table2,
   MessageSquare,
+  LayoutGrid,
 } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { themeClasses } from "@/lib/theme-classes";
-import { fmt, fmtDate, namesMatch, getMonday, formatWeekLabel, toChatBlock } from "@/lib/formatters";
+import { fmt, fmtDate, namesMatch, getMonday, formatWeekLabel, toChatBlock, toTeamsHtml } from "@/lib/formatters";
 import { teamBadgeClasses } from "@/lib/team-colors";
 import { useCapabilities } from "@/hooks/useCapabilities";
 import {
@@ -174,12 +175,14 @@ interface CopyButtonsProps {
   label: string;
   sheetsActive: boolean;
   chatActive: boolean;
+  teamsActive: boolean;
   onSheets: () => void;
   onChat: () => void;
+  onTeams: () => void;
   dark: boolean;
 }
 
-function CopyButtons({ label, sheetsActive, chatActive, onSheets, onChat, dark }: CopyButtonsProps) {
+function CopyButtons({ label, sheetsActive, chatActive, teamsActive, onSheets, onChat, onTeams, dark }: CopyButtonsProps) {
   const base = `flex items-center gap-1 px-2 py-1 rounded-md text-[12px] font-medium border transition-colors`;
   const active = dark ? "border-emerald-700 text-emerald-400" : "border-emerald-300 text-emerald-600";
   const idle = dark ? "border-neutral-700 text-neutral-400 hover:bg-neutral-800" : "border-neutral-200 text-neutral-500 hover:bg-neutral-50";
@@ -207,6 +210,17 @@ function CopyButtons({ label, sheetsActive, chatActive, onSheets, onChat, dark }
           : <><MessageSquare aria-hidden="true" className="h-3 w-3" />Chat</>
         }
       </button>
+      <button
+        onClick={onTeams}
+        aria-label={`Copy ${label} for Microsoft Teams`}
+        title="Copy for Microsoft Teams (HTML table)"
+        className={`${base} ${teamsActive ? active : idle}`}
+      >
+        {teamsActive
+          ? <><Check aria-hidden="true" className="h-3 w-3" />Copied</>
+          : <><LayoutGrid aria-hidden="true" className="h-3 w-3" />Teams</>
+        }
+      </button>
     </div>
   );
 }
@@ -232,7 +246,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
   const [metricFocus, setMetricFocus] = useState<MetricFocus>("all");
   const [copiedRow, setCopiedRow] = useState<string | null>(null);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [copiedTable, setCopiedTable] = useState<"noFees-sheets" | "noFees-chat" | "agents-sheets" | "agents-chat" | null>(null);
+  const [copiedTable, setCopiedTable] = useState<"noFees-sheets" | "noFees-chat" | "noFees-teams" | "agents-sheets" | "agents-chat" | "agents-teams" | null>(null);
   const tableCopyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => () => {
@@ -257,7 +271,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
     });
   };
 
-  const copyNoFeesTable = (format: "sheets" | "chat") => {
+  const copyNoFeesTable = (format: "sheets" | "chat" | "teams") => {
     const header = format === "sheets"
       ? ["Case Name", "Assigned", "Level", "Claim", "Approval", "Days"]
       : ["Case", "Agent", "Level", "Claim", "Approved", "Days"];
@@ -273,17 +287,23 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
         : c.name;
       return [caseName, c.assigned, displayLevel, c.claim, fmtDate(c.approvalDate) ?? "—", c.daysSinceApproval];
     });
-    const text = format === "sheets"
-      ? [header, ...rows].map((r) => r.join("\t")).join("\n")
-      : toChatBlock("No Fees Cases", header, rows);
-    navigator.clipboard.writeText(text).then(() => {
+    const done = () => {
       setCopiedTable(`noFees-${format}`);
       if (tableCopyTimerRef.current) clearTimeout(tableCopyTimerRef.current);
       tableCopyTimerRef.current = setTimeout(() => setCopiedTable(null), 1500);
-    });
+    };
+    if (format === "teams") {
+      const blob = new Blob([toTeamsHtml("No Fees Cases", header, rows)], { type: "text/html" });
+      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done);
+    } else {
+      const text = format === "sheets"
+        ? [header, ...rows].map((r) => r.join("\t")).join("\n")
+        : toChatBlock("No Fees Cases", header, rows);
+      navigator.clipboard.writeText(text).then(done);
+    }
   };
 
-  const copyAgentTable = (format: "sheets" | "chat") => {
+  const copyAgentTable = (format: "sheets" | "chat" | "teams") => {
     const chat = format === "chat";
     const headers: string[] = ["Agent"];
     if (showCol("cases"))       headers.push("Open");
@@ -318,14 +338,20 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
     if (showCol("clientcalls")) totalsRow.push(filteredTotals.weekClientCalls);
     if (showCol("faxsent"))     totalsRow.push(filteredTotals.weekFaxSent);
     if (showCol("winsheets"))   totalsRow.push(filteredTotals.completedWinSheets);
-    const text = format === "sheets"
-      ? [headers, ...dataRows, totalsRow].map((r) => r.join("\t")).join("\n")
-      : toChatBlock(`Agent Tracking — ${windowLabel}`, headers, [...dataRows, totalsRow]);
-    navigator.clipboard.writeText(text).then(() => {
+    const done = () => {
       setCopiedTable(`agents-${format}`);
       if (tableCopyTimerRef.current) clearTimeout(tableCopyTimerRef.current);
       tableCopyTimerRef.current = setTimeout(() => setCopiedTable(null), 1500);
-    });
+    };
+    if (format === "teams") {
+      const blob = new Blob([toTeamsHtml(`Agent Tracking — ${windowLabel}`, headers, [...dataRows, totalsRow])], { type: "text/html" });
+      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done);
+    } else {
+      const text = format === "sheets"
+        ? [headers, ...dataRows, totalsRow].map((r) => r.join("\t")).join("\n")
+        : toChatBlock(`Agent Tracking — ${windowLabel}`, headers, [...dataRows, totalsRow]);
+      navigator.clipboard.writeText(text).then(done);
+    }
   };
 
   const [dateMode, setDateMode] = useState<DateMode>("week");
@@ -707,8 +733,10 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                 label="No Fees Cases"
                 sheetsActive={copiedTable === "noFees-sheets"}
                 chatActive={copiedTable === "noFees-chat"}
+                teamsActive={copiedTable === "noFees-teams"}
                 onSheets={() => copyNoFeesTable("sheets")}
                 onChat={() => copyNoFeesTable("chat")}
+                onTeams={() => copyNoFeesTable("teams")}
                 dark={dark}
               />
             </div>
@@ -1002,8 +1030,10 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                   label="Agent Tracking"
                   sheetsActive={copiedTable === "agents-sheets"}
                   chatActive={copiedTable === "agents-chat"}
+                  teamsActive={copiedTable === "agents-teams"}
                   onSheets={() => copyAgentTable("sheets")}
                   onChat={() => copyAgentTable("chat")}
+                  onTeams={() => copyAgentTable("teams")}
                   dark={dark}
                 />
               </div>

--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -294,7 +294,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
     };
     if (format === "teams") {
       const blob = new Blob([toTeamsHtml("No Fees Cases", header, rows)], { type: "text/html" });
-      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done);
+      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done).catch(console.warn);
     } else {
       const text = format === "sheets"
         ? [header, ...rows].map((r) => r.join("\t")).join("\n")
@@ -345,7 +345,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
     };
     if (format === "teams") {
       const blob = new Blob([toTeamsHtml(`Agent Tracking — ${windowLabel}`, headers, [...dataRows, totalsRow])], { type: "text/html" });
-      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done);
+      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done).catch(console.warn);
     } else {
       const text = format === "sheets"
         ? [headers, ...dataRows, totalsRow].map((r) => r.join("\t")).join("\n")

--- a/src/components/scoreboard/Scoreboard.tsx
+++ b/src/components/scoreboard/Scoreboard.tsx
@@ -2,14 +2,14 @@
 
 import { useState, useReducer, useEffect, useRef } from "react";
 import { useTheme } from "next-themes";
-import { RefreshCw, ChevronLeft, ChevronRight, Upload, Trophy, Clipboard, Check, Table2, MessageSquare } from "lucide-react";
+import { RefreshCw, ChevronLeft, ChevronRight, Upload, Trophy, Clipboard, Check, Table2, MessageSquare, LayoutGrid } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
 import CsvImportModal, { type ColumnDef } from "@/components/modals/CsvImportModal";
 import { bulkImportDailyMetrics } from "@/app/(dashboard)/scoreboard/actions";
 import { parseDate, parseNonNegativeInt } from "@/lib/import/csv-parser";
 import { teamHeaderBg } from "@/lib/team-colors";
 import { useCapabilities } from "@/hooks/useCapabilities";
-import { getMonday, toChatBlock } from "@/lib/formatters";
+import { getMonday, toChatBlock, toTeamsHtml } from "@/lib/formatters";
 
 // ---------- types ----------
 
@@ -109,7 +109,7 @@ export const Scoreboard = () => {
   const [csvImportOpen, setCsvImportOpen] = useState(false);
   const [copiedRow, setCopiedRow] = useState<string | null>(null);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [copiedTable, setCopiedTable] = useState<"sheets" | "chat" | null>(null);
+  const [copiedTable, setCopiedTable] = useState<"sheets" | "chat" | "teams" | null>(null);
   const tableCopyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => () => {
@@ -171,7 +171,7 @@ export const Scoreboard = () => {
     1
   );
 
-  const copyAllTeams = (format: "sheets" | "chat") => {
+  const copyAllTeams = (format: "sheets" | "chat" | "teams") => {
     const weekLabels = weeks.map((w) => w.label);
     const teamBlocks = TEAMS.flatMap(({ key, label: teamLabel }) => {
       const currentAgents = (weeks[0]?.agents ?? []).filter((a) => a.team === key && a.role !== "team_lead");
@@ -185,8 +185,17 @@ export const Scoreboard = () => {
       return [{ teamLabel, header: ["Agent", ...weekLabels], rows: rows.map((r) => [r.agent, ...r.weekValues]) }];
     });
 
-    let text: string;
-    if (format === "sheets") {
+    const done = () => {
+      setCopiedTable(format);
+      if (tableCopyTimerRef.current) clearTimeout(tableCopyTimerRef.current);
+      tableCopyTimerRef.current = setTimeout(() => setCopiedTable(null), 1500);
+    };
+
+    if (format === "teams") {
+      const html = teamBlocks.map(({ teamLabel, header, rows }) => toTeamsHtml(teamLabel, header, rows)).join("");
+      const blob = new Blob([html], { type: "text/html" });
+      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done);
+    } else if (format === "sheets") {
       const lines: string[] = [];
       for (const { teamLabel, header, rows } of teamBlocks) {
         lines.push(teamLabel);
@@ -194,16 +203,11 @@ export const Scoreboard = () => {
         for (const row of rows) lines.push(row.join("\t"));
         lines.push("");
       }
-      text = lines.join("\n");
+      navigator.clipboard.writeText(lines.join("\n")).then(done);
     } else {
-      text = teamBlocks.map(({ teamLabel, header, rows }) => toChatBlock(teamLabel, header, rows)).join("\n\n");
+      const text = teamBlocks.map(({ teamLabel, header, rows }) => toChatBlock(teamLabel, header, rows)).join("\n\n");
+      navigator.clipboard.writeText(text).then(done);
     }
-
-    navigator.clipboard.writeText(text).then(() => {
-      setCopiedTable(format);
-      if (tableCopyTimerRef.current) clearTimeout(tableCopyTimerRef.current);
-      tableCopyTimerRef.current = setTimeout(() => setCopiedTable(null), 1500);
-    });
   };
 
   return (
@@ -264,6 +268,17 @@ export const Scoreboard = () => {
             {copiedTable === "chat"
               ? <><Check aria-hidden="true" className="h-3.5 w-3.5" />Copied</>
               : <><MessageSquare aria-hidden="true" className="h-3.5 w-3.5" />Chat</>
+            }
+          </button>
+          <button
+            onClick={() => copyAllTeams("teams")}
+            aria-label="Copy scoreboard for Microsoft Teams"
+            title="Copy for Microsoft Teams (HTML table)"
+            className={`flex items-center gap-1 px-2 py-1 rounded-md text-[13px] font-medium border transition-colors ${copiedTable === "teams" ? (dark ? "border-emerald-700 text-emerald-400" : "border-emerald-300 text-emerald-600") : (dark ? "border-neutral-700 text-neutral-300 hover:bg-neutral-800" : "border-neutral-200 text-neutral-600 hover:bg-neutral-50")}`}
+          >
+            {copiedTable === "teams"
+              ? <><Check aria-hidden="true" className="h-3.5 w-3.5" />Copied</>
+              : <><LayoutGrid aria-hidden="true" className="h-3.5 w-3.5" />Teams</>
             }
           </button>
           <button

--- a/src/components/scoreboard/Scoreboard.tsx
+++ b/src/components/scoreboard/Scoreboard.tsx
@@ -194,7 +194,7 @@ export const Scoreboard = () => {
     if (format === "teams") {
       const html = teamBlocks.map(({ teamLabel, header, rows }) => toTeamsHtml(teamLabel, header, rows)).join("");
       const blob = new Blob([html], { type: "text/html" });
-      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done);
+      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done).catch(console.warn);
     } else if (format === "sheets") {
       const lines: string[] = [];
       for (const { teamLabel, header, rows } of teamBlocks) {

--- a/src/components/scoreboard/ScoreboardSummaryCards.tsx
+++ b/src/components/scoreboard/ScoreboardSummaryCards.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { Check, Table2, MessageSquare } from "lucide-react";
+import { Check, Table2, MessageSquare, LayoutGrid } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
-import { fmt, toChatBlock } from "@/lib/formatters";
+import { fmt, toChatBlock, toTeamsHtml } from "@/lib/formatters";
 import { teamCardClasses, teamAccentText, teamLabel } from "@/lib/team-colors";
 
 export interface ScoreboardSummary {
@@ -63,14 +63,14 @@ export function ScoreboardSummaryCards({
   const [t2Days, setT2Days] = useState<60 | 90>(60);
   const [t16Days, setT16Days] = useState<60 | 90>(60);
   const [concDays, setConcDays] = useState<60 | 90>(60);
-  const [byTeamCopied, setByTeamCopied] = useState<"sheets" | "chat" | null>(null);
+  const [byTeamCopied, setByTeamCopied] = useState<"sheets" | "chat" | "teams" | null>(null);
   const byTeamCopyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => () => {
     if (byTeamCopyTimerRef.current) clearTimeout(byTeamCopyTimerRef.current);
   }, []);
 
-  const copyByTeam = (format: "sheets" | "chat") => {
+  const copyByTeam = (format: "sheets" | "chat" | "teams") => {
     const header = format === "sheets"
       ? ["Team", "Agents", "Fees Collected", "SSA Calls", "CL Calls", "Win Sheets", "Cases Closed", "Open Cases"]
       : ["Team", "Agents", "Collected", "SSA", "CL Calls", "Wins", "Closed", "Open"];
@@ -84,14 +84,20 @@ export function ScoreboardSummaryCards({
       team.casesClosed,
       team.openCases,
     ]);
-    const text = format === "sheets"
-      ? [header, ...rows].map((r) => r.join("\t")).join("\n")
-      : toChatBlock(`By Team — ${label}`, header, rows);
-    navigator.clipboard.writeText(text).then(() => {
+    const done = () => {
       setByTeamCopied(format);
       if (byTeamCopyTimerRef.current) clearTimeout(byTeamCopyTimerRef.current);
       byTeamCopyTimerRef.current = setTimeout(() => setByTeamCopied(null), 1500);
-    });
+    };
+    if (format === "teams") {
+      const blob = new Blob([toTeamsHtml(`By Team — ${label}`, header, rows)], { type: "text/html" });
+      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done);
+    } else {
+      const text = format === "sheets"
+        ? [header, ...rows].map((r) => r.join("\t")).join("\n")
+        : toChatBlock(`By Team — ${label}`, header, rows);
+      navigator.clipboard.writeText(text).then(done);
+    }
   };
 
   // Quiet per-metric accent (border + tint) on the plain cards — not used on
@@ -203,6 +209,17 @@ export function ScoreboardSummaryCards({
                 {byTeamCopied === "chat"
                   ? <><Check aria-hidden="true" className="h-3 w-3" />Copied</>
                   : <><MessageSquare aria-hidden="true" className="h-3 w-3" />Chat</>
+                }
+              </button>
+              <button
+                onClick={() => copyByTeam("teams")}
+                aria-label="Copy By Team for Microsoft Teams"
+                title="Copy for Microsoft Teams (HTML table)"
+                className={`flex items-center gap-1 px-2 py-1 rounded-md text-[12px] font-medium border transition-colors ${byTeamCopied === "teams" ? (dark ? "border-emerald-700 text-emerald-400" : "border-emerald-300 text-emerald-600") : (dark ? "border-neutral-700 text-neutral-400 hover:bg-neutral-800" : "border-neutral-200 text-neutral-500 hover:bg-neutral-50")}`}
+              >
+                {byTeamCopied === "teams"
+                  ? <><Check aria-hidden="true" className="h-3 w-3" />Copied</>
+                  : <><LayoutGrid aria-hidden="true" className="h-3 w-3" />Teams</>
                 }
               </button>
             </div>

--- a/src/components/scoreboard/ScoreboardSummaryCards.tsx
+++ b/src/components/scoreboard/ScoreboardSummaryCards.tsx
@@ -91,7 +91,7 @@ export function ScoreboardSummaryCards({
     };
     if (format === "teams") {
       const blob = new Blob([toTeamsHtml(`By Team — ${label}`, header, rows)], { type: "text/html" });
-      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done);
+      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done).catch(console.warn);
     } else {
       const text = format === "sheets"
         ? [header, ...rows].map((r) => r.join("\t")).join("\n")

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -117,17 +117,19 @@ export const toTeamsHtml = (
   headers: string[],
   rows: (string | number)[][],
 ): string => {
+  const esc = (s: string) =>
+    s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
   const th = `padding:4px 8px;border:1px solid #d0d0d0;background:#f5f5f5;font-weight:600;text-align:left`;
   const td = `padding:4px 8px;border:1px solid #d0d0d0`;
-  const headRow = headers.map((h) => `<th style="${th}">${h}</th>`).join("");
+  const headRow = headers.map((h) => `<th style="${th}">${esc(h)}</th>`).join("");
   const bodyRows = rows
     .map(
       (r) =>
-        `<tr>${headers.map((_, ci) => `<td style="${td}">${r[ci] ?? ""}</td>`).join("")}</tr>`,
+        `<tr>${headers.map((_, ci) => `<td style="${td}">${esc(String(r[ci] ?? ""))}</td>`).join("")}</tr>`,
     )
     .join("");
   return (
-    `<p><strong>${title}</strong></p>` +
+    `<p><strong>${esc(title)}</strong></p>` +
     `<table style="border-collapse:collapse">` +
     `<thead><tr>${headRow}</tr></thead>` +
     `<tbody>${bodyRows}</tbody>` +

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -111,6 +111,30 @@ export const fmtDateLong = (iso: string | null | undefined): string => {
   return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
 };
 
+// MS Teams pastes rich text from clipboard — an HTML table renders with visible borders and alignment.
+export const toTeamsHtml = (
+  title: string,
+  headers: string[],
+  rows: (string | number)[][],
+): string => {
+  const th = `padding:4px 8px;border:1px solid #d0d0d0;background:#f5f5f5;font-weight:600;text-align:left`;
+  const td = `padding:4px 8px;border:1px solid #d0d0d0`;
+  const headRow = headers.map((h) => `<th style="${th}">${h}</th>`).join("");
+  const bodyRows = rows
+    .map(
+      (r) =>
+        `<tr>${headers.map((_, ci) => `<td style="${td}">${r[ci] ?? ""}</td>`).join("")}</tr>`,
+    )
+    .join("");
+  return (
+    `<p><strong>${title}</strong></p>` +
+    `<table style="border-collapse:collapse">` +
+    `<thead><tr>${headRow}</tr></thead>` +
+    `<tbody>${bodyRows}</tbody>` +
+    `</table>`
+  );
+};
+
 // Google Chat renders ``` blocks in a fixed-width font — padding aligns columns.
 export const toChatBlock = (
   title: string,


### PR DESCRIPTION
Adds a **Teams** copy button alongside the existing Sheets and Chat buttons on all four table sections.

## Problem
The Google Chat format (triple-backtick code block) does not render as a visual table in Microsoft Teams.

## Solution
Teams accepts rich-text paste from the clipboard. Clicking **Teams** copies an HTML `<table>` via `ClipboardItem({ "text/html": ... })`. When pasted into a Teams message, it renders as a bordered, aligned table.

Note: Teams' official markdown docs list no table syntax. The HTML clipboard approach relies on Teams' rich-text paste handler, which accepts it in practice. Ms. Jazz is testing this.

## Sections updated
- By Team (Reports)
- No Fees Cases (Reports)
- Agent Tracking (Reports)
- Scoreboard (all teams — consecutive HTML tables, one per team)

## Format comparison
| Button | Mechanism | Best for |
|--------|-----------|----------|
| Sheets | Tab-separated text | Paste into Google Sheets |
| Chat | ` ``` `-fenced monospace block | Google Chat |
| Teams | `text/html` ClipboardItem | Microsoft Teams |

## Audit fixes included
- HTML entity escaping (`&`, `<`, `>`) on all values passed into `toTeamsHtml`
- `.catch(console.warn)` on all `clipboard.write()` call sites — surfaces permission/browser failures instead of silently swallowing them