### PR TITLE
feat: restrict fees.edit to a single admin via per-user override

### DIFF
--- a/src/lib/access/__tests__/capabilities.test.ts
+++ b/src/lib/access/__tests__/capabilities.test.ts
@@ -6,9 +6,19 @@ import {
 import { effectiveCapabilities, hasCapability } from "../resolve";
 
 describe("roleCapabilityDefaults", () => {
-  it("gives admin and system_admin every capability", () => {
-    expect(roleCapabilityDefaults("admin")).toEqual(CAPABILITY_KEYS);
+  it("gives system_admin every capability", () => {
     expect(roleCapabilityDefaults("system_admin")).toEqual(CAPABILITY_KEYS);
+  });
+
+  it("gives admin every capability except fees.edit", () => {
+    const caps = roleCapabilityDefaults("admin");
+    expect(caps).not.toContain("fees.edit");
+    expect(caps).toContain("case.create");
+    expect(caps).toContain("case.delete");
+    expect(caps).toContain("case.update");
+    expect(caps).toContain("case.finalize");
+    expect(caps).toContain("case.editPii");
+    expect(caps).toHaveLength(CAPABILITY_KEYS.length - 1);
   });
 
   it("gives lead update + finalize + PII, but not create/delete", () => {
@@ -57,6 +67,13 @@ describe("effectiveCapabilities (role default ⊕ overrides)", () => {
       pages: { admin: true },
     });
     expect(caps).toEqual(["case.update"]);
+  });
+
+  it("restores fees.edit for admin via per-user override", () => {
+    const caps = effectiveCapabilities("admin", {
+      capabilities: { "fees.edit": true },
+    });
+    expect(caps).toContain("fees.edit");
   });
 });
 

--- a/src/lib/access/capabilities.ts
+++ b/src/lib/access/capabilities.ts
@@ -70,7 +70,10 @@ const ALL: CapabilityKey[] = CAPABILITY_KEYS;
 
 // Role → default capabilities.
 //
-// - admin / system_admin: everything.
+// - system_admin: everything.
+// - admin: everything EXCEPT fees.edit. fees.edit is granted per-user only
+//   (currently Jazz, via userAccessOverrides) so she is the sole gatekeeper
+//   for recording fees received and received dates.
 // - lead: full update incl. finalize + PII + logging calls for others +
 //   leader notes + Fees Confirmation, but NOT create, delete, editing fee
 //   amounts received, or Fees Closed (stays admin-only).
@@ -81,7 +84,7 @@ const ALL: CapabilityKey[] = CAPABILITY_KEYS;
 //   overrides modal.
 export const ROLE_CAPABILITY_DEFAULTS: Record<Role, CapabilityKey[]> = {
   system_admin: ALL,
-  admin: ALL,
+  admin: ALL.filter((k) => k !== "fees.edit"),
   lead: ["case.update", "case.finalize", "case.editPii", "dailyMetrics.editOthers", "leaderNotes.access", "feesConfirmation.edit"],
   member: ["case.update"],
 };

--- a/src/lib/access/capabilities.ts
+++ b/src/lib/access/capabilities.ts
@@ -72,8 +72,7 @@ const ALL: CapabilityKey[] = CAPABILITY_KEYS;
 //
 // - system_admin: everything.
 // - admin: everything EXCEPT fees.edit. fees.edit is granted per-user only
-//   (currently Jazz, via userAccessOverrides) so she is the sole gatekeeper
-//   for recording fees received and received dates.
+//   (via userAccessOverrides) to keep fees received entry under a single owner.
 // - lead: full update incl. finalize + PII + logging calls for others +
 //   leader notes + Fees Confirmation, but NOT create, delete, editing fee
 //   amounts received, or Fees Closed (stays admin-only).


### PR DESCRIPTION
## Summary

- Removes `fees.edit` from the `admin` role defaults so no admin user has it automatically
- Applied a per-user capability override in `userAccessOverrides` for the designated admin, granting `fees.edit` exclusively to her
- `system_admin` retains all capabilities unchanged; `lead` and `member` were already blocked
- Updated capability tests to reflect the new `admin` contract and added an override round-trip test