### PR TITLE
fix: use JWT capabilities in sessionHasCapability (hotfix)

### DIFF
--- a/src/lib/auth-helpers.ts
+++ b/src/lib/auth-helpers.ts
@@ -53,10 +53,11 @@ export const sessionHasCapability = (
   if (!session?.user) return false;
   const role = session.user.role;
   const rawCaps = session.user.capabilities;
-  const isAdmin = role === "admin" || role === "system_admin";
-  const caps = isAdmin
-    ? roleCapabilityDefaults(role)
-    : rawCaps && rawCaps.length > 0
+  // Prefer the JWT's baked-in effective capabilities (role defaults ⊕ per-user
+  // overrides, resolved at sign-in). Fall back to role defaults only for tokens
+  // minted before the capabilities feature existed (empty array).
+  const caps =
+    rawCaps && rawCaps.length > 0
       ? rawCaps
       : roleCapabilityDefaults(role);
   return hasCapability(caps, capability);


### PR DESCRIPTION
## Root cause

`sessionHasCapability` in `auth-helpers.ts` had the same admin bypass as `useCapabilities` — for `admin`/`system_admin` roles it always derived capabilities from `roleCapabilityDefaults(role)` and ignored the JWT. This meant server-side API guards (used by `requireCapability`) also rejected valid per-user override grants, blocking the reopen case action and any other server mutation that uses `requireCapability`.

## Fix

Same fix as PR #354 — removed the admin special-case. All roles now use the JWT's baked-in capabilities first, falling back to role defaults only for pre-feature tokens with an empty capabilities array.