### PR TITLE
feat: exclude cleared cases from total overpaid stat

### DIFF
--- a/src/app/api/overpaid-cases/route.ts
+++ b/src/app/api/overpaid-cases/route.ts
@@ -99,7 +99,7 @@ export const GET = async (req: NextRequest) => {
     const [agg] = await db
       .select({
         total: sql<number>`COUNT(*)::int`,
-        totalOverpaid: sql<number>`ROUND(SUM(${overpaidExpr}), 2)`,
+        totalOverpaid: sql<number>`ROUND(SUM(${overpaidExpr}) FILTER (WHERE COALESCE(${overpaidCases.checksCleared}, false) = false), 2)`,
         clearedCount: sql<number>`COUNT(*) FILTER (WHERE COALESCE(${overpaidCases.checksCleared}, false) = true)::int`,
         ltrCount: sql<number>`COUNT(*) FILTER (WHERE ${overpaidCases.opLtrReceived} IS NOT NULL)::int`,
       })

--- a/src/app/api/overpaid-cases/route.ts
+++ b/src/app/api/overpaid-cases/route.ts
@@ -100,6 +100,7 @@ export const GET = async (req: NextRequest) => {
       .select({
         total: sql<number>`COUNT(*)::int`,
         totalOverpaid: sql<number>`ROUND(SUM(${overpaidExpr}) FILTER (WHERE COALESCE(${overpaidCases.checksCleared}, false) = false), 2)`,
+        clearedTotalOverpaid: sql<number>`ROUND(SUM(${overpaidExpr}) FILTER (WHERE COALESCE(${overpaidCases.checksCleared}, false) = true), 2)`,
         clearedCount: sql<number>`COUNT(*) FILTER (WHERE COALESCE(${overpaidCases.checksCleared}, false) = true)::int`,
         ltrCount: sql<number>`COUNT(*) FILTER (WHERE ${overpaidCases.opLtrReceived} IS NOT NULL)::int`,
       })
@@ -110,6 +111,7 @@ export const GET = async (req: NextRequest) => {
 
     const total = agg?.total ?? 0;
     const totalOverpaid = Number(agg?.totalOverpaid ?? 0);
+    const clearedTotalOverpaid = Number(agg?.clearedTotalOverpaid ?? 0);
     const clearedCount = agg?.clearedCount ?? 0;
     const ltrCount = agg?.ltrCount ?? 0;
 
@@ -177,7 +179,7 @@ export const GET = async (req: NextRequest) => {
     const pageFeesReceived = pageFeesCents / 100;
     const pageOverpaid = pageOverpaidCents / 100;
 
-    return NextResponse.json({ data, page, limit, total, totalOverpaid, clearedCount, ltrCount, agents, unassignedCount, pageFeesReceived, pageOverpaid });
+    return NextResponse.json({ data, page, limit, total, totalOverpaid, clearedTotalOverpaid, clearedCount, ltrCount, agents, unassignedCount, pageFeesReceived, pageOverpaid });
   } catch (error) {
     console.error("GET /api/overpaid-cases error:", error);
     return NextResponse.json(

--- a/src/components/overpaid-cases/ClearedCases.tsx
+++ b/src/components/overpaid-cases/ClearedCases.tsx
@@ -156,7 +156,7 @@ export const ClearedCases = ({ dark, t, refreshToken, onRestored }: Props) => {
       const data: ClearedRow[] = json.data || [];
       setRows(data);
       setTotal(typeof json.total === "number" ? json.total : 0);
-      setTotalOverpaid(typeof json.totalOverpaid === "number" ? json.totalOverpaid : 0);
+      setTotalOverpaid(typeof json.clearedTotalOverpaid === "number" ? json.clearedTotalOverpaid : 0);
       noteSnapshot.current = new Map(data.map((r) => [r.id, r.updateNote]));
     } catch (err) {
       if ((err as Error).name === "AbortError") return;

--- a/src/components/overpaid-cases/OverpaidCases.tsx
+++ b/src/components/overpaid-cases/OverpaidCases.tsx
@@ -820,7 +820,7 @@ export const OverpaidCases = () => {
         <div className={`${sectionCard} p-4`}>
           <p className={`text-[12px] font-semibold uppercase tracking-wider ${t.textMuted}`}>Total Overpaid</p>
           <p className={`text-xl font-bold mt-1 ${dark ? "text-amber-400" : "text-amber-600"}`}>{isInitialLoad ? "—" : fmtFull(stats.totalOverpaid)}</p>
-          <p className={`text-[12px] ${t.textMuted} mt-0.5`}>across filtered cases</p>
+          <p className={`text-[12px] ${t.textMuted} mt-0.5`}>pending (excluding cleared)</p>
         </div>
         <div className={`${sectionCard} p-4`}>
           <p className={`text-[12px] font-semibold uppercase tracking-wider ${t.textMuted}`}>LTR Received</p>


### PR DESCRIPTION
## Summary

- The **Total Overpaid** stat card was summing all cases including those with checks cleared, overstating the outstanding balance
- Added `FILTER (WHERE checksCleared = false)` to the SUM in the aggregate query so cleared cases (already refunded) are excluded
- Updated the stat label from "across filtered cases" to "pending (excluding cleared)" to make the scope explicit