### PR TITLE
feat: default agent tracking view to Day

### DIFF
--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -341,7 +341,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
     }
   };
 
-  const [dateMode, setDateMode] = useState<DateMode>("week");
+  const [dateMode, setDateMode] = useState<DateMode>("day");
   const nowForInit = new Date();
   const [monthSel, setMonthSel] = useState(nowForInit.getMonth());
   const [yearSel, setYearSel] = useState(nowForInit.getFullYear());


### PR DESCRIPTION
Changes default date mode from Week to Day so agents see today's entries on load.