### PR TITLE
feat: add last activity column to admin users table

### DIFF
--- a/src/app/(dashboard)/admin/page.tsx
+++ b/src/app/(dashboard)/admin/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
-import { desc, eq } from "drizzle-orm";
+import { desc, eq, sql } from "drizzle-orm";
 
 import { db } from "@/lib/db";
 import { users, adminActivityLog, activityLog, cases } from "@/lib/db/schema";
@@ -46,6 +46,19 @@ export default async function AdminRoute() {
     ? rows
     : rows.filter((r) => r.role !== "system_admin");
 
+  // Last activity_log entry per agent, matched by name (createdBy is the
+  // user's display name, not their ID).
+  const activityRows = await db.execute(sql`
+    SELECT created_by, MAX(created_at) AS last_activity_at
+    FROM activity_log
+    WHERE created_by IS NOT NULL
+    GROUP BY created_by
+  `) as unknown as { created_by: string; last_activity_at: string }[];
+
+  const lastActivityMap = new Map(
+    activityRows.map((r) => [r.created_by, r.last_activity_at]),
+  );
+
   const userList: AdminUser[] = visibleRows.map((r) => ({
     id: r.id,
     email: r.email,
@@ -54,6 +67,7 @@ export default async function AdminRoute() {
     isActive: r.isActive,
     lastLoginAt: r.lastLoginAt ? r.lastLoginAt.toISOString() : null,
     createdAt: r.createdAt.toISOString(),
+    lastActivityAt: lastActivityMap.get(r.name ?? "") ?? null,
   }));
 
   // Most recent admin actions for the Activity Logs tab. Emails are snapshots

--- a/src/components/admin/UsersTable.tsx
+++ b/src/components/admin/UsersTable.tsx
@@ -54,6 +54,7 @@ export type AdminUser = {
   role: "admin" | "lead" | "member" | "system_admin";
   isActive: boolean;
   lastLoginAt: string | null;
+  lastActivityAt: string | null;
   createdAt: string;
 };
 
@@ -217,6 +218,7 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
               <th className={`${thBase} text-left`}>Role</th>
               <th className={`${thBase} text-center`}>Active</th>
               <th className={`${thBase} text-left`}>Last login</th>
+              <th className={`${thBase} text-left`}>Last activity</th>
               <th className={`${thBase} text-left`}>Created</th>
               <th className={`${thBase} text-right`}>Actions</th>
             </tr>
@@ -225,7 +227,7 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
             {users.length === 0 ? (
               <tr>
                 <td
-                  colSpan={6}
+                  colSpan={7}
                   className={`${tdBase} text-center py-8 ${t.textMuted}`}
                 >
                   No users yet.
@@ -281,6 +283,9 @@ export function UsersTable({ users, currentUserId }: UsersTableProps) {
                     </td>
                     <td className={`${tdBase} ${t.textMuted}`}>
                       {formatRelative(user.lastLoginAt)}
+                    </td>
+                    <td className={`${tdBase} ${t.textMuted}`}>
+                      {formatRelative(user.lastActivityAt)}
                     </td>
                     <td className={`${tdBase} ${t.textMuted}`}>
                       {formatRelative(user.createdAt)}


### PR DESCRIPTION
## Summary

- Add a "Last activity" column to the admin users table showing when each agent last logged a case activity entry
- Queries `activity_log` grouped by `created_by` (agent display name) to get the most recent entry per user
- Uses the existing `formatRelative()` helper — shows "—" for users with no activity on record
- Column sits between "Last login" and "Created"