### PR TITLE
fix: match Fees Closed sync by parsed name, not raw string

### DIFF
--- a/scripts/backup-full-export.ts
+++ b/scripts/backup-full-export.ts
@@ -1,0 +1,146 @@
+/**
+ * Standalone CLI equivalent of the Admin > Backup & Restore "Export" button
+ * (src/app/api/admin/backup/export/route.ts). Produces the same
+ * BACKUP_TABLES-driven, restore-compatible .xlsx — usable ahead of a manual
+ * data cleanup where there's no browser session to hit the authenticated route.
+ *
+ * Usage:
+ *   npm run db:studio -- (n/a) — instead run directly:
+ *   npx dotenv -e .env.local -- tsx scripts/backup-full-export.ts
+ */
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import ExcelJS from "exceljs";
+import { getTableColumns } from "drizzle-orm";
+import type { PgTable } from "drizzle-orm/pg-core";
+import * as schema from "../src/lib/db/schema";
+
+// Mirrors src/lib/backup/registry.ts (BACKUP_TABLES) and src/lib/backup/humanize.ts
+// (humanizeKey) verbatim. Reimplemented here rather than imported because both
+// of those files start with `import "server-only"`, which throws when loaded
+// outside a Next.js server-component bundle (i.e. under plain tsx). Keep this
+// list in sync with registry.ts if that file changes.
+const BACKUP_SCHEMA_VERSION = 1;
+const BACKUP_TABLES: { key: string; label: string; table: PgTable; excludeColumns?: string[] }[] = [
+  { key: "Cases", label: "Cases", table: schema.cases, excludeColumns: ["fullSsn", "ssnEncrypted"] },
+  { key: "FeeRecords", label: "Fee Records", table: schema.feeRecords },
+  { key: "FeePetitions", label: "Fee Petitions", table: schema.feePetitions },
+  { key: "FeePayments", label: "Fee Payments", table: schema.feePayments },
+  { key: "OverpaidCases", label: "Overpaid Cases", table: schema.overpaidCases },
+  { key: "UserDetails", label: "User Details", table: schema.userDetails, excludeColumns: ["ssn"] },
+  { key: "TeamMembers", label: "Team Members", table: schema.teamMembers },
+  { key: "DropdownOptions", label: "Dropdown Options", table: schema.dropdownOptions },
+  { key: "DailyMetrics", label: "Daily Metrics", table: schema.dailyMetrics },
+  { key: "InboundCallRecords", label: "Inbound Calls", table: schema.inboundCallRecords },
+  { key: "InboundCallPoc", label: "Inbound Call POC", table: schema.inboundCallPoc },
+  { key: "LeaderNotes", label: "Leader Notes", table: schema.leaderNotes },
+  { key: "CaseArchive", label: "Case Archive", table: schema.caseArchive },
+  { key: "ChronicleDocuments", label: "Chronicle Documents", table: schema.chronicleDocuments },
+  { key: "MyCaseNoticeDocuments", label: "MyCase Notice Docs", table: schema.mycaseNoticeDocuments },
+];
+
+const WORD_OVERRIDES: Record<string, string> = {
+  id: "ID", ssa: "SSA", ssn: "SSN", alj: "ALJ", dob: "DOB", ein: "EIN",
+  poc: "POC", ib: "IB", ob: "OB", url: "URL", pdf: "PDF",
+  t16: "T16", t2: "T2", aux: "AUX",
+  mycase: "MyCase",
+  ltr: "Letter", clmt: "Claimant", conf: "Confirmation", op: "Overpayment",
+};
+
+function humanizeKey(key: string): string {
+  const words = key
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .split(" ")
+    .filter(Boolean);
+  return words
+    .map((w) => WORD_OVERRIDES[w.toLowerCase()] ?? w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+const HEADER_FILL: ExcelJS.Fill = { type: "pattern", pattern: "solid", fgColor: { argb: "FF4F46E5" } };
+const HEADER_FONT: Partial<ExcelJS.Font> = { bold: true, color: { argb: "FFFFFFFF" } };
+
+const styleHeaderRow = (sheet: ExcelJS.Worksheet) => {
+  const header = sheet.getRow(1);
+  header.font = HEADER_FONT;
+  header.eachCell((cell) => { cell.fill = HEADER_FILL; });
+  header.height = 20;
+  sheet.views = [{ state: "frozen", ySplit: 1 }];
+  sheet.autoFilter = { from: { row: 1, column: 1 }, to: { row: 1, column: sheet.columnCount } };
+};
+
+const toCellValue = (v: unknown): unknown => {
+  if (v instanceof Date) return v.toISOString();
+  if (v !== null && typeof v === "object") return JSON.stringify(v);
+  return v;
+};
+
+async function main() {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    console.error("DATABASE_URL is not set. Run via: npx dotenv -e .env.local -- tsx scripts/backup-full-export.ts");
+    process.exit(1);
+  }
+
+  const client = postgres(connectionString, { max: 1, prepare: false });
+  const db = drizzle(client, { schema });
+
+  try {
+    const tableRows = await Promise.all(
+      BACKUP_TABLES.map((config) => db.select().from(config.table)),
+    );
+
+    const wb = new ExcelJS.Workbook();
+    const exportedAt = new Date().toISOString();
+    const exportedBy = "CLI script (scripts/backup-full-export.ts) — pre-cleanup snapshot for duplicate Fees Closed rows";
+    const manifestRows = BACKUP_TABLES.map((config, i) => ({
+      table: config.key,
+      label: config.label,
+      rowCount: tableRows[i].length,
+    }));
+
+    const manifestSheet = wb.addWorksheet("_Manifest");
+    manifestSheet.columns = [{ key: "a", width: 24 }, { key: "b", width: 24 }, { key: "c", width: 14 }];
+    manifestSheet.addRow(["Schema Version", BACKUP_SCHEMA_VERSION]);
+    manifestSheet.addRow(["Exported At", exportedAt]);
+    manifestSheet.addRow(["Exported By", exportedBy]);
+    manifestSheet.addRow([]);
+    const headerRowNum = manifestSheet.rowCount + 1;
+    manifestSheet.addRow(["Table", "Label", "Row Count"]);
+    for (const r of manifestRows) manifestSheet.addRow([r.table, r.label, r.rowCount]);
+    const manifestHeaderRow = manifestSheet.getRow(headerRowNum);
+    manifestHeaderRow.font = HEADER_FONT;
+    manifestHeaderRow.eachCell((cell) => { cell.fill = HEADER_FILL; });
+
+    BACKUP_TABLES.forEach((config, i) => {
+      const allKeys = Object.keys(getTableColumns(config.table));
+      const keys = allKeys.filter((k) => !(config.excludeColumns ?? []).includes(k));
+
+      const sheet = wb.addWorksheet(config.label);
+      sheet.columns = keys.map((k) => ({
+        header: humanizeKey(k),
+        key: k,
+        width: Math.min(Math.max(humanizeKey(k).length + 4, 12), 40),
+      }));
+      for (const r of tableRows[i]) {
+        const row = r as Record<string, unknown>;
+        const plain: Record<string, unknown> = {};
+        for (const k of keys) plain[k] = toCellValue(row[k]);
+        sheet.addRow(plain);
+      }
+      styleHeaderRow(sheet);
+    });
+
+    const filename = `hsl-backup-${exportedAt.slice(0, 19).replace(/[:T]/g, "-")}.xlsx`;
+    await wb.xlsx.writeFile(filename);
+    console.log(`✓ Wrote ${filename}`);
+    for (const r of manifestRows) console.log(`  ${r.label}: ${r.rowCount} rows`);
+  } catch (err) {
+    console.error("Backup export failed:", err);
+    process.exitCode = 1;
+  } finally {
+    await client.end();
+  }
+}
+
+main();

--- a/scripts/cleanup-duplicate-cases.ts
+++ b/scripts/cleanup-duplicate-cases.ts
@@ -1,0 +1,122 @@
+/**
+ * Deletes the stale duplicate `cases` rows created by the Fees Closed sync
+ * bug (fixed in src/app/api/sheets/fees-closed/sync/route.ts). For every
+ * (lastName, firstName) group where every row has a *synthetic* client_id
+ * (>= 900,000,000), keeps the row with the latest createdAt and deletes the
+ * rest. `fee_records`/`activity_log`/etc. cascade-delete via the FK on
+ * cases.clientId (onDelete: "cascade") — see src/lib/db/schema.ts.
+ *
+ * Groups where any row has a *real* (non-synthetic) client_id are never
+ * touched — those are legitimate distinct cases that happen to share a name
+ * (confirmed manually for "Jackson, Melissa" and "Edwards, Lisa").
+ *
+ * Defaults to a dry run (prints what would be deleted, changes nothing).
+ * Pass --apply to actually delete.
+ *
+ * Usage:
+ *   npx dotenv -e .env.local -- tsx scripts/cleanup-duplicate-cases.ts            # dry run
+ *   npx dotenv -e .env.local -- tsx scripts/cleanup-duplicate-cases.ts --apply    # deletes
+ *
+ * Take a full backup first: scripts/backup-full-export.ts
+ */
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { inArray, and, gte } from "drizzle-orm";
+import * as schema from "../src/lib/db/schema";
+
+const SYNTHETIC_ID_BASE = 900_000_000;
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    console.error("DATABASE_URL is not set.");
+    process.exit(1);
+  }
+
+  const client = postgres(connectionString, { max: 1, prepare: false });
+  const db = drizzle(client, { schema });
+
+  try {
+    const allCases = await db
+      .select({
+        id: schema.cases.id,
+        clientId: schema.cases.clientId,
+        firstName: schema.cases.firstName,
+        lastName: schema.cases.lastName,
+        createdAt: schema.cases.createdAt,
+      })
+      .from(schema.cases);
+
+    const key = (r: { firstName: string; lastName: string }) =>
+      `${r.lastName.trim().toLowerCase()}|${r.firstName.trim().toLowerCase()}`;
+
+    const groups = new Map<string, typeof allCases>();
+    for (const r of allCases) {
+      const k = key(r);
+      const arr = groups.get(k) ?? [];
+      arr.push(r);
+      groups.set(k, arr);
+    }
+
+    const bugGroups = Array.from(groups.entries()).filter(
+      ([, rows]) => rows.length > 1 && rows.every((r) => r.clientId >= SYNTHETIC_ID_BASE),
+    );
+
+    const toDelete: number[] = [];
+    const toKeep: number[] = [];
+
+    for (const [k, rows] of bugGroups) {
+      const sorted = [...rows].sort((a, b) => {
+        const at = a.createdAt?.getTime() ?? 0;
+        const bt = b.createdAt?.getTime() ?? 0;
+        if (at !== bt) return bt - at; // newest first
+        return b.clientId - a.clientId;
+      });
+      const keep = sorted[0];
+      const drop = sorted.slice(1);
+      toKeep.push(keep.clientId);
+      toDelete.push(...drop.map((r) => r.clientId));
+
+      const [lastName, firstName] = k.split("|");
+      console.log(
+        `"${lastName}, ${firstName}": keep clientId=${keep.clientId} (createdAt=${keep.createdAt?.toISOString()}), delete ${drop.length} row(s): [${drop.map((r) => r.clientId).join(", ")}]`,
+      );
+    }
+
+    console.log(
+      `\n${bugGroups.length} groups, ${toKeep.length} rows to keep, ${toDelete.length} rows to delete.`,
+    );
+
+    if (!apply) {
+      console.log("\nDry run only — no changes made. Re-run with --apply to delete.");
+      return;
+    }
+
+    if (toDelete.length === 0) {
+      console.log("Nothing to delete.");
+      return;
+    }
+
+    await db.transaction(async (tx) => {
+      const deleted = await tx
+        .delete(schema.cases)
+        .where(and(inArray(schema.cases.clientId, toDelete), gte(schema.cases.clientId, SYNTHETIC_ID_BASE)))
+        .returning({ clientId: schema.cases.clientId });
+      console.log(`\n✓ Deleted ${deleted.length} case rows (and cascaded fee_records/activity_log/etc.).`);
+      if (deleted.length !== toDelete.length) {
+        throw new Error(
+          `Expected to delete ${toDelete.length} rows but deleted ${deleted.length} — rolling back.`,
+        );
+      }
+    });
+  } catch (err) {
+    console.error("Cleanup failed:", err);
+    process.exitCode = 1;
+  } finally {
+    await client.end();
+  }
+}
+
+main();

--- a/scripts/diff-duplicate-cases.ts
+++ b/scripts/diff-duplicate-cases.ts
@@ -1,0 +1,121 @@
+/**
+ * Read-only follow-up to find-duplicate-cases.ts: for every duplicate
+ * (lastName, firstName) group with all-synthetic client_ids, fetch each
+ * row's full `cases` + `fee_records` data and report whether every row in
+ * the group is byte-identical (ignoring id/clientId/createdAt/updatedAt/
+ * syncedAt) or whether values drifted across sync runs.
+ *
+ * Usage:
+ *   npx dotenv -e .env.local -- tsx scripts/diff-duplicate-cases.ts
+ */
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { inArray, eq } from "drizzle-orm";
+import * as schema from "../src/lib/db/schema";
+
+const SYNTHETIC_ID_BASE = 900_000_000;
+const IGNORE_KEYS = new Set([
+  "id", "clientId", "caseId", "createdAt", "updatedAt", "syncedAt", "closedAt",
+]);
+
+const normalize = (row: Record<string, unknown>) => {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(row)) {
+    if (IGNORE_KEYS.has(k)) continue;
+    out[k] = v instanceof Date ? v.toISOString() : v;
+  }
+  return out;
+};
+
+async function main() {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    console.error("DATABASE_URL is not set.");
+    process.exit(1);
+  }
+
+  const client = postgres(connectionString, { max: 1, prepare: false });
+  const db = drizzle(client, { schema });
+
+  try {
+    const allCases = await db
+      .select({
+        id: schema.cases.id,
+        clientId: schema.cases.clientId,
+        firstName: schema.cases.firstName,
+        lastName: schema.cases.lastName,
+      })
+      .from(schema.cases);
+
+    const key = (r: { firstName: string; lastName: string }) =>
+      `${r.lastName.trim().toLowerCase()}|${r.firstName.trim().toLowerCase()}`;
+
+    const groups = new Map<string, typeof allCases>();
+    for (const r of allCases) {
+      const k = key(r);
+      const arr = groups.get(k) ?? [];
+      arr.push(r);
+      groups.set(k, arr);
+    }
+
+    // Only the sync-bug groups: >1 row, every clientId synthetic.
+    const bugGroups = Array.from(groups.entries()).filter(
+      ([, rows]) => rows.length > 1 && rows.every((r) => r.clientId >= SYNTHETIC_ID_BASE),
+    );
+
+    console.log(`${bugGroups.length} synthetic duplicate group(s) to diff.\n`);
+
+    let identicalGroups = 0;
+    let driftedGroups = 0;
+
+    for (const [k, rows] of bugGroups) {
+      const clientIds = rows.map((r) => r.clientId);
+      const caseRows = await db
+        .select()
+        .from(schema.cases)
+        .where(inArray(schema.cases.clientId, clientIds));
+      const feeRows = await db
+        .select()
+        .from(schema.feeRecords)
+        .where(inArray(schema.feeRecords.caseId, clientIds));
+
+      const caseNorms = caseRows
+        .sort((a, b) => a.clientId - b.clientId)
+        .map((r) => JSON.stringify(normalize(r as unknown as Record<string, unknown>)));
+      const feeNorms = feeRows
+        .sort((a, b) => a.caseId - b.caseId)
+        .map((r) => JSON.stringify(normalize(r as unknown as Record<string, unknown>)));
+
+      const casesIdentical = new Set(caseNorms).size === 1;
+      const feesIdentical = new Set(feeNorms).size === 1;
+
+      const [lastName, firstName] = k.split("|");
+      if (casesIdentical && feesIdentical) {
+        identicalGroups++;
+      } else {
+        driftedGroups++;
+        console.log(`DRIFT: "${lastName}, ${firstName}" (${rows.length} rows) — cases identical=${casesIdentical}, feeRecords identical=${feesIdentical}`);
+        if (!feesIdentical) {
+          // Show which fields differ between the first and last fee record.
+          const sorted = feeRows.sort((a, b) => a.caseId - b.caseId);
+          const first = normalize(sorted[0] as unknown as Record<string, unknown>);
+          const last = normalize(sorted[sorted.length - 1] as unknown as Record<string, unknown>);
+          for (const kk of Object.keys(first)) {
+            if (JSON.stringify(first[kk]) !== JSON.stringify(last[kk])) {
+              console.log(`    ${kk}: first=${JSON.stringify(first[kk])} last=${JSON.stringify(last[kk])}`);
+            }
+          }
+        }
+      }
+    }
+
+    console.log(`\nSummary: ${identicalGroups} groups fully identical, ${driftedGroups} groups drifted.`);
+  } catch (err) {
+    console.error("Diff failed:", err);
+    process.exitCode = 1;
+  } finally {
+    await client.end();
+  }
+}
+
+main();

--- a/scripts/find-duplicate-cases.ts
+++ b/scripts/find-duplicate-cases.ts
@@ -1,0 +1,91 @@
+/**
+ * Read-only scan for duplicate `cases` rows caused by the Fees Closed sync
+ * bug (fixed in src/app/api/sheets/fees-closed/sync/route.ts): unresolved
+ * sheet rows used to get a brand-new synthetic client_id on every sync run
+ * instead of updating the existing case, so the same person could end up
+ * with N separate case + fee_record rows.
+ *
+ * Groups cases by normalized (lastName, firstName) and reports any group
+ * with more than one row. Does not modify anything.
+ *
+ * Usage:
+ *   npx dotenv -e .env.local -- tsx scripts/find-duplicate-cases.ts
+ */
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { inArray } from "drizzle-orm";
+import * as schema from "../src/lib/db/schema";
+
+const SYNTHETIC_ID_BASE = 900_000_000;
+
+async function main() {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    console.error("DATABASE_URL is not set. Run via: npx dotenv -e .env.local -- tsx scripts/find-duplicate-cases.ts");
+    process.exit(1);
+  }
+
+  const client = postgres(connectionString, { max: 1, prepare: false });
+  const db = drizzle(client, { schema });
+
+  try {
+    const allCases = await db
+      .select({
+        id: schema.cases.id,
+        clientId: schema.cases.clientId,
+        firstName: schema.cases.firstName,
+        lastName: schema.cases.lastName,
+        caseLink: schema.cases.caseLink,
+        createdAt: schema.cases.createdAt,
+      })
+      .from(schema.cases);
+
+    const key = (r: { firstName: string; lastName: string }) =>
+      `${r.lastName.trim().toLowerCase()}|${r.firstName.trim().toLowerCase()}`;
+
+    const groups = new Map<string, typeof allCases>();
+    for (const r of allCases) {
+      const k = key(r);
+      const arr = groups.get(k) ?? [];
+      arr.push(r);
+      groups.set(k, arr);
+    }
+
+    const dupGroups = Array.from(groups.entries())
+      .filter(([, rows]) => rows.length > 1)
+      .sort((a, b) => b[1].length - a[1].length);
+
+    if (dupGroups.length === 0) {
+      console.log("No duplicate (lastName, firstName) groups found.");
+      return;
+    }
+
+    const caseIds = dupGroups.flatMap(([, rows]) => rows.map((r) => r.clientId));
+    const feeRecordRows = await db
+      .select({ caseId: schema.feeRecords.caseId, isClosed: schema.feeRecords.isClosed })
+      .from(schema.feeRecords)
+      .where(inArray(schema.feeRecords.caseId, caseIds));
+    const feeRecordMap = new Map(feeRecordRows.map((r) => [r.caseId, r.isClosed]));
+
+    console.log(`${dupGroups.length} duplicate name group(s), ${caseIds.length} total rows:\n`);
+    for (const [k, rows] of dupGroups) {
+      const [lastName, firstName] = k.split("|");
+      console.log(`"${lastName}, ${firstName}" — ${rows.length} rows`);
+      for (const r of rows.sort((a, b) => a.clientId - b.clientId)) {
+        const synthetic = r.clientId >= SYNTHETIC_ID_BASE ? "synthetic" : "real";
+        const closed = feeRecordMap.get(r.clientId);
+        console.log(
+          `  id=${r.id} clientId=${r.clientId} (${synthetic}) isClosed=${closed ?? "no fee_record"} createdAt=${r.createdAt?.toISOString()} caseLink="${r.caseLink}"`,
+        );
+      }
+      console.log("");
+    }
+  } catch (err) {
+    console.error("Scan failed:", err);
+    process.exitCode = 1;
+  } finally {
+    await client.end();
+  }
+}
+
+main();

--- a/src/app/api/sheets/fees-closed/sync/route.ts
+++ b/src/app/api/sheets/fees-closed/sync/route.ts
@@ -124,18 +124,31 @@ export const POST = async (req: NextRequest) => {
     const { rows: parsed, warnings } = mapFeesClosedRows(rawRows);
 
     // Resolve IDs: prefer CASE NAME_url; fall back to mirror DB by name.
-    // Normalize whitespace so minor formatting differences don't cause silent misses.
-    const normName = (s: string) => s.trim().replace(/\s+/g, " ");
-    const noUrlNames = parsed.filter((r) => r.myCaseId == null).map((r) => r.caseName);
-    const mirrorRows = noUrlNames.length > 0
+    // The sheet's CASE NAME and the mirror's `name` column are both raw case
+    // captions ("YYYY.MM.DD Lastname, Firstname v. ALJ ..."), so a raw string
+    // equality check breaks on any date/annotation drift between the two. Parse
+    // both sides down to {lastName, firstName} and match on that instead.
+    const nameKey = (s: string) => {
+      const { firstName, lastName } = parseCaseLink(s);
+      return `${lastName.trim().toLowerCase()}|${firstName.trim().toLowerCase()}`;
+    };
+    const noUrlLastNames = Array.from(
+      new Set(
+        parsed
+          .filter((r) => r.myCaseId == null)
+          .map((r) => parseCaseLink(r.caseName).lastName)
+          .filter((n) => n.length > 0),
+      ),
+    );
+    const mirrorRows = noUrlLastNames.length > 0
       ? await myCaseDb<{ id: string | number; name: string }[]>`
-          SELECT id, TRIM(name) AS name FROM cases WHERE TRIM(name) = ANY(${noUrlNames.map(normName)})
+          SELECT id, name FROM cases WHERE name ILIKE ANY(${noUrlLastNames.map((n) => `%${n}%`)})
         `.catch(() => [] as { id: string | number; name: string }[])
       : [];
-    const mirrorMap = new Map(mirrorRows.map((r) => [normName(r.name), Number(r.id)]));
+    const mirrorMap = new Map(mirrorRows.map((r) => [nameKey(r.name), Number(r.id)]));
 
     const resolveId = (r: ParsedFeesClosedRow): number | null =>
-      r.myCaseId ?? mirrorMap.get(normName(r.caseName)) ?? null;
+      r.myCaseId ?? mirrorMap.get(nameKey(r.caseName)) ?? null;
 
     // matchedInDb = already has a closed feeRecord in the local DB.
     const resolvedIds = parsed.map(resolveId).filter((id): id is number => id !== null);


### PR DESCRIPTION
## Summary
- `resolveId()` in the Fees Closed sync route matched a sheet row's raw `CASE NAME` against the MyCase mirror's `name` column with exact string equality. Date prefixes/ALJ suffixes meant this almost never matched, so unresolved rows got a brand-new synthetic `client_id` on every sync run instead of updating the existing case — creating a duplicate case + fee record each time.
- Matching now parses both sides to `{lastName, firstName}` via the existing `parseCaseLink` helper and compares that tuple instead.
- Adds the one-off scripts used to back up, scan, diff, and clean up the 765 duplicate rows this bug had already created in prod (see #378 for the full writeup).

Closes #378