### PR TITLE
fix: save caseLink when adding cases manually

### DIFF
--- a/src/app/api/cases/route.ts
+++ b/src/app/api/cases/route.ts
@@ -320,6 +320,7 @@ const createCaseSchema = z.object({
   aljLastName: optionalText,
   assignedTo: optionalText,
   winSheetStatus: optionalText,
+  caseLink: optionalText,
   // Chronicle client id → persisted to user_details so the dashboard can deep
   // link to Chronicle. Blank/absent stays undefined.
   chronicleId: z.preprocess(
@@ -376,6 +377,7 @@ export const POST = async (req: NextRequest) => {
       officeWithJurisdiction: input.officeWithJurisdiction,
       aljFirstName: input.aljFirstName,
       aljLastName: input.aljLastName,
+      caseLink: input.caseLink,
     });
 
     await db.insert(feeRecords).values({

--- a/src/components/modals/AddCaseModal.tsx
+++ b/src/components/modals/AddCaseModal.tsx
@@ -21,8 +21,8 @@ interface AddCaseModalProps {
 }
 
 interface FormState {
-  // Worksheet-style entry: the visible CASE LINK text + the MyCase hyperlink.
-  // `caseLink` is a transient parse source (not sent to the API).
+  // Worksheet-style case title (e.g. "2026.07.06 Young, Jeannette v. ALJ …").
+  // Saved to cases.case_link so it appears in CSV exports.
   caseLink: string;
   clientId: string;
   firstName: string;


### PR DESCRIPTION
## Summary

- Cases added via the Add Case modal were not saving the worksheet case title (`case_link`) to the database — the field existed in the form but was intentionally excluded from the API schema as a "transient parse source"
- This left `caseLink` null for all manually-added cases, causing blank **MyCase Title** cells in CSV exports
- Fix: added `caseLink` to `createCaseSchema` and the DB insert in `POST /api/cases`; cases added going forward will have the field populated
- Existing manually-added cases with no `case_link` will still export blank — those would need a backfill if required

**Files changed:** `src/app/api/cases/route.ts`, `src/components/modals/AddCaseModal.tsx`