### PR TITLE
feat: add Sheets/Chat/Teams copy buttons to all notification tabs

### DIFF
--- a/src/components/notifications/AuditLogTab.tsx
+++ b/src/components/notifications/AuditLogTab.tsx
@@ -1,9 +1,16 @@
 "use client";
 
 import { useState, useEffect, useRef, Fragment } from "react";
-import { ChevronLeft, ChevronRight, RefreshCw, ClipboardList, AlertCircle } from "lucide-react";
+import { ChevronLeft, ChevronRight, RefreshCw, ClipboardList, AlertCircle, Check, Table2, MessageSquare, LayoutGrid, type LucideIcon } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
-import { getMonday, formatWeekLabel } from "@/lib/formatters";
+import { getMonday, formatWeekLabel, toChatBlock, toTeamsHtml } from "@/lib/formatters";
+
+type CopyFormat = "sheets" | "chat" | "teams";
+const COPY_FORMATS: { format: CopyFormat; Icon: LucideIcon; label: string; ariaLabel: string; title: string }[] = [
+  { format: "sheets", Icon: Table2, label: "Sheets", ariaLabel: "Copy for Google Sheets", title: "Copy for Google Sheets (tab-separated)" },
+  { format: "chat", Icon: MessageSquare, label: "Chat", ariaLabel: "Copy for Google Chat", title: "Copy for Google Chat (monospace code block)" },
+  { format: "teams", Icon: LayoutGrid, label: "Teams", ariaLabel: "Copy for Microsoft Teams", title: "Copy for Microsoft Teams (HTML table)" },
+];
 
 interface DailyMetricRow {
   agent: string;
@@ -36,6 +43,10 @@ export function AuditLogTab({ dark, t }: AuditLogTabProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const [copiedTable, setCopiedTable] = useState<CopyFormat | null>(null);
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => { if (copyTimerRef.current) clearTimeout(copyTimerRef.current); }, []);
 
   const monday = getMonday(weekOffset);
 
@@ -80,6 +91,31 @@ export function AuditLogTab({ dark, t }: AuditLogTabProps) {
   const rowHover  = dark ? "hover:bg-neutral-800/30" : "hover:bg-neutral-50";
   const dateBg    = dark ? "bg-neutral-800/60" : "bg-neutral-50";
 
+  const copyTable = (format: CopyFormat) => {
+    const title = `Audit Log — ${formatWeekLabel(monday)}`;
+    const header = ["Date", "Agent", "SSA Calls", "Client IB", "Client OB", "Win Sheets", "Notes"];
+    const tableRows: (string | number)[][] = dates.flatMap((date) =>
+      byDate[date]
+        .slice()
+        .sort((a, b) => a.agent.localeCompare(b.agent))
+        .map((r) => [fmtDate(date), r.agent, r.ssaCalls, r.clientCallsIb, r.clientCallsOb, r.winSheetsCreated, r.notes ?? ""])
+    );
+    const done = () => {
+      setCopiedTable(format);
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+      copyTimerRef.current = setTimeout(() => setCopiedTable(null), 1500);
+    };
+    if (format === "teams") {
+      const blob = new Blob([toTeamsHtml(title, header, tableRows)], { type: "text/html" });
+      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done).catch(console.warn);
+    } else if (format === "sheets") {
+      const lines = [title, header.join("\t"), ...tableRows.map((r) => r.join("\t"))];
+      navigator.clipboard.writeText(lines.join("\n")).then(done);
+    } else {
+      navigator.clipboard.writeText(toChatBlock(title, header, tableRows)).then(done);
+    }
+  };
+
   return (
     <div className={`rounded-xl border ${t.card}`}>
       {/* Header */}
@@ -96,6 +132,17 @@ export function AuditLogTab({ dark, t }: AuditLogTabProps) {
           </div>
         </div>
         <div className="flex items-center gap-1">
+          {!loading && !error && dates.length > 0 && COPY_FORMATS.map(({ format, Icon, label, ariaLabel, title }) => (
+            <button
+              key={format}
+              onClick={() => copyTable(format)}
+              aria-label={ariaLabel}
+              title={title}
+              className={`flex items-center gap-1 px-2 py-1 rounded-md text-[13px] font-medium border transition-colors ${copiedTable === format ? (dark ? "border-emerald-700 text-emerald-400" : "border-emerald-300 text-emerald-600") : (dark ? "border-neutral-700 text-neutral-300 hover:bg-neutral-800" : "border-neutral-200 text-neutral-600 hover:bg-neutral-50")}`}
+            >
+              {copiedTable === format ? <><Check aria-hidden="true" className="h-3.5 w-3.5" />Copied</> : <><Icon aria-hidden="true" className="h-3.5 w-3.5" />{label}</>}
+            </button>
+          ))}
           <button
             onClick={() => setWeekOffset((v) => v - 1)}
             className={`h-8 w-8 rounded-md flex items-center justify-center transition-colors ${t.hover} ${t.textSub}`}

--- a/src/components/notifications/CallsBacklogTab.tsx
+++ b/src/components/notifications/CallsBacklogTab.tsx
@@ -1,8 +1,16 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import { RefreshCw, PhoneMissed, AlertCircle, ExternalLink } from "lucide-react";
+import { RefreshCw, PhoneMissed, AlertCircle, ExternalLink, Check, Table2, MessageSquare, LayoutGrid, type LucideIcon } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
+import { toChatBlock, toTeamsHtml } from "@/lib/formatters";
+
+type CopyFormat = "sheets" | "chat" | "teams";
+const COPY_FORMATS: { format: CopyFormat; Icon: LucideIcon; label: string; ariaLabel: string; title: string }[] = [
+  { format: "sheets", Icon: Table2, label: "Sheets", ariaLabel: "Copy for Google Sheets", title: "Copy for Google Sheets (tab-separated)" },
+  { format: "chat", Icon: MessageSquare, label: "Chat", ariaLabel: "Copy for Google Chat", title: "Copy for Google Chat (monospace code block)" },
+  { format: "teams", Icon: LayoutGrid, label: "Teams", ariaLabel: "Copy for Microsoft Teams", title: "Copy for Microsoft Teams (HTML table)" },
+];
 import Link from "next/link";
 
 interface BacklogRow {
@@ -35,6 +43,10 @@ export function CallsBacklogTab({ dark, t }: CallsBacklogTabProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const [copiedTable, setCopiedTable] = useState<"sheets" | "chat" | "teams" | null>(null);
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => { if (copyTimerRef.current) clearTimeout(copyTimerRef.current); }, []);
 
   const fetchBacklog = useCallback(async () => {
     abortRef.current?.abort();
@@ -64,6 +76,32 @@ export function CallsBacklogTab({ dark, t }: CallsBacklogTabProps) {
   const rowDivide = dark ? "border-neutral-800/40" : "border-neutral-100";
   const rowHover = dark ? "hover:bg-neutral-800/30" : "hover:bg-neutral-50";
 
+  const copyTable = (format: "sheets" | "chat" | "teams") => {
+    const title = "Calls Backlog";
+    const header = ["Call Date", "Number", "Reason", "Case Link", "Specialist"];
+    const tableRows: (string | number)[][] = rows.map((r) => [
+      fmtDate(r.callDate),
+      r.number || "—",
+      r.transcript || "—",
+      r.caseLink || "—",
+      r.specialistAssigned || "—",
+    ]);
+    const done = () => {
+      setCopiedTable(format);
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+      copyTimerRef.current = setTimeout(() => setCopiedTable(null), 1500);
+    };
+    if (format === "teams") {
+      const blob = new Blob([toTeamsHtml(title, header, tableRows)], { type: "text/html" });
+      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done).catch(console.warn);
+    } else if (format === "sheets") {
+      const lines = [title, header.join("\t"), ...tableRows.map((r) => r.join("\t"))];
+      navigator.clipboard.writeText(lines.join("\n")).then(done);
+    } else {
+      navigator.clipboard.writeText(toChatBlock(title, header, tableRows)).then(done);
+    }
+  };
+
   return (
     <div className="space-y-4">
       <div className={`rounded-xl border ${t.card}`}>
@@ -80,7 +118,18 @@ export function CallsBacklogTab({ dark, t }: CallsBacklogTabProps) {
               </p>
             </div>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1 flex-wrap justify-end">
+            {!loading && !error && rows.length > 0 && COPY_FORMATS.map(({ format, Icon, label, ariaLabel, title }) => (
+              <button
+                key={format}
+                onClick={() => copyTable(format)}
+                aria-label={ariaLabel}
+                title={title}
+                className={`flex items-center gap-1 px-2 py-1 rounded-md text-[13px] font-medium border transition-colors ${copiedTable === format ? (dark ? "border-emerald-700 text-emerald-400" : "border-emerald-300 text-emerald-600") : (dark ? "border-neutral-700 text-neutral-300 hover:bg-neutral-800" : "border-neutral-200 text-neutral-600 hover:bg-neutral-50")}`}
+              >
+                {copiedTable === format ? <><Check aria-hidden="true" className="h-3.5 w-3.5" />Copied</> : <><Icon aria-hidden="true" className="h-3.5 w-3.5" />{label}</>}
+              </button>
+            ))}
             <button
               onClick={fetchBacklog}
               disabled={loading}

--- a/src/components/notifications/ClosedCasesTab.tsx
+++ b/src/components/notifications/ClosedCasesTab.tsx
@@ -1,9 +1,16 @@
 "use client";
 
 import { useState, useEffect, useRef, Fragment } from "react";
-import { ChevronLeft, ChevronRight, RefreshCw, CheckCircle, AlertCircle, ExternalLink } from "lucide-react";
+import { ChevronLeft, ChevronRight, RefreshCw, CheckCircle, AlertCircle, ExternalLink, Check, Table2, MessageSquare, LayoutGrid, type LucideIcon } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
-import { getMonday, formatWeekLabelShort as formatWeekLabel } from "@/lib/formatters";
+import { getMonday, formatWeekLabelShort as formatWeekLabel, toChatBlock, toTeamsHtml } from "@/lib/formatters";
+
+type CopyFormat = "sheets" | "chat" | "teams";
+const COPY_FORMATS: { format: CopyFormat; Icon: LucideIcon; label: string; ariaLabel: string; title: string }[] = [
+  { format: "sheets", Icon: Table2, label: "Sheets", ariaLabel: "Copy for Google Sheets", title: "Copy for Google Sheets (tab-separated)" },
+  { format: "chat", Icon: MessageSquare, label: "Chat", ariaLabel: "Copy for Google Chat", title: "Copy for Google Chat (monospace code block)" },
+  { format: "teams", Icon: LayoutGrid, label: "Teams", ariaLabel: "Copy for Microsoft Teams", title: "Copy for Microsoft Teams (HTML table)" },
+];
 
 interface DayCount {
   date: string;
@@ -44,6 +51,10 @@ export function ClosedCasesTab({ dark, t }: ClosedCasesTabProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const [copiedTable, setCopiedTable] = useState<CopyFormat | null>(null);
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => { if (copyTimerRef.current) clearTimeout(copyTimerRef.current); }, []);
 
   const monday = getMonday(weekOffset);
 
@@ -94,6 +105,43 @@ export function ClosedCasesTab({ dark, t }: ClosedCasesTabProps) {
   const barBg = dark ? "bg-sky-500/30" : "bg-sky-200";
   const dateBg = dark ? "bg-neutral-800/60" : "bg-neutral-50";
 
+  const copyTable = (format: CopyFormat) => {
+    const weekLabel = formatWeekLabel(monday);
+    const countTitle = `Closed Cases — ${weekLabel}`;
+    const countHeader = ["Day", "Closed"];
+    const countRows: (string | number)[][] = [
+      ...days.map((d) => [fmtDate(d.date), d.count || 0]),
+      ["Week Total", weekTotal],
+    ];
+    const listTitle = `Cases Closed — ${weekLabel}`;
+    const listHeader = ["Date", "Case Name", "Assigned To"];
+    const listRows: (string | number)[][] = closureDates.flatMap((date) =>
+      closuresByDate[date].map((c) => [fmtDate(date), c.caseName, c.assignedTo ?? "—"])
+    );
+    const done = () => {
+      setCopiedTable(format);
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+      copyTimerRef.current = setTimeout(() => setCopiedTable(null), 1500);
+    };
+    if (format === "teams") {
+      const html = toTeamsHtml(countTitle, countHeader, countRows) +
+        (listRows.length ? toTeamsHtml(listTitle, listHeader, listRows) : "");
+      const blob = new Blob([html], { type: "text/html" });
+      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done).catch(console.warn);
+    } else if (format === "sheets") {
+      const lines = [
+        countTitle, countHeader.join("\t"), ...countRows.map((r) => r.join("\t")),
+        "",
+        ...(listRows.length ? [listTitle, listHeader.join("\t"), ...listRows.map((r) => r.join("\t"))] : []),
+      ];
+      navigator.clipboard.writeText(lines.join("\n")).then(done);
+    } else {
+      const parts = [toChatBlock(countTitle, countHeader, countRows)];
+      if (listRows.length) parts.push(toChatBlock(listTitle, listHeader, listRows));
+      navigator.clipboard.writeText(parts.join("\n\n")).then(done);
+    }
+  };
+
   return (
     <div className="space-y-4">
       <div className={`rounded-xl border ${t.card}`}>
@@ -111,6 +159,17 @@ export function ClosedCasesTab({ dark, t }: ClosedCasesTabProps) {
             </div>
           </div>
           <div className="flex items-center gap-1">
+            {!loading && !error && days.length > 0 && COPY_FORMATS.map(({ format, Icon, label, ariaLabel, title }) => (
+              <button
+                key={format}
+                onClick={() => copyTable(format)}
+                aria-label={ariaLabel}
+                title={title}
+                className={`flex items-center gap-1 px-2 py-1 rounded-md text-[13px] font-medium border transition-colors ${copiedTable === format ? (dark ? "border-emerald-700 text-emerald-400" : "border-emerald-300 text-emerald-600") : (dark ? "border-neutral-700 text-neutral-300 hover:bg-neutral-800" : "border-neutral-200 text-neutral-600 hover:bg-neutral-50")}`}
+              >
+                {copiedTable === format ? <><Check aria-hidden="true" className="h-3.5 w-3.5" />Copied</> : <><Icon aria-hidden="true" className="h-3.5 w-3.5" />{label}</>}
+              </button>
+            ))}
             <button
               onClick={() => setWeekOffset((v) => v - 1)}
               className={`h-8 w-8 rounded-md flex items-center justify-center transition-colors ${t.hover} ${t.textSub}`}

--- a/src/components/notifications/FeePetitionApprovedTab.tsx
+++ b/src/components/notifications/FeePetitionApprovedTab.tsx
@@ -1,9 +1,16 @@
 "use client";
 
 import { useState, useEffect, useRef, Fragment } from "react";
-import { ChevronLeft, ChevronRight, RefreshCw, CheckCircle2, AlertCircle, ExternalLink } from "lucide-react";
+import { ChevronLeft, ChevronRight, RefreshCw, CheckCircle2, AlertCircle, ExternalLink, Check, Table2, MessageSquare, LayoutGrid, type LucideIcon } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
-import { getMonday, formatWeekLabelShort as formatWeekLabel } from "@/lib/formatters";
+import { getMonday, formatWeekLabelShort as formatWeekLabel, toChatBlock, toTeamsHtml } from "@/lib/formatters";
+
+type CopyFormat = "sheets" | "chat" | "teams";
+const COPY_FORMATS: { format: CopyFormat; Icon: LucideIcon; label: string; ariaLabel: string; title: string }[] = [
+  { format: "sheets", Icon: Table2, label: "Sheets", ariaLabel: "Copy for Google Sheets", title: "Copy for Google Sheets (tab-separated)" },
+  { format: "chat", Icon: MessageSquare, label: "Chat", ariaLabel: "Copy for Google Chat", title: "Copy for Google Chat (monospace code block)" },
+  { format: "teams", Icon: LayoutGrid, label: "Teams", ariaLabel: "Copy for Microsoft Teams", title: "Copy for Microsoft Teams (HTML table)" },
+];
 
 interface DayCount {
   date: string;
@@ -46,6 +53,10 @@ export function FeePetitionApprovedTab({ dark, t }: FeePetitionApprovedTabProps)
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const [copiedTable, setCopiedTable] = useState<CopyFormat | null>(null);
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => { if (copyTimerRef.current) clearTimeout(copyTimerRef.current); }, []);
 
   const monday = getMonday(weekOffset);
 
@@ -96,6 +107,43 @@ export function FeePetitionApprovedTab({ dark, t }: FeePetitionApprovedTabProps)
   const barBg = dark ? "bg-emerald-500/30" : "bg-emerald-200";
   const dateBg = dark ? "bg-neutral-800/60" : "bg-neutral-50";
 
+  const copyTable = (format: CopyFormat) => {
+    const weekLabel = formatWeekLabel(monday);
+    const countTitle = `Fee Petitions Approved — ${weekLabel}`;
+    const countHeader = ["Day", "Approved"];
+    const countRows: (string | number)[][] = [
+      ...days.map((d) => [fmtDate(d.date), d.count || 0]),
+      ["Week Total", weekTotal],
+    ];
+    const listTitle = `Approved — ${weekLabel}`;
+    const listHeader = ["Date", "Case Name", "Assigned To"];
+    const listRows: (string | number)[][] = approvalDates.flatMap((date) =>
+      approvalsByDate[date].map((a) => [fmtDate(date), a.caseName, a.assignedTo ?? "—"])
+    );
+    const done = () => {
+      setCopiedTable(format);
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+      copyTimerRef.current = setTimeout(() => setCopiedTable(null), 1500);
+    };
+    if (format === "teams") {
+      const html = toTeamsHtml(countTitle, countHeader, countRows) +
+        (listRows.length ? toTeamsHtml(listTitle, listHeader, listRows) : "");
+      const blob = new Blob([html], { type: "text/html" });
+      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done).catch(console.warn);
+    } else if (format === "sheets") {
+      const lines = [
+        countTitle, countHeader.join("\t"), ...countRows.map((r) => r.join("\t")),
+        "",
+        ...(listRows.length ? [listTitle, listHeader.join("\t"), ...listRows.map((r) => r.join("\t"))] : []),
+      ];
+      navigator.clipboard.writeText(lines.join("\n")).then(done);
+    } else {
+      const parts = [toChatBlock(countTitle, countHeader, countRows)];
+      if (listRows.length) parts.push(toChatBlock(listTitle, listHeader, listRows));
+      navigator.clipboard.writeText(parts.join("\n\n")).then(done);
+    }
+  };
+
   return (
     <div className="space-y-4">
       <div className={`rounded-xl border ${t.card}`}>
@@ -113,6 +161,17 @@ export function FeePetitionApprovedTab({ dark, t }: FeePetitionApprovedTabProps)
             </div>
           </div>
           <div className="flex items-center gap-1">
+            {!loading && !error && days.length > 0 && COPY_FORMATS.map(({ format, Icon, label, ariaLabel, title }) => (
+              <button
+                key={format}
+                onClick={() => copyTable(format)}
+                aria-label={ariaLabel}
+                title={title}
+                className={`flex items-center gap-1 px-2 py-1 rounded-md text-[13px] font-medium border transition-colors ${copiedTable === format ? (dark ? "border-emerald-700 text-emerald-400" : "border-emerald-300 text-emerald-600") : (dark ? "border-neutral-700 text-neutral-300 hover:bg-neutral-800" : "border-neutral-200 text-neutral-600 hover:bg-neutral-50")}`}
+              >
+                {copiedTable === format ? <><Check aria-hidden="true" className="h-3.5 w-3.5" />Copied</> : <><Icon aria-hidden="true" className="h-3.5 w-3.5" />{label}</>}
+              </button>
+            ))}
             <button
               onClick={() => setWeekOffset((v) => v - 1)}
               className={`h-8 w-8 rounded-md flex items-center justify-center transition-colors ${t.hover} ${t.textSub}`}

--- a/src/components/notifications/NewCasesTab.tsx
+++ b/src/components/notifications/NewCasesTab.tsx
@@ -2,9 +2,16 @@
 
 import { useState, useEffect, useRef, Fragment } from "react";
 import Link from "next/link";
-import { ChevronLeft, ChevronRight, RefreshCw, UserPlus, AlertCircle, ExternalLink } from "lucide-react";
+import { ChevronLeft, ChevronRight, RefreshCw, UserPlus, AlertCircle, ExternalLink, Check, Table2, MessageSquare, LayoutGrid, type LucideIcon } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
-import { getMonday, formatWeekLabelShort as formatWeekLabel } from "@/lib/formatters";
+import { getMonday, formatWeekLabelShort as formatWeekLabel, toChatBlock, toTeamsHtml } from "@/lib/formatters";
+
+type CopyFormat = "sheets" | "chat" | "teams";
+const COPY_FORMATS: { format: CopyFormat; Icon: LucideIcon; label: string; ariaLabel: string; title: string }[] = [
+  { format: "sheets", Icon: Table2, label: "Sheets", ariaLabel: "Copy for Google Sheets", title: "Copy for Google Sheets (tab-separated)" },
+  { format: "chat", Icon: MessageSquare, label: "Chat", ariaLabel: "Copy for Google Chat", title: "Copy for Google Chat (monospace code block)" },
+  { format: "teams", Icon: LayoutGrid, label: "Teams", ariaLabel: "Copy for Microsoft Teams", title: "Copy for Microsoft Teams (HTML table)" },
+];
 
 interface DayCount {
   date: string;
@@ -47,6 +54,10 @@ export function NewCasesTab({ dark, t }: NewCasesTabProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const [copiedTable, setCopiedTable] = useState<"sheets" | "chat" | "teams" | null>(null);
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => { if (copyTimerRef.current) clearTimeout(copyTimerRef.current); }, []);
 
   const monday = getMonday(weekOffset);
 
@@ -97,6 +108,45 @@ export function NewCasesTab({ dark, t }: NewCasesTabProps) {
   const barBg = dark ? "bg-indigo-500/30" : "bg-indigo-200";
   const dateBg = dark ? "bg-neutral-800/60" : "bg-neutral-50";
 
+  const copyTable = (format: "sheets" | "chat" | "teams") => {
+    const weekLabel = formatWeekLabel(monday);
+    const countTitle = `New Cases — ${weekLabel}`;
+    const countHeader = ["Day", "New Cases"];
+    const countRows: (string | number)[][] = [
+      ...days.map((d) => [fmtDate(d.date), d.count || 0]),
+      ["Week Total", weekTotal],
+    ];
+    const caseTitle = `Cases Added — ${weekLabel}`;
+    const caseHeader = ["Date", "Case Name", "Added"];
+    const caseRows: (string | number)[][] = caseDates.flatMap((date) =>
+      casesByDate[date].map((c) => [fmtDate(date), c.name, fmtTime(c.createdAt)])
+    );
+
+    const done = () => {
+      setCopiedTable(format);
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+      copyTimerRef.current = setTimeout(() => setCopiedTable(null), 1500);
+    };
+
+    if (format === "teams") {
+      const html = toTeamsHtml(countTitle, countHeader, countRows) +
+        (caseRows.length ? toTeamsHtml(caseTitle, caseHeader, caseRows) : "");
+      const blob = new Blob([html], { type: "text/html" });
+      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done).catch(console.warn);
+    } else if (format === "sheets") {
+      const lines = [
+        countTitle, countHeader.join("\t"), ...countRows.map((r) => r.join("\t")),
+        "",
+        ...(caseRows.length ? [caseTitle, caseHeader.join("\t"), ...caseRows.map((r) => r.join("\t"))] : []),
+      ];
+      navigator.clipboard.writeText(lines.join("\n")).then(done);
+    } else {
+      const parts = [toChatBlock(countTitle, countHeader, countRows)];
+      if (caseRows.length) parts.push(toChatBlock(caseTitle, caseHeader, caseRows));
+      navigator.clipboard.writeText(parts.join("\n\n")).then(done);
+    }
+  };
+
   return (
     <div className="space-y-4">
     <div className={`rounded-xl border ${t.card}`}>
@@ -114,6 +164,17 @@ export function NewCasesTab({ dark, t }: NewCasesTabProps) {
           </div>
         </div>
         <div className="flex items-center gap-1">
+          {!loading && !error && days.length > 0 && COPY_FORMATS.map(({ format, Icon, label, ariaLabel, title }) => (
+            <button
+              key={format}
+              onClick={() => copyTable(format)}
+              aria-label={ariaLabel}
+              title={title}
+              className={`flex items-center gap-1 px-2 py-1 rounded-md text-[13px] font-medium border transition-colors ${copiedTable === format ? (dark ? "border-emerald-700 text-emerald-400" : "border-emerald-300 text-emerald-600") : (dark ? "border-neutral-700 text-neutral-300 hover:bg-neutral-800" : "border-neutral-200 text-neutral-600 hover:bg-neutral-50")}`}
+            >
+              {copiedTable === format ? <><Check aria-hidden="true" className="h-3.5 w-3.5" />Copied</> : <><Icon aria-hidden="true" className="h-3.5 w-3.5" />{label}</>}
+            </button>
+          ))}
           <button
             onClick={() => setWeekOffset((v) => v - 1)}
             className={`h-8 w-8 rounded-md flex items-center justify-center transition-colors ${t.hover} ${t.textSub}`}

--- a/src/components/notifications/PaymentsTab.tsx
+++ b/src/components/notifications/PaymentsTab.tsx
@@ -1,9 +1,16 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
-import { ChevronLeft, ChevronRight, RefreshCw, DollarSign, AlertCircle, ExternalLink } from "lucide-react";
+import { useState, useEffect, useRef, Fragment } from "react";
+import { ChevronLeft, ChevronRight, RefreshCw, DollarSign, AlertCircle, ExternalLink, Check, Table2, MessageSquare, LayoutGrid, type LucideIcon } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
-import { getMonday, formatWeekLabelShort as formatWeekLabel, fmt } from "@/lib/formatters";
+import { getMonday, formatWeekLabelShort as formatWeekLabel, fmt, toChatBlock, toTeamsHtml } from "@/lib/formatters";
+
+type CopyFormat = "sheets" | "chat" | "teams";
+const COPY_FORMATS: { format: CopyFormat; Icon: LucideIcon; label: string; ariaLabel: string; title: string }[] = [
+  { format: "sheets", Icon: Table2, label: "Sheets", ariaLabel: "Copy for Google Sheets", title: "Copy for Google Sheets (tab-separated)" },
+  { format: "chat", Icon: MessageSquare, label: "Chat", ariaLabel: "Copy for Google Chat", title: "Copy for Google Chat (monospace code block)" },
+  { format: "teams", Icon: LayoutGrid, label: "Teams", ariaLabel: "Copy for Microsoft Teams", title: "Copy for Microsoft Teams (HTML table)" },
+];
 
 interface DayTotal {
   date: string;
@@ -50,6 +57,10 @@ export function PaymentsTab({ dark, t }: PaymentsTabProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const [copiedTable, setCopiedTable] = useState<CopyFormat | null>(null);
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => { if (copyTimerRef.current) clearTimeout(copyTimerRef.current); }, []);
 
   const monday = getMonday(weekOffset);
 
@@ -101,6 +112,43 @@ export function PaymentsTab({ dark, t }: PaymentsTabProps) {
   const barBg = dark ? "bg-emerald-500/30" : "bg-emerald-200";
   const dateBg = dark ? "bg-neutral-800/60" : "bg-neutral-50";
 
+  const copyTable = (format: CopyFormat) => {
+    const weekLabel = formatWeekLabel(monday);
+    const countTitle = `Payments Received — ${weekLabel}`;
+    const countHeader = ["Day", "Amount", "Count"];
+    const countRows: (string | number)[][] = [
+      ...days.map((d) => [fmtDate(d.date), fmt(d.total), d.count]),
+      ["Week Total", fmt(weekTotal), weekCount],
+    ];
+    const listTitle = `Payments Entered — ${weekLabel}`;
+    const listHeader = ["Date", "Case Name", "Amount", "Type", "Agent"];
+    const listRows: (string | number)[][] = paymentDates.flatMap((date) =>
+      paymentsByDate[date].map((p) => [fmtDate(date), p.caseName, fmt(p.amount), p.feeType, p.assignedTo ?? "—"])
+    );
+    const done = () => {
+      setCopiedTable(format);
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+      copyTimerRef.current = setTimeout(() => setCopiedTable(null), 1500);
+    };
+    if (format === "teams") {
+      const html = toTeamsHtml(countTitle, countHeader, countRows) +
+        (listRows.length ? toTeamsHtml(listTitle, listHeader, listRows) : "");
+      const blob = new Blob([html], { type: "text/html" });
+      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done).catch(console.warn);
+    } else if (format === "sheets") {
+      const lines = [
+        countTitle, countHeader.join("\t"), ...countRows.map((r) => r.join("\t")),
+        "",
+        ...(listRows.length ? [listTitle, listHeader.join("\t"), ...listRows.map((r) => r.join("\t"))] : []),
+      ];
+      navigator.clipboard.writeText(lines.join("\n")).then(done);
+    } else {
+      const parts = [toChatBlock(countTitle, countHeader, countRows)];
+      if (listRows.length) parts.push(toChatBlock(listTitle, listHeader, listRows));
+      navigator.clipboard.writeText(parts.join("\n\n")).then(done);
+    }
+  };
+
   return (
     <div className="space-y-4">
       <div className={`rounded-xl border ${t.card}`}>
@@ -119,6 +167,17 @@ export function PaymentsTab({ dark, t }: PaymentsTabProps) {
             </div>
           </div>
           <div className="flex items-center gap-1">
+            {!loading && !error && days.length > 0 && COPY_FORMATS.map(({ format, Icon, label, ariaLabel, title }) => (
+              <button
+                key={format}
+                onClick={() => copyTable(format)}
+                aria-label={ariaLabel}
+                title={title}
+                className={`flex items-center gap-1 px-2 py-1 rounded-md text-[13px] font-medium border transition-colors ${copiedTable === format ? (dark ? "border-emerald-700 text-emerald-400" : "border-emerald-300 text-emerald-600") : (dark ? "border-neutral-700 text-neutral-300 hover:bg-neutral-800" : "border-neutral-200 text-neutral-600 hover:bg-neutral-50")}`}
+              >
+                {copiedTable === format ? <><Check aria-hidden="true" className="h-3.5 w-3.5" />Copied</> : <><Icon aria-hidden="true" className="h-3.5 w-3.5" />{label}</>}
+              </button>
+            ))}
             <button
               onClick={() => setWeekOffset((v) => v - 1)}
               className={`h-8 w-8 rounded-md flex items-center justify-center transition-colors ${t.hover} ${t.textSub}`}
@@ -236,8 +295,8 @@ export function PaymentsTab({ dark, t }: PaymentsTabProps) {
               </thead>
               <tbody>
                 {paymentDates.map((date) => (
-                  <>
-                    <tr key={`header-${date}`} className={`border-b ${rowDivide}`}>
+                  <Fragment key={date}>
+                    <tr className={`border-b ${rowDivide}`}>
                       <td
                         colSpan={4}
                         className={`px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wider ${t.textMuted} ${dateBg}`}
@@ -276,7 +335,7 @@ export function PaymentsTab({ dark, t }: PaymentsTabProps) {
                         </td>
                       </tr>
                     ))}
-                  </>
+                  </Fragment>
                 ))}
               </tbody>
             </table>

--- a/src/components/notifications/RecentActivityTab.tsx
+++ b/src/components/notifications/RecentActivityTab.tsx
@@ -1,9 +1,16 @@
 "use client";
 
 import { useState, useEffect, useRef, Fragment } from "react";
-import { ChevronLeft, ChevronRight, RefreshCw, Clock, AlertCircle } from "lucide-react";
+import { ChevronLeft, ChevronRight, RefreshCw, Clock, AlertCircle, Check, Table2, MessageSquare, LayoutGrid, type LucideIcon } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
-import { getMonday, formatWeekLabel } from "@/lib/formatters";
+import { getMonday, formatWeekLabel, toChatBlock, toTeamsHtml } from "@/lib/formatters";
+
+type CopyFormat = "sheets" | "chat" | "teams";
+const COPY_FORMATS: { format: CopyFormat; Icon: LucideIcon; label: string; ariaLabel: string; title: string }[] = [
+  { format: "sheets", Icon: Table2, label: "Sheets", ariaLabel: "Copy for Google Sheets", title: "Copy for Google Sheets (tab-separated)" },
+  { format: "chat", Icon: MessageSquare, label: "Chat", ariaLabel: "Copy for Google Chat", title: "Copy for Google Chat (monospace code block)" },
+  { format: "teams", Icon: LayoutGrid, label: "Teams", ariaLabel: "Copy for Microsoft Teams", title: "Copy for Microsoft Teams (HTML table)" },
+];
 
 interface ActivityEntry {
   id: string;
@@ -38,6 +45,10 @@ export function RecentActivityTab({ dark, t }: RecentActivityTabProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const [copiedTable, setCopiedTable] = useState<"sheets" | "chat" | "teams" | null>(null);
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => { if (copyTimerRef.current) clearTimeout(copyTimerRef.current); }, []);
 
   const monday = getMonday(weekOffset);
 
@@ -83,6 +94,34 @@ export function RecentActivityTab({ dark, t }: RecentActivityTabProps) {
   const rowHover  = dark ? "hover:bg-neutral-800/30" : "hover:bg-neutral-50";
   const dateBg    = dark ? "bg-neutral-800/60" : "bg-neutral-50";
 
+  const copyTable = (format: "sheets" | "chat" | "teams") => {
+    const title = `Recent Activity — ${formatWeekLabel(monday)}`;
+    const header = ["Date", "Time", "Agent", "Case", "Activity"];
+    const rows = dates.flatMap((date) =>
+      byDate[date].map((e) => [
+        fmtDateOnly(date + "T12:00:00"),
+        new Date(e.createdAt).toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" }),
+        e.createdBy,
+        e.caseName ?? "—",
+        e.message,
+      ])
+    );
+    const done = () => {
+      setCopiedTable(format);
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+      copyTimerRef.current = setTimeout(() => setCopiedTable(null), 1500);
+    };
+    if (format === "teams") {
+      const blob = new Blob([toTeamsHtml(title, header, rows)], { type: "text/html" });
+      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done).catch(console.warn);
+    } else if (format === "sheets") {
+      const lines = [title, header.join("\t"), ...rows.map((r) => r.join("\t"))];
+      navigator.clipboard.writeText(lines.join("\n")).then(done);
+    } else {
+      navigator.clipboard.writeText(toChatBlock(title, header, rows)).then(done);
+    }
+  };
+
   return (
     <div className={`rounded-xl border ${t.card}`}>
       {/* Header */}
@@ -99,6 +138,17 @@ export function RecentActivityTab({ dark, t }: RecentActivityTabProps) {
           </div>
         </div>
         <div className="flex items-center gap-1">
+          {!loading && !error && dates.length > 0 && COPY_FORMATS.map(({ format, Icon, label, ariaLabel, title }) => (
+            <button
+              key={format}
+              onClick={() => copyTable(format)}
+              aria-label={ariaLabel}
+              title={title}
+              className={`flex items-center gap-1 px-2 py-1 rounded-md text-[13px] font-medium border transition-colors ${copiedTable === format ? (dark ? "border-emerald-700 text-emerald-400" : "border-emerald-300 text-emerald-600") : (dark ? "border-neutral-700 text-neutral-300 hover:bg-neutral-800" : "border-neutral-200 text-neutral-600 hover:bg-neutral-50")}`}
+            >
+              {copiedTable === format ? <><Check aria-hidden="true" className="h-3.5 w-3.5" />Copied</> : <><Icon aria-hidden="true" className="h-3.5 w-3.5" />{label}</>}
+            </button>
+          ))}
           <button
             onClick={() => setWeekOffset((v) => v - 1)}
             className={`h-8 w-8 rounded-md flex items-center justify-center transition-colors ${t.hover} ${t.textSub}`}

--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -23,6 +23,7 @@ import {
   Table2,
   MessageSquare,
   LayoutGrid,
+  type LucideIcon,
 } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { themeClasses } from "@/lib/theme-classes";
@@ -186,41 +187,27 @@ function CopyButtons({ label, sheetsActive, chatActive, teamsActive, onSheets, o
   const base = `flex items-center gap-1 px-2 py-1 rounded-md text-[12px] font-medium border transition-colors`;
   const active = dark ? "border-emerald-700 text-emerald-400" : "border-emerald-300 text-emerald-600";
   const idle = dark ? "border-neutral-700 text-neutral-400 hover:bg-neutral-800" : "border-neutral-200 text-neutral-500 hover:bg-neutral-50";
+  const buttons: { Icon: LucideIcon; btnLabel: string; ariaLabel: string; title: string; isActive: boolean; onClick: () => void }[] = [
+    { Icon: Table2, btnLabel: "Sheets", ariaLabel: `Copy ${label} for Google Sheets`, title: "Copy for Google Sheets (tab-separated)", isActive: sheetsActive, onClick: onSheets },
+    { Icon: MessageSquare, btnLabel: "Chat", ariaLabel: `Copy ${label} for Google Chat`, title: "Copy for Google Chat (monospace code block)", isActive: chatActive, onClick: onChat },
+    { Icon: LayoutGrid, btnLabel: "Teams", ariaLabel: `Copy ${label} for Microsoft Teams`, title: "Copy for Microsoft Teams (HTML table)", isActive: teamsActive, onClick: onTeams },
+  ];
   return (
     <div className="flex items-center gap-1">
-      <button
-        onClick={onSheets}
-        aria-label={`Copy ${label} for Google Sheets`}
-        title="Copy for Google Sheets (tab-separated)"
-        className={`${base} ${sheetsActive ? active : idle}`}
-      >
-        {sheetsActive
-          ? <><Check aria-hidden="true" className="h-3 w-3" />Copied</>
-          : <><Table2 aria-hidden="true" className="h-3 w-3" />Sheets</>
-        }
-      </button>
-      <button
-        onClick={onChat}
-        aria-label={`Copy ${label} for Google Chat`}
-        title="Copy for Google Chat (monospace code block)"
-        className={`${base} ${chatActive ? active : idle}`}
-      >
-        {chatActive
-          ? <><Check aria-hidden="true" className="h-3 w-3" />Copied</>
-          : <><MessageSquare aria-hidden="true" className="h-3 w-3" />Chat</>
-        }
-      </button>
-      <button
-        onClick={onTeams}
-        aria-label={`Copy ${label} for Microsoft Teams`}
-        title="Copy for Microsoft Teams (HTML table)"
-        className={`${base} ${teamsActive ? active : idle}`}
-      >
-        {teamsActive
-          ? <><Check aria-hidden="true" className="h-3 w-3" />Copied</>
-          : <><LayoutGrid aria-hidden="true" className="h-3 w-3" />Teams</>
-        }
-      </button>
+      {buttons.map(({ Icon, btnLabel, ariaLabel, title, isActive, onClick }) => (
+        <button
+          key={btnLabel}
+          onClick={onClick}
+          aria-label={ariaLabel}
+          title={title}
+          className={`${base} ${isActive ? active : idle}`}
+        >
+          {isActive
+            ? <><Check aria-hidden="true" className="h-3 w-3" />Copied</>
+            : <><Icon aria-hidden="true" className="h-3 w-3" />{btnLabel}</>
+          }
+        </button>
+      ))}
     </div>
   );
 }

--- a/src/components/scoreboard/Scoreboard.tsx
+++ b/src/components/scoreboard/Scoreboard.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useReducer, useEffect, useRef } from "react";
 import { useTheme } from "next-themes";
-import { RefreshCw, ChevronLeft, ChevronRight, Upload, Trophy, Clipboard, Check, Table2, MessageSquare, LayoutGrid } from "lucide-react";
+import { RefreshCw, ChevronLeft, ChevronRight, Upload, Trophy, Clipboard, Check, Table2, MessageSquare, LayoutGrid, type LucideIcon } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
 import CsvImportModal, { type ColumnDef } from "@/components/modals/CsvImportModal";
 import { bulkImportDailyMetrics } from "@/app/(dashboard)/scoreboard/actions";
@@ -10,6 +10,13 @@ import { parseDate, parseNonNegativeInt } from "@/lib/import/csv-parser";
 import { teamHeaderBg } from "@/lib/team-colors";
 import { useCapabilities } from "@/hooks/useCapabilities";
 import { getMonday, toChatBlock, toTeamsHtml } from "@/lib/formatters";
+
+type CopyFormat = "sheets" | "chat" | "teams";
+const COPY_FORMATS: { format: CopyFormat; Icon: LucideIcon; label: string; ariaLabel: string; title: string }[] = [
+  { format: "sheets", Icon: Table2, label: "Sheets", ariaLabel: "Copy scoreboard for Google Sheets", title: "Copy for Google Sheets (tab-separated)" },
+  { format: "chat", Icon: MessageSquare, label: "Chat", ariaLabel: "Copy scoreboard for Google Chat", title: "Copy for Google Chat (monospace code block)" },
+  { format: "teams", Icon: LayoutGrid, label: "Teams", ariaLabel: "Copy scoreboard for Microsoft Teams", title: "Copy for Microsoft Teams (HTML table)" },
+];
 
 // ---------- types ----------
 
@@ -248,39 +255,17 @@ export const Scoreboard = () => {
               Import
             </button>
           )}
-          <button
-            onClick={() => copyAllTeams("sheets")}
-            aria-label="Copy scoreboard for Google Sheets"
-            title="Copy for Google Sheets (tab-separated)"
-            className={`flex items-center gap-1 px-2 py-1 rounded-md text-[13px] font-medium border transition-colors ${copiedTable === "sheets" ? (dark ? "border-emerald-700 text-emerald-400" : "border-emerald-300 text-emerald-600") : (dark ? "border-neutral-700 text-neutral-300 hover:bg-neutral-800" : "border-neutral-200 text-neutral-600 hover:bg-neutral-50")}`}
-          >
-            {copiedTable === "sheets"
-              ? <><Check aria-hidden="true" className="h-3.5 w-3.5" />Copied</>
-              : <><Table2 aria-hidden="true" className="h-3.5 w-3.5" />Sheets</>
-            }
-          </button>
-          <button
-            onClick={() => copyAllTeams("chat")}
-            aria-label="Copy scoreboard for Google Chat"
-            title="Copy for Google Chat (monospace code block)"
-            className={`flex items-center gap-1 px-2 py-1 rounded-md text-[13px] font-medium border transition-colors ${copiedTable === "chat" ? (dark ? "border-emerald-700 text-emerald-400" : "border-emerald-300 text-emerald-600") : (dark ? "border-neutral-700 text-neutral-300 hover:bg-neutral-800" : "border-neutral-200 text-neutral-600 hover:bg-neutral-50")}`}
-          >
-            {copiedTable === "chat"
-              ? <><Check aria-hidden="true" className="h-3.5 w-3.5" />Copied</>
-              : <><MessageSquare aria-hidden="true" className="h-3.5 w-3.5" />Chat</>
-            }
-          </button>
-          <button
-            onClick={() => copyAllTeams("teams")}
-            aria-label="Copy scoreboard for Microsoft Teams"
-            title="Copy for Microsoft Teams (HTML table)"
-            className={`flex items-center gap-1 px-2 py-1 rounded-md text-[13px] font-medium border transition-colors ${copiedTable === "teams" ? (dark ? "border-emerald-700 text-emerald-400" : "border-emerald-300 text-emerald-600") : (dark ? "border-neutral-700 text-neutral-300 hover:bg-neutral-800" : "border-neutral-200 text-neutral-600 hover:bg-neutral-50")}`}
-          >
-            {copiedTable === "teams"
-              ? <><Check aria-hidden="true" className="h-3.5 w-3.5" />Copied</>
-              : <><LayoutGrid aria-hidden="true" className="h-3.5 w-3.5" />Teams</>
-            }
-          </button>
+          {COPY_FORMATS.map(({ format, Icon, label, ariaLabel, title }) => (
+            <button
+              key={format}
+              onClick={() => copyAllTeams(format)}
+              aria-label={ariaLabel}
+              title={title}
+              className={`flex items-center gap-1 px-2 py-1 rounded-md text-[13px] font-medium border transition-colors ${copiedTable === format ? (dark ? "border-emerald-700 text-emerald-400" : "border-emerald-300 text-emerald-600") : (dark ? "border-neutral-700 text-neutral-300 hover:bg-neutral-800" : "border-neutral-200 text-neutral-600 hover:bg-neutral-50")}`}
+            >
+              {copiedTable === format ? <><Check aria-hidden="true" className="h-3.5 w-3.5" />Copied</> : <><Icon aria-hidden="true" className="h-3.5 w-3.5" />{label}</>}
+            </button>
+          ))}
           <button
             onClick={() => setWeekOffset(weekOffset - 1)}
             className={`flex items-center gap-1 px-2 py-1 rounded-md text-[13px] font-medium border transition-colors ${dark ? "border-neutral-700 text-neutral-300 hover:bg-neutral-800" : "border-neutral-200 text-neutral-600 hover:bg-neutral-50"}`}


### PR DESCRIPTION
## Summary

- Add Sheets / Chat / Teams copy buttons to all 7 notification tabs (Recent Activity, New Cases, Calls Backlog, Fee Petition Approved, Payments, Closed Cases, Audit Log) — consistent with the existing copy buttons on Reports and Scoreboard
- Refactor copy button JSX in Scoreboard and ScoreboardTracker to use `.map()` over a `COPY_FORMATS` config array, matching the pattern now used across all tabs
- Fix missing React `key` on `<Fragment>` in PaymentsTab (key was misplaced on inner `<tr>` instead of the wrapping fragment)