### PR TITLE
feat: rename app from Fee Collections to Collections Dashboard

### DIFF
--- a/src/app/(dashboard)/admin/page.tsx
+++ b/src/app/(dashboard)/admin/page.tsx
@@ -15,7 +15,7 @@ import {
 export const dynamic = "force-dynamic";
 
 export const metadata = {
-  title: "Admin · SSA Fee Collections",
+  title: "Admin · Collections Dashboard",
 };
 
 export default async function AdminRoute() {

--- a/src/app/(dashboard)/archive/page.tsx
+++ b/src/app/(dashboard)/archive/page.tsx
@@ -6,7 +6,7 @@ import { ArchivePageClient } from "./ArchivePageClient";
 export const dynamic = "force-dynamic";
 
 export const metadata = {
-  title: "Archive · SSA Fee Collections",
+  title: "Archive · Collections Dashboard",
 };
 
 export default async function ArchiveRoute() {

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -74,7 +74,7 @@ function DashboardShell({ children }: { children: ReactNode }) {
             <Menu className="h-5 w-5" />
           </button>
 
-          <h1 className={`text-base font-bold ${t.text}`}>Fee Collections</h1>
+          <h1 className={`text-base font-bold ${t.text}`}>Collections Dashboard</h1>
         </div>
 
         <Header dateRange={dateRange} onDateRangeChange={setDateRange} />

--- a/src/app/(dashboard)/resources/page.tsx
+++ b/src/app/(dashboard)/resources/page.tsx
@@ -9,7 +9,7 @@ import { ResourcesClient } from "@/components/resources/ResourcesClient";
 export const dynamic = "force-dynamic";
 
 export const metadata = {
-  title: "Resources · SSA Fee Collections",
+  title: "Resources · Collections Dashboard",
 };
 
 export default async function ResourcesPage() {

--- a/src/app/change-password/page.tsx
+++ b/src/app/change-password/page.tsx
@@ -3,7 +3,7 @@ import { DollarSign } from "lucide-react";
 import { ChangePasswordForm } from "./change-password-form";
 
 export const metadata: Metadata = {
-  title: "Set new password · SSA Fee Collections",
+  title: "Set new password · Collections Dashboard",
 };
 
 export default function ChangePasswordPage() {
@@ -16,7 +16,7 @@ export default function ChangePasswordPage() {
           </div>
           <div>
             <h1 className="text-lg font-bold text-neutral-900">
-              Fee Collections
+              Collections Dashboard
             </h1>
             <p className="text-xs text-neutral-500">Hogan Smith Law</p>
           </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,8 +11,8 @@ const outfit = Outfit({
 });
 
 export const metadata: Metadata = {
-  title: "SSA Fee Collections Dashboard",
-  description: "Fee collections management for Hogan Smith Law",
+  title: "Collections Dashboard",
+  description: "Collections management for Hogan Smith Law",
 };
 
 const RootLayout = async ({

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -14,7 +14,7 @@ import {
 const SHOW_TEST_LOGINS = process.env.NEXT_PUBLIC_SHOW_TEST_LOGINS === "true";
 
 export const metadata: Metadata = {
-  title: "Sign in · SSA Fee Collections",
+  title: "Sign in · Collections Dashboard",
 };
 
 export default async function LoginPage({
@@ -45,7 +45,7 @@ export default async function LoginPage({
             />
           </div>
           <h1 className="text-sm font-medium tracking-wide text-neutral-500 uppercase dark:text-neutral-400">
-            Fee Collections
+            Collections Dashboard
           </h1>
         </div>
 

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -279,7 +279,7 @@ export const Sidebar = ({ open, onToggle, onMobileClose }: SidebarProps) => {
               {open && (
                 <div className="leading-tight">
                   <div className={`text-[15px] font-bold ${t.text}`}>
-                    Fee Collections
+                    Collections Dashboard
                   </div>
                   <div className={`text-[12px] ${t.textMuted}`}>
                     Hogan Smith Law


### PR DESCRIPTION
## Summary

- Rename the app display name from "Fee Collections" to "Collections Dashboard" across all UI surfaces
- Updated: root layout title, dashboard mobile header, sidebar app name, login page heading, change-password page heading, and all page-level metadata titles (admin, archive, resources)
- Remaining dashboard pages without explicit metadata inherit the updated root layout title automatically
- n8n workflow JSON files left untouched (external workflow definitions)