### PR TITLE
fix: remove reverse sync — Fee Petition Approved now requires manual checkbox only

### DIFF
--- a/src/app/(dashboard)/fee-petitions/actions.ts
+++ b/src/app/(dashboard)/fee-petitions/actions.ts
@@ -8,9 +8,11 @@ import { resolveCaseId } from "@/lib/import/resolve-case";
 import { requireCapability } from "@/lib/auth-helpers";
 import type { ImportResult } from "@/components/modals/CsvImportModal";
 
-// Kept in sync with FeeRecordsTable.tsx's CASE_STATUS_COLORS — the literal
-// Remarks value that means the same thing as this page's "Fee Petition
-// Approved" column.
+// The Remarks value written to Master Fees when a lead approves a petition
+// via the checkbox. FeeRecordsTable.tsx's CASE_STATUS_COLORS uses the same
+// literal for badge styling. This is a one-way push: the checkbox sets this
+// value in Remarks, but Remarks being set to this string does NOT set the
+// checkbox (reverse sync intentionally removed — see route.ts PATCH handler).
 const FEE_PETITION_APPROVED_REMARKS = "FEE PETITION APPROVED";
 
 const FIELD_KEYS = [
@@ -72,11 +74,11 @@ export async function upsertFeePetition(input: {
     }
 
     // Checking "Fee Petition Approved" here also sets Remarks on Master Fees
-    // to match, so the two stay in sync regardless of which page someone
-    // edits from. Only syncs forward on check — unchecking doesn't touch
-    // Remarks, since Remarks has many other unrelated values and blanking it
-    // as a side effect of an unrelated checkbox would be a surprising, lossy
-    // side effect on a different page.
+    // to "FEE PETITION APPROVED" so the two stay visible together. This is
+    // intentionally one-way: only the checkbox here can approve a petition;
+    // editing Remarks directly in Master Fees no longer triggers this flag
+    // (the reverse sync was removed so that agents cannot self-approve by
+    // picking a Remarks value without a lead/Lori reviewing first).
     const row = await db.transaction(async (tx) => {
       const [r] = await tx
         .insert(feePetitions)

--- a/src/app/api/cases/[id]/route.ts
+++ b/src/app/api/cases/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { db } from "@/lib/db";
-import { cases, feeRecords, feePetitions, activityLog, userDetails } from "@/lib/db/schema";
+import { cases, feeRecords, activityLog, userDetails } from "@/lib/db/schema";
 import { eq, desc, sql } from "drizzle-orm";
 import { auth } from "@/auth";
 import { requireCapability, requireAdmin, guardStatus, sessionHasCapability } from "@/lib/auth-helpers";
@@ -522,23 +522,6 @@ export const PATCH = async (
       // query excludes on overpaid_dismissed_at regardless of marked_overpaid.
       if (feeFields.markedOverpaid === true) {
         updates.push(sql`overpaid_dismissed_at = NULL`);
-      }
-
-      // Setting Remarks to "FEE PETITION APPROVED" also checks the Fee
-      // Petitions page's own "Fee Petition Approved" column, so the two stay
-      // in sync regardless of
-      // which page someone edits from. Only syncs forward — changing Remarks
-      // to something else doesn't uncheck it, since Remarks has many other
-      // unrelated values and the approval itself doesn't become untrue just
-      // because a note field changed.
-      if (feeFields.caseStatus === "FEE PETITION APPROVED") {
-        await db
-          .insert(feePetitions)
-          .values({ caseId, feePetitionApproved: true })
-          .onConflictDoUpdate({
-            target: feePetitions.caseId,
-            set: { feePetitionApproved: true, updatedAt: new Date() },
-          });
       }
 
       if (updates.length > 0) {

--- a/src/components/fee-petitions/FeePetitions.tsx
+++ b/src/components/fee-petitions/FeePetitions.tsx
@@ -57,8 +57,8 @@ interface FeePetitionRow {
   ltrToClmtWithSignature: boolean;
   ltrToAlj: boolean;
   faxConfFeePet: boolean;
-  // Outcome flag, not part of the filing checklist above — synced with
-  // Remarks ("FEE PETITION APPROVED") on Master Fees in both directions.
+  // Outcome flag, not part of the filing checklist above. Checking this
+  // sets Remarks to "FEE PETITION APPROVED" on Master Fees (one-way only).
   feePetitionApproved: boolean;
   updateNote: string;
   nextFollowUpDate: string | null;

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -350,11 +350,11 @@ export const feePetitions = pgTable(
     faxConfFeePet: boolean("fax_conf_fee_pet").notNull().default(false),
 
     // Outcome flag, not a filing step — kept separate from the checklist
-    // above. Synced with fee_records.case_status ("Remarks" on Master Fees):
-    // setting Remarks to "FEE PETITION APPROVED" checks this, and checking
-    // this sets Remarks to "FEE PETITION APPROVED". See upsertFeePetition
-    // (fee-petitions/actions.ts) and the PATCH handler in
-    // api/cases/[id]/route.ts for the two sync directions.
+    // above. One-way link to fee_records.case_status ("Remarks" on Master
+    // Fees): checking this sets Remarks to "FEE PETITION APPROVED" via
+    // upsertFeePetition (fee-petitions/actions.ts). The reverse direction
+    // (Remarks → this flag) was intentionally removed so agents cannot
+    // self-approve by editing Remarks directly in Master Fees.
     feePetitionApproved: boolean("fee_petition_approved").notNull().default(false),
 
     // Inline note (legacy — superseded by activity_log + feePetitionId)


### PR DESCRIPTION
## What changed

Removed the reverse sync that automatically set `fee_petition_approved = true` on the Fee Petitions page whenever an agent updated the **Remarks** field to `"FEE PETITION APPROVED"` in Master Fees.

## Why

Agents were selecting the Fee Petition Approved option in Remarks on their own once they saw fees received, which silently moved cases into Completed Petitions — bypassing Lori's review step. Ms. Jazz reported the issue.

## Behaviour after this fix

| Action | Before | After |
|---|---|---|
| Agent sets Remarks → "FEE PETITION APPROVED" in Master Fees | Auto-checks `feePetitionApproved`, moves case to Completed Petitions | No effect on the checkbox or Completed Petitions |
| Lead/Lori checks the Fee Petition Approved checkbox in Fee Petitions | Moves to Completed Petitions + sets Remarks in Master Fees | Same — unchanged |

The capability gate (`case.update`) on the checkbox is also unchanged, so agents cannot use the checkbox themselves.

## Files

- `src/app/api/cases/[id]/route.ts` — removed 16-line reverse-sync block and unused `feePetitions` import
- `src/app/(dashboard)/fee-petitions/actions.ts` — updated comments to reflect one-way flow
- `src/lib/db/schema.ts` — updated stale bidirectional-sync comment
- `src/components/fee-petitions/FeePetitions.tsx` — updated stale bidirectional-sync comment

## Gates

- Lint ✅ clean
- Tests ✅ 118/118 passed
- Build ✅ clean