### PR TITLE
feat: restrict PIF editing to per-user override only

### DIFF
--- a/src/lib/access/__tests__/capabilities.test.ts
+++ b/src/lib/access/__tests__/capabilities.test.ts
@@ -10,24 +10,27 @@ describe("roleCapabilityDefaults", () => {
     expect(roleCapabilityDefaults("system_admin")).toEqual(CAPABILITY_KEYS);
   });
 
-  it("gives admin every capability except fees.edit", () => {
+  it("gives admin every capability except fees.edit and feesConfirmation.edit", () => {
     const caps = roleCapabilityDefaults("admin");
     expect(caps).not.toContain("fees.edit");
+    expect(caps).not.toContain("feesConfirmation.edit");
     expect(caps).toContain("case.create");
     expect(caps).toContain("case.delete");
     expect(caps).toContain("case.update");
     expect(caps).toContain("case.finalize");
     expect(caps).toContain("case.editPii");
-    expect(caps).toHaveLength(CAPABILITY_KEYS.length - 1);
+    expect(caps).toHaveLength(CAPABILITY_KEYS.length - 2);
   });
 
-  it("gives lead update + finalize + PII, but not create/delete", () => {
+  it("gives lead update + finalize + PII, but not create/delete/fees/PIF", () => {
     const caps = roleCapabilityDefaults("lead");
     expect(caps).toContain("case.update");
     expect(caps).toContain("case.finalize");
     expect(caps).toContain("case.editPii");
     expect(caps).not.toContain("case.create");
     expect(caps).not.toContain("case.delete");
+    expect(caps).not.toContain("fees.edit");
+    expect(caps).not.toContain("feesConfirmation.edit");
   });
 
   it("gives member update only (no create/delete/finalize/PII)", () => {
@@ -69,11 +72,12 @@ describe("effectiveCapabilities (role default ⊕ overrides)", () => {
     expect(caps).toEqual(["case.update"]);
   });
 
-  it("restores fees.edit for admin via per-user override", () => {
+  it("restores fees.edit and feesConfirmation.edit for admin via per-user override", () => {
     const caps = effectiveCapabilities("admin", {
-      capabilities: { "fees.edit": true },
+      capabilities: { "fees.edit": true, "feesConfirmation.edit": true },
     });
     expect(caps).toContain("fees.edit");
+    expect(caps).toContain("feesConfirmation.edit");
   });
 });
 

--- a/src/lib/access/__tests__/capabilities.test.ts
+++ b/src/lib/access/__tests__/capabilities.test.ts
@@ -27,6 +27,8 @@ describe("roleCapabilityDefaults", () => {
     expect(caps).toContain("case.update");
     expect(caps).toContain("case.finalize");
     expect(caps).toContain("case.editPii");
+    expect(caps).toContain("dailyMetrics.editOthers");
+    expect(caps).toContain("leaderNotes.access");
     expect(caps).not.toContain("case.create");
     expect(caps).not.toContain("case.delete");
     expect(caps).not.toContain("fees.edit");

--- a/src/lib/access/capabilities.ts
+++ b/src/lib/access/capabilities.ts
@@ -71,11 +71,12 @@ const ALL: CapabilityKey[] = CAPABILITY_KEYS;
 // Role → default capabilities.
 //
 // - system_admin: everything.
-// - admin: everything EXCEPT fees.edit. fees.edit is granted per-user only
-//   (via userAccessOverrides) to keep fees received entry under a single owner.
+// - admin: everything EXCEPT fees.edit and feesConfirmation.edit. Both are
+//   granted per-user only (via userAccessOverrides) to keep fees received and
+//   PIF entry under a single owner.
 // - lead: full update incl. finalize + PII + logging calls for others +
-//   leader notes + Fees Confirmation, but NOT create, delete, editing fee
-//   amounts received, or Fees Closed (stays admin-only).
+//   leader notes, but NOT create, delete, editing fee amounts received,
+//   PIF, or Fees Closed (stays admin-only).
 // - member: day-to-day collections — update (record payments, status, notes)
 //   only, and only their own daily call log. No create/delete, no finalize
 //   (close/overpaid/approvedBy), no PII, no leader notes, no Fees
@@ -83,8 +84,8 @@ const ALL: CapabilityKey[] = CAPABILITY_KEYS;
 //   overrides modal.
 export const ROLE_CAPABILITY_DEFAULTS: Record<Role, CapabilityKey[]> = {
   system_admin: ALL,
-  admin: ALL.filter((k) => k !== "fees.edit"),
-  lead: ["case.update", "case.finalize", "case.editPii", "dailyMetrics.editOthers", "leaderNotes.access", "feesConfirmation.edit"],
+  admin: ALL.filter((k) => k !== "fees.edit" && k !== "feesConfirmation.edit"),
+  lead: ["case.update", "case.finalize", "case.editPii", "dailyMetrics.editOthers", "leaderNotes.access"],
   member: ["case.update"],
 };
 

--- a/src/lib/access/capabilities.ts
+++ b/src/lib/access/capabilities.ts
@@ -79,9 +79,8 @@ const ALL: CapabilityKey[] = CAPABILITY_KEYS;
 //   PIF, or Fees Closed (stays admin-only).
 // - member: day-to-day collections — update (record payments, status, notes)
 //   only, and only their own daily call log. No create/delete, no finalize
-//   (close/overpaid/approvedBy), no PII, no leader notes, no Fees
-//   Confirmation. Admins can widen any of these per-user via the access
-//   overrides modal.
+//   (close/overpaid/approvedBy), no PII, no leader notes, no PIF. Admins
+//   can widen any of these per-user via the access overrides modal.
 export const ROLE_CAPABILITY_DEFAULTS: Record<Role, CapabilityKey[]> = {
   system_admin: ALL,
   admin: ALL.filter((k) => k !== "fees.edit" && k !== "feesConfirmation.edit"),


### PR DESCRIPTION
## Summary

- Removes `feesConfirmation.edit` from both `admin` and `lead` role defaults — no role gets it automatically
- Updated the designated admin's `userAccessOverrides` record to grant both `fees.edit` and `feesConfirmation.edit`, making her the sole manual editor of both fields
- PIF auto-suggestion (DB trigger) continues to run for all cases regardless of this gate
- Updated capability tests to assert both exclusions and the override round-trip