### PR TITLE
fix: distinct icon for Follow-Ups tab; sync BASE_CASE fixture

### DIFF
--- a/src/app/(dashboard)/notifications/page.tsx
+++ b/src/app/(dashboard)/notifications/page.tsx
@@ -11,6 +11,7 @@ import {
   DollarSign,
   Phone,
   PhoneCall,
+  CalendarClock,
   UserPlus,
   CheckCheck,
   CheckCircle2,
@@ -111,7 +112,7 @@ const PAGE_TABS: { key: PageTab; label: string; icon: React.ElementType }[] = [
   { key: "recent_activity",       label: "Recent Activity",       icon: Activity },
   { key: "new_cases",             label: "New Cases",             icon: UserPlus },
   { key: "calls_backlog",         label: "Calls Backlog",         icon: PhoneCall },
-  { key: "follow_ups",            label: "Follow-Ups",            icon: PhoneCall },
+  { key: "follow_ups",            label: "Follow-Ups",            icon: CalendarClock },
 ];
 
 // ============================================================================

--- a/src/components/cases/__tests__/FeeRecordsTable.column-parity.test.tsx
+++ b/src/components/cases/__tests__/FeeRecordsTable.column-parity.test.tsx
@@ -149,6 +149,7 @@ const BASE_CASE: CaseRow = {
   office: "Test Office",
   notesCount: 0,
   leaderNotesCount: 0,
+  caseLink: null,
   winSheetLink: null,
   winSheetLinkText: null,
 };


### PR DESCRIPTION
## Summary

- Follow-Ups and Calls Backlog tabs shared the same `PhoneCall` icon — swapped Follow-Ups to `CalendarClock` to distinguish them in the tab bar
- `BASE_CASE` fixture in `FeeRecordsTable.column-parity.test.tsx` was missing `caseLink: null` after `caseLink` was added as a required field on `CaseRow`; fixture is now in sync

Both found during post-merge audit.