### PR TITLE
fix: use JWT capabilities for all roles (hotfix)

### DIFF
--- a/src/hooks/useCapabilities.ts
+++ b/src/hooks/useCapabilities.ts
@@ -20,16 +20,13 @@ export function useCapabilities() {
   const { data: session } = useSession();
   const role = session?.user?.role;
   const rawCaps = session?.user?.capabilities;
-  // Admins always derive from role defaults (= ALL) so a stale JWT that
-  // predates a newly-added capability never silently blocks them.
-  // Non-admins use JWT caps with a role-default fallback for pre-capability tokens.
-  const isAdmin = role === "admin" || role === "system_admin";
+  // Prefer the JWT's baked-in effective capabilities (role default ⊕ per-user
+  // overrides, resolved at sign-in). Fall back to role defaults only for tokens
+  // minted before the capabilities feature existed (empty array).
   const capabilities = (
-    isAdmin
-      ? roleCapabilityDefaults(role)
-      : Array.isArray(rawCaps) && rawCaps.length > 0
-        ? rawCaps
-        : roleCapabilityDefaults(role)
+    Array.isArray(rawCaps) && rawCaps.length > 0
+      ? rawCaps
+      : roleCapabilityDefaults(role)
   ) as CapabilityKey[];
 
   return {


### PR DESCRIPTION
## Root cause

`useCapabilities` had a special admin branch that always fell back to `roleCapabilityDefaults(role)` instead of reading the JWT. This was written when `admin = ALL capabilities`, so ignoring the JWT was harmless. After removing `fees.edit` and `feesConfirmation.edit` from admin defaults, the hook discards per-user overrides for admin users — the JWT has the correct grants but the UI gate never sees them.

## Fix

Removed the admin special-case. All roles now use the same logic: prefer the JWT's baked-in effective capabilities (resolved at sign-in as role defaults ⊕ per-user overrides), fall back to role defaults only for pre-feature tokens with an empty capabilities array.

The API routes were always correct — they enforce via the JWT directly. Only the UI gate was affected.