### PR TITLE
Add sort by Next Follow-Up on fee petitions page

### DIFF
--- a/src/app/api/fee-petitions/route.ts
+++ b/src/app/api/fee-petitions/route.ts
@@ -4,7 +4,7 @@ import { cases, feePetitions, feeRecords, activityLog } from "@/lib/db/schema";
 import { eq, ilike, sql, inArray } from "drizzle-orm";
 import { requirePageAccess, guardStatus } from "@/lib/auth-helpers";
 
-const SORT_KEYS = ["claimant", "approvalDate", "updatedAt", "progress", "createdAt", "feesReceived"] as const;
+const SORT_KEYS = ["claimant", "approvalDate", "updatedAt", "progress", "createdAt", "feesReceived", "nextFollowUpDate"] as const;
 type SortKey = (typeof SORT_KEYS)[number];
 
 // Fee Requested/Received are sums across t16/t2/aux fee_records columns, but
@@ -308,7 +308,9 @@ export const GET = async (req: NextRequest) => {
               ? sql`${cases.approvalDate} ${dir} NULLS LAST`
               : sort === "feesReceived"
                 ? sql`${feeRecords.totalFeesPaid} ${dir} NULLS LAST`
-                : sql`${cases.createdAt} ${dir} NULLS LAST`;
+                : sort === "nextFollowUpDate"
+                  ? sql`${feePetitions.nextFollowUpDate} ${dir} NULLS LAST`
+                  : sql`${cases.createdAt} ${dir} NULLS LAST`;
 
     const rows = await db
       .select(ROW_COLUMNS)

--- a/src/components/fee-petitions/FeePetitions.tsx
+++ b/src/components/fee-petitions/FeePetitions.tsx
@@ -74,7 +74,7 @@ type CheckboxKey =
   | "ltrToClmtWithSignature"
   | "ltrToAlj"
   | "faxConfFeePet";
-type SortKey = "claimant" | "approvalDate" | "updatedAt" | "progress" | "createdAt" | "feesReceived";
+type SortKey = "claimant" | "approvalDate" | "updatedAt" | "progress" | "createdAt" | "feesReceived" | "nextFollowUpDate";
 type SortDir = "asc" | "desc";
 type TouchedFilter = "" | "none";
 type MissingFilter = "" | CheckboxKey;
@@ -83,7 +83,7 @@ type Assignee = { name: string; count: number };
 
 // ---------- helpers ----------
 const PAGE_SIZE_OPTIONS = [25, 50, 100, 200];
-const SORT_KEYS: SortKey[] = ["claimant", "approvalDate", "updatedAt", "progress", "createdAt", "feesReceived"];
+const SORT_KEYS: SortKey[] = ["claimant", "approvalDate", "updatedAt", "progress", "createdAt", "feesReceived", "nextFollowUpDate"];
 const CHECKBOX_KEYS = ["timeDelineation", "feePetitionDoc", "ltrToClmt", "ltrToClmtWithSignature", "ltrToAlj", "faxConfFeePet"] as const;
 
 const daysSince = (dateStr: string | null): number | null => {
@@ -1292,7 +1292,18 @@ export const FeePetitions = () => {
                 <th className={`${thBase} ${t.textSub} text-center border-l ${t.borderLight} sticky top-0 z-20 ${stickyHeaderBg}`}>
                   Fee Petition Approved
                 </th>
-                <th className={`${thBase} ${t.textSub} text-left border-l ${t.borderLight} sticky top-0 z-20 ${stickyHeaderBg}`}>Next Follow-Up</th>
+                <th
+                  aria-sort={ariaSortFor("nextFollowUpDate")}
+                  className={`${thBase} ${t.textSub} text-left border-l ${t.borderLight} sticky top-0 z-20 ${stickyHeaderBg}`}
+                >
+                  <button
+                    type="button"
+                    onClick={() => toggleSort("nextFollowUpDate")}
+                    className="inline-flex items-center gap-1 cursor-pointer rounded-sm focus:outline-none focus:ring-2 focus:ring-inset focus:ring-neutral-300 dark:focus:ring-neutral-600"
+                  >
+                    Next Follow-Up {sortIcon("nextFollowUpDate")}
+                  </button>
+                </th>
                 <th className={`${thBase} ${t.textSub} text-left min-w-50 sticky top-0 z-20 ${stickyHeaderBg}`}>Recent Update</th>
                 <th className={`${thBase} ${t.textSub} text-center sticky top-0 z-20 ${stickyHeaderBg}`}>Logs</th>
               </tr>


### PR DESCRIPTION
Closes #376

Adds sorting on the **Next Follow-Up** column of the Fee Petitions page, matching the existing sortable-header pattern (Claimant, Fees Received, Approved, Updated, Progress).

- `nextFollowUpDate` added to `SortKey` in both the client table (`FeePetitions.tsx`) and the API route (`/api/fee-petitions`), with an `ORDER BY ... NULLS LAST` clause on the server.
- Verified locally against the live dev server: logged in as the seeded test admin and confirmed both asc/desc ordering via the API.