### PR TITLE
feat: add sort by Notice Sent date in overpaid cases

### DIFF
--- a/src/app/api/overpaid-cases/route.ts
+++ b/src/app/api/overpaid-cases/route.ts
@@ -4,7 +4,7 @@ import { cases, feeRecords, overpaidCases } from "@/lib/db/schema";
 import { eq, ilike, sql } from "drizzle-orm";
 import { requirePageAccess, guardStatus } from "@/lib/auth-helpers";
 
-const SORT_KEYS = ["claimant", "feesReceived", "overpaidAmount", "opLtrDate", "assignedTo", "createdAt"] as const;
+const SORT_KEYS = ["claimant", "feesReceived", "overpaidAmount", "opLtrDate", "noticeSent", "assignedTo", "createdAt"] as const;
 type SortKey = (typeof SORT_KEYS)[number];
 
 // GET /api/overpaid-cases?page=&limit=&search=&sort=&dir=&status=&agent=&ltr=&minAmount=&maxAmount=
@@ -120,7 +120,9 @@ export const GET = async (req: NextRequest) => {
           ? sql`${feeRecords.totalFeesPaid}::numeric ${dir} NULLS LAST`
           : sort === "opLtrDate"
             ? sql`${overpaidCases.opLtrReceived} ${dir} NULLS LAST`
-            : sort === "assignedTo"
+            : sort === "noticeSent"
+              ? sql`${overpaidCases.opLtrDate} ${dir} NULLS LAST`
+              : sort === "assignedTo"
               ? sql`${feeRecords.assignedTo} ${dir} NULLS LAST`
               : sort === "overpaidAmount"
                 ? sql`${overpaidCases.overpaidAmount} ${dir} NULLS LAST`

--- a/src/components/overpaid-cases/OverpaidCases.tsx
+++ b/src/components/overpaid-cases/OverpaidCases.tsx
@@ -50,13 +50,13 @@ interface OverpaidCaseRow {
 }
 
 type CheckboxKey = "checksCleared";
-type SortKey = "claimant" | "feesReceived" | "overpaidAmount" | "opLtrDate" | "assignedTo" | "createdAt";
+type SortKey = "claimant" | "feesReceived" | "overpaidAmount" | "opLtrDate" | "noticeSent" | "assignedTo" | "createdAt";
 type SortDir = "asc" | "desc";
 type LtrFilter = "" | "none";
 
 // ---------- helpers ----------
 const PAGE_SIZE_OPTIONS = [25, 50, 100, 200];
-const SORT_KEYS: SortKey[] = ["claimant", "feesReceived", "overpaidAmount", "opLtrDate", "assignedTo", "createdAt"];
+const SORT_KEYS: SortKey[] = ["claimant", "feesReceived", "overpaidAmount", "opLtrDate", "noticeSent", "assignedTo", "createdAt"];
 const DEFAULTS = {
   search: "",
   agent: "",
@@ -1223,7 +1223,18 @@ export const OverpaidCases = () => {
                   </button>
                 </th>
                 <th className={`${thBase} ${t.textSub} text-left sticky top-0 z-20 ${stickyHeaderBg} min-w-28`}>PIF</th>
-                <th className={`${thBase} ${t.textSub} text-left sticky top-0 z-20 ${stickyHeaderBg}`}>Notice Sent</th>
+                <th
+                  aria-sort={ariaSortFor("noticeSent")}
+                  className={`${thBase} ${t.textSub} text-left sticky top-0 z-20 ${stickyHeaderBg}`}
+                >
+                  <button
+                    type="button"
+                    onClick={() => toggleSort("noticeSent")}
+                    className="inline-flex items-center gap-1 cursor-pointer rounded-sm focus:outline-none focus:ring-2 focus:ring-inset focus:ring-neutral-300 dark:focus:ring-neutral-600"
+                  >
+                    Notice Sent {sortIcon("noticeSent")}
+                  </button>
+                </th>
                 <th
                   aria-sort={ariaSortFor("opLtrDate")}
                   className={`${thBase} ${t.textSub} text-left sticky top-0 z-20 ${stickyHeaderBg}`}


### PR DESCRIPTION
## Summary

- Adds a sort button to the **Notice Sent** column header in the Overpaid Cases table
- New sort key `noticeSent` added to both the component's `SortKey` type and the API route's whitelist
- API maps `noticeSent` → `overpaid_cases.op_ltr_date` (the sent date column) with `NULLS LAST`
- Matches the existing pattern of the sortable Notice Received column exactly (same `aria-sort`, same button/icon structure)