### PR TITLE
feat: restrict Follow-Ups and Calls Backlog tabs to lead/admin roles

### DIFF
--- a/src/app/(dashboard)/notifications/page.tsx
+++ b/src/app/(dashboard)/notifications/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useTheme } from "next-themes";
+import { useSession } from "next-auth/react";
 import Link from "next/link";
 import {
   Bell,
@@ -138,12 +139,20 @@ function timeAgo(dateStr: string): string {
 // Component
 // ============================================================================
 
+// Tabs hidden from member role — visible to lead, admin, system_admin only.
+const LEAD_ONLY_TABS = new Set<PageTab>(["calls_backlog", "follow_ups"]);
+
 export default function NotificationsPage() {
   const { resolvedTheme } = useTheme();
+  const { data: session } = useSession();
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
   const dark = mounted ? resolvedTheme === "dark" : false;
   const t = themeClasses(dark);
+
+  const role = session?.user?.role;
+  const canSeeLeadTabs = role === "lead" || role === "admin" || role === "system_admin";
+  const visibleTabs = PAGE_TABS.filter((tab) => !LEAD_ONLY_TABS.has(tab.key) || canSeeLeadTabs);
 
   const [stored, setStored] = useState<Notification[]>([]);
   const [live, setLive] = useState<Notification[]>([]);
@@ -264,7 +273,7 @@ export default function NotificationsPage() {
     <div className="space-y-4">
       {/* Page-level tab switcher */}
       <div className={`flex gap-1 p-1 rounded-lg border w-fit ${dark ? "bg-neutral-900 border-neutral-800" : "bg-neutral-100/60 border-neutral-200"}`}>
-        {PAGE_TABS.map(({ key, label, icon: Icon }) => (
+        {visibleTabs.map(({ key, label, icon: Icon }) => (
           <button
             key={key}
             onClick={() => setPageTab(key)}

--- a/src/app/api/follow-ups/route.ts
+++ b/src/app/api/follow-ups/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
+import { isAdminRole } from "@/lib/auth-helpers";
 import { db } from "@/lib/db";
 import { sql } from "drizzle-orm";
 
@@ -10,6 +11,8 @@ export async function GET(req: NextRequest) {
   try {
     const session = await auth();
     if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    const role = session.user?.role;
+    if (!isAdminRole(role) && role !== "lead") return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
     const { searchParams } = req.nextUrl;
     const week = searchParams.get("week") ?? new Date().toISOString().split("T")[0];

--- a/src/app/api/inbound-calls/backlog/route.ts
+++ b/src/app/api/inbound-calls/backlog/route.ts
@@ -3,12 +3,15 @@ import { db } from "@/lib/db";
 import { inboundCallRecords } from "@/lib/db/schema";
 import { eq, asc } from "drizzle-orm";
 import { auth } from "@/auth";
+import { isAdminRole } from "@/lib/auth-helpers";
 
 // GET /api/inbound-calls/backlog — all unresolved inbound calls, oldest first
 export const GET = async () => {
   try {
     const session = await auth();
     if (!session?.user) return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+    const role = session.user.role;
+    if (!isAdminRole(role) && role !== "lead") return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
     const rows = await db
       .select()


### PR DESCRIPTION
## Summary

- **Follow-Ups** and **Calls Backlog** tabs are now hidden for `member` role — visible only to `lead`, `admin`, and `system_admin`
- UI: `useSession` added to the notifications page; tabs filtered at render time via `LEAD_ONLY_TABS` set
- API defense-in-depth: `GET /api/follow-ups` and `GET /api/inbound-calls/backlog` now return 403 for member sessions — tab hiding is UX only, the routes are the authority
- Members already on the notifications page see the same experience with two fewer tabs; no redirect or error state needed