### PR TITLE
fix: fall back to externalId/MyCase URL in MyCase Title export column

### DIFF
--- a/src/components/cases/FeeRecordsTable.tsx
+++ b/src/components/cases/FeeRecordsTable.tsx
@@ -1242,7 +1242,7 @@ export const FeeRecordsTable = ({
         [
           r.id,
           escape(r.name),
-          escape(r.caseLink ?? ""),
+          escape(r.caseLink ?? r.externalId ?? buildMyCaseUrl(r.id)),
           escape(r.claim),
           escape(r.assigned),
           escape(r.office),

--- a/src/components/fee-petitions/FeePetitions.tsx
+++ b/src/components/fee-petitions/FeePetitions.tsx
@@ -825,7 +825,7 @@ export const FeePetitions = () => {
           const completedCount = CHECKBOX_COLUMNS.reduce((acc, c) => acc + (r[c.key] ? 1 : 0), 0);
           return [
             escape(r.claimant),
-            escape(r.caseLink ?? ""),
+            escape(r.caseLink ?? r.externalId ?? buildMyCaseUrl(r.id)),
             r.approvalDate ?? "",
             r.updatedAt ?? "",
             `${completedCount}/${CHECKBOX_COLUMNS.length}`,

--- a/src/components/overpaid-cases/ClearedCases.tsx
+++ b/src/components/overpaid-cases/ClearedCases.tsx
@@ -245,7 +245,7 @@ export const ClearedCases = ({ dark, t, refreshToken, onRestored }: Props) => {
         ...all.map((r) =>
           [
             escape(r.claimant),
-            escape(r.caseLink ?? ""),
+            escape(r.caseLink ?? r.externalId ?? buildMyCaseUrl(r.id)),
             escape(r.assignedTo ?? ""),
             escape(r.region ?? ""),
             r.feesReceived.toFixed(2),

--- a/src/components/overpaid-cases/OverpaidCases.tsx
+++ b/src/components/overpaid-cases/OverpaidCases.tsx
@@ -729,7 +729,7 @@ export const OverpaidCases = () => {
         ...all.map((r) =>
           [
             escape(r.claimant),
-            escape(r.caseLink ?? ""),
+            escape(r.caseLink ?? r.externalId ?? buildMyCaseUrl(r.id)),
             escape(r.assignedTo ?? ""),
             escape(r.region ?? ""),
             r.feesReceived.toFixed(2),


### PR DESCRIPTION
## Summary

- The `MyCase Title` export column was blank for cases where `case_link` was not stored in the DB (e.g. cases added manually before the recent fix, or cases synced from MyCase where the name field was empty)
- All cases in the dashboard show a clickable MyCase link (built from `externalId` or `buildMyCaseUrl` fallback) — the export should show at minimum the same
- Fallback chain applied to all four exports: `caseLink` (worksheet title) → `externalId` (stored MyCase/Chronicle URL) → `buildMyCaseUrl(id)` (generated URL)
- Cases with the full worksheet title still show it; cases without it now show the MyCase URL instead of a blank cell

**Files changed:** `FeeRecordsTable.tsx`, `FeePetitions.tsx`, `OverpaidCases.tsx`, `ClearedCases.tsx`