### PR TITLE
feat: allow POC schedule editing for upcoming weeks

### DIFF
--- a/src/app/api/inbound-calls/[id]/route.ts
+++ b/src/app/api/inbound-calls/[id]/route.ts
@@ -4,6 +4,7 @@ import { inboundCallRecords } from "@/lib/db/schema";
 import { eq, sql } from "drizzle-orm";
 import { auth } from "@/auth";
 import { z } from "zod";
+import { getMondayOfDate } from "@/lib/formatters";
 
 const resolveId = async (context: {
   params: { id: string } | Promise<{ id: string }>;
@@ -40,6 +41,12 @@ export const PATCH = async (
     }
 
     const updates: Record<string, unknown> = { ...parsed.data };
+    // A record belongs to the week of its call date. Keep week_start in sync so
+    // editing the date re-files the row into that week's table — same rule the
+    // CSV importer already applies on insert.
+    if (parsed.data.callDate) {
+      updates.weekStart = getMondayOfDate(parsed.data.callDate);
+    }
     updates.updatedAt = sql`now()`;
 
     const [row] = await db
@@ -52,6 +59,7 @@ export const PATCH = async (
 
     return NextResponse.json({
       id: row.id,
+      weekStart: row.weekStart,
       callDate: row.callDate,
       createdAt: row.createdAt.toISOString(),
       number: row.number ?? "",

--- a/src/app/api/inbound-calls/route.ts
+++ b/src/app/api/inbound-calls/route.ts
@@ -4,6 +4,7 @@ import { inboundCallRecords } from "@/lib/db/schema";
 import { eq, desc } from "drizzle-orm";
 import { auth } from "@/auth";
 import { z } from "zod";
+import { getMondayOfDate } from "@/lib/formatters";
 
 // GET /api/inbound-calls?week=YYYY-MM-DD&sort=createdAt|callDate
 export const GET = async (req: NextRequest) => {
@@ -28,6 +29,7 @@ export const GET = async (req: NextRequest) => {
 
     const data = rows.map((r) => ({
       id: r.id,
+      weekStart: r.weekStart,
       callDate: r.callDate,
       createdAt: r.createdAt.toISOString(),
       number: r.number ?? "",
@@ -44,8 +46,10 @@ export const GET = async (req: NextRequest) => {
   }
 };
 
+// weekStart is intentionally absent — it is always derived from callDate so a
+// record can never be filed under a week its date doesn't fall in. Extra keys
+// are stripped by Zod, so callers still sending weekStart are unaffected.
 const createSchema = z.object({
-  weekStart: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   callDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   number: z.string().max(50).optional(),
   transcript: z.string().optional(),
@@ -66,12 +70,12 @@ export const POST = async (req: NextRequest) => {
       return NextResponse.json({ error: "Invalid input", issues: parsed.error.issues }, { status: 400 });
     }
 
-    const { weekStart, callDate, number, transcript, caseLink, specialistAssigned, calledBackResolved } = parsed.data;
+    const { callDate, number, transcript, caseLink, specialistAssigned, calledBackResolved } = parsed.data;
 
     const [row] = await db
       .insert(inboundCallRecords)
       .values({
-        weekStart,
+        weekStart: getMondayOfDate(callDate),
         callDate,
         number: number ?? null,
         transcript: transcript ?? null,
@@ -83,6 +87,7 @@ export const POST = async (req: NextRequest) => {
 
     return NextResponse.json({
       id: row.id,
+      weekStart: row.weekStart,
       callDate: row.callDate,
       createdAt: row.createdAt.toISOString(),
       number: row.number ?? "",

--- a/src/components/inbound-calls/InboundCallsClient.tsx
+++ b/src/components/inbound-calls/InboundCallsClient.tsx
@@ -185,6 +185,9 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
   const pocSaveControllerRef = useRef<AbortController | null>(null);
   const patchAbortRef = useRef<Map<string, AbortController>>(new Map());
   const savedTimerRef = useRef<Map<string, NodeJS.Timeout>>(new Map());
+  // Last value sent for each field, so a blur straight after a change-triggered
+  // save doesn't fire a second, identical write.
+  const lastSentRef = useRef<Map<string, string | boolean | null>>(new Map());
   const fetchCancelledRef = useRef(false);
 
   // ── fetch available weeks ───────────────────────────────────────────────────
@@ -339,6 +342,11 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
     }
 
     const key = fieldKey(id, field);
+    // Nothing changed since the last write for this field — most often a blur
+    // arriving right behind a change that already saved.
+    if (lastSentRef.current.get(key) === value) return;
+    lastSentRef.current.set(key, value);
+
     // Abort only a previous save of the SAME field. Keying by row id alone made
     // tabbing to the next field cancel the one before it, and the row kept the
     // typed value locally — so a lost edit still looked saved.
@@ -377,6 +385,8 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
       savedTimerRef.current.set(key, timer);
     } catch (err) {
       if ((err as Error).name === "AbortError") return;
+      // Failed, so this value is not what the server holds — let a retry through.
+      lastSentRef.current.delete(key);
       setFieldState((s) => ({ ...s, [key]: undefined }));
       setLiveMessage("Save failed");
       toast.error((err as Error).message);
@@ -719,7 +729,15 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
                         <input
                           type="date"
                           value={row.callDate}
-                          onChange={(e) => handleFieldChange(row.id, "callDate", e.target.value)}
+                          onChange={(e) => {
+                            const next = e.target.value;
+                            handleFieldChange(row.id, "callDate", next);
+                            // A date picker emits a complete value on selection, so
+                            // save straight away. Waiting for blur left the user
+                            // looking at an unsaved date with nothing happening.
+                            // Part-typed values are ignored here and caught on blur.
+                            if (ISO_DATE.test(next)) updateRecord(row.id, "callDate", next);
+                          }}
                           onBlur={(e) => updateRecord(row.id, "callDate", e.target.value)}
                           className={fieldCls(row.id, "callDate")}
                         />

--- a/src/components/inbound-calls/InboundCallsClient.tsx
+++ b/src/components/inbound-calls/InboundCallsClient.tsx
@@ -74,6 +74,24 @@ const PAST_WEEKS = 7;
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 
+// How long the "saved" tick stays on a field after a successful write.
+const SAVED_TICK_MS = 1500;
+
+type FieldState = "saving" | "saved" | undefined;
+
+// Save state is keyed by `${rowId}:${field}` so the six inline fields on one row
+// never share a slot — sharing one lets a save on one field cancel another's.
+const fieldKey = (id: number, field: string) => `${id}:${field}`;
+
+function SaveStatus({ state }: { state: FieldState }) {
+  if (!state) return null;
+  return state === "saving" ? (
+    <RefreshCw aria-hidden="true" className="h-3 w-3 shrink-0 animate-spin text-neutral-400" />
+  ) : (
+    <Check aria-hidden="true" className="h-3 w-3 shrink-0 text-emerald-500" />
+  );
+}
+
 const DAYS = [
   { num: 1, label: "Monday" },
   { num: 2, label: "Tuesday" },
@@ -156,7 +174,8 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
   const [records, setRecords] = useState<CallRecord[]>([]);
   const [recordsLoading, setRecordsLoading] = useState(false);
   const [recordsError, setRecordsError] = useState<string | null>(null);
-  const [saving, setSaving] = useState<Record<number, boolean>>({});
+  const [fieldState, setFieldState] = useState<Record<string, FieldState>>({});
+  const [liveMessage, setLiveMessage] = useState("");
   const [addingRow, setAddingRow] = useState(false);
   const [pendingDelete, setPendingDelete] = useState<number | null>(null);
   const [csvImportOpen, setCsvImportOpen] = useState(false);
@@ -164,9 +183,8 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
   const recordsControllerRef = useRef<AbortController | null>(null);
   const pocControllerRef = useRef<AbortController | null>(null);
   const pocSaveControllerRef = useRef<AbortController | null>(null);
-  const patchAbortRef = useRef<Map<number, AbortController>>(new Map());
-  const addRowAbortRef = useRef<AbortController | null>(null);
-  const deleteAbortRef = useRef<AbortController | null>(null);
+  const patchAbortRef = useRef<Map<string, AbortController>>(new Map());
+  const savedTimerRef = useRef<Map<string, NodeJS.Timeout>>(new Map());
   const fetchCancelledRef = useRef(false);
 
   // ── fetch available weeks ───────────────────────────────────────────────────
@@ -234,17 +252,40 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
     setPocError(null);
     fetchPoc(selectedWeek);
     fetchRecords(selectedWeek, sortField);
-    const patchAborts = patchAbortRef.current;
     return () => {
       fetchCancelledRef.current = true;
+      // Only the GETs are aborted. In-flight writes (PATCH/POST/DELETE) are
+      // deliberately left to finish — cancelling them on a week change or an
+      // unmount discards an edit the user has already been shown as accepted.
       pocControllerRef.current?.abort();
       recordsControllerRef.current?.abort();
-      for (const ctrl of patchAborts.values()) ctrl.abort();
-      patchAborts.clear();
-      addRowAbortRef.current?.abort();
-      deleteAbortRef.current?.abort();
     };
   }, [selectedWeek, sortField, fetchPoc, fetchRecords]);
+
+  // ── saved-tick timers ──────────────────────────────────────────────────────
+
+  useEffect(() => {
+    const timers = savedTimerRef.current;
+    return () => {
+      for (const timer of timers.values()) clearTimeout(timer);
+      timers.clear();
+    };
+  }, []);
+
+  // ── warn if leaving mid-save ───────────────────────────────────────────────
+
+  const savesInFlight = Object.values(fieldState).filter((s) => s === "saving").length;
+
+  useEffect(() => {
+    if (savesInFlight === 0) return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      // Legacy browsers need returnValue set to trigger the prompt.
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [savesInFlight]);
 
   // ── week menu close on outside click ───────────────────────────────────────
 
@@ -297,10 +338,16 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
       return;
     }
 
-    patchAbortRef.current.get(id)?.abort();
+    const key = fieldKey(id, field);
+    // Abort only a previous save of the SAME field. Keying by row id alone made
+    // tabbing to the next field cancel the one before it, and the row kept the
+    // typed value locally — so a lost edit still looked saved.
+    patchAbortRef.current.get(key)?.abort();
     const controller = new AbortController();
-    patchAbortRef.current.set(id, controller);
-    setSaving((prev) => ({ ...prev, [id]: true }));
+    patchAbortRef.current.set(key, controller);
+    const pendingTick = savedTimerRef.current.get(key);
+    if (pendingTick) clearTimeout(pendingTick);
+    setFieldState((s) => ({ ...s, [key]: "saving" }));
     try {
       const res = await fetch(`/api/inbound-calls/${id}`, {
         method: "PATCH",
@@ -311,27 +358,33 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
       if (!res.ok) throw new Error(`Save failed (${res.status})`);
       // The server re-files a record into the week its call date falls in, so a
       // date edit can move the row out of the week on screen.
-      if (field === "callDate") {
-        const saved: CallRecord = await res.json();
-        if (fetchCancelledRef.current) return;
-        if (saved.weekStart !== selectedWeek) {
-          setRecords((prev) => prev.filter((r) => r.id !== id));
-          toast.success(`Call moved to ${weekLabel(saved.weekStart)}`);
-        }
+      const movedTo =
+        field === "callDate" ? ((await res.json()) as CallRecord).weekStart : null;
+
+      setFieldState((s) => ({ ...s, [key]: "saved" }));
+      setLiveMessage("Change saved");
+      const timer = setTimeout(() => {
+        setFieldState((s) => ({ ...s, [key]: undefined }));
+        savedTimerRef.current.delete(key);
+      }, SAVED_TICK_MS);
+      savedTimerRef.current.set(key, timer);
+
+      if (movedTo && movedTo !== selectedWeek && !fetchCancelledRef.current) {
+        setRecords((prev) => prev.filter((r) => r.id !== id));
+        toast.success(`Call moved to ${weekLabel(movedTo)}`);
       }
     } catch (err) {
       if ((err as Error).name === "AbortError") return;
+      setFieldState((s) => ({ ...s, [key]: undefined }));
+      setLiveMessage("Save failed");
+      toast.error((err as Error).message);
       if (field === "callDate") {
         // Don't leave a date on screen that isn't in the database.
-        toast.error((err as Error).message);
         void fetchRecords(selectedWeek, sortField);
-        return;
       }
-      // silently fail — row stays with local edit
     } finally {
-      if (patchAbortRef.current.get(id) === controller) {
-        patchAbortRef.current.delete(id);
-        setSaving((prev) => ({ ...prev, [id]: false }));
+      if (patchAbortRef.current.get(key) === controller) {
+        patchAbortRef.current.delete(key);
       }
     }
   };
@@ -345,11 +398,11 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
   // ── add row ────────────────────────────────────────────────────────────────
 
   const addRow = async () => {
-    addRowAbortRef.current?.abort();
-    const controller = new AbortController();
-    addRowAbortRef.current = controller;
     setAddingRow(true);
     try {
+      // No AbortController: each click creates a distinct record, so there is
+      // nothing for a later request to supersede — aborting would just discard
+      // a row the server may already have written.
       const res = await fetch("/api/inbound-calls", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -358,15 +411,13 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
           // in the current week — any other week gets its own Monday.
           callDate: isCurrentWeek(selectedWeek) ? todayEasternIso() : selectedWeek,
         }),
-        signal: controller.signal,
       });
       if (!res.ok) throw new Error(`Failed to add row (${res.status})`);
       const row = await res.json();
       if (fetchCancelledRef.current) return;
       setRecords((prev) => [row, ...prev]);
     } catch (err) {
-      if ((err as Error).name === "AbortError") return;
-      // silently fail
+      toast.error((err as Error).message);
     } finally {
       if (!fetchCancelledRef.current) setAddingRow(false);
     }
@@ -375,19 +426,16 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
   // ── delete row ─────────────────────────────────────────────────────────────
 
   const confirmDelete = async (id: number) => {
-    deleteAbortRef.current?.abort();
-    const controller = new AbortController();
-    deleteAbortRef.current = controller;
     setPendingDelete(null);
     setRecords((prev) => prev.filter((r) => r.id !== id));
     try {
-      const res = await fetch(`/api/inbound-calls/${id}`, {
-        method: "DELETE",
-        signal: controller.signal,
-      });
+      // No AbortController, for the same reason as addRow: deleting one record
+      // never supersedes deleting another, and the row is already gone from the
+      // table optimistically.
+      const res = await fetch(`/api/inbound-calls/${id}`, { method: "DELETE" });
       if (!res.ok) throw new Error(`Delete failed (${res.status})`);
     } catch (err) {
-      if ((err as Error).name === "AbortError") return;
+      toast.error((err as Error).message);
       if (!fetchCancelledRef.current) fetchRecords(selectedWeek, sortField);
     }
   };
@@ -418,6 +466,9 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
           defaultHeaderRow={2}
         />
       )}
+      <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+        {liveMessage}
+      </div>
       {/* ── header bar ── */}
       <div className={`${card} px-4 py-3 flex items-center justify-between gap-3 flex-wrap`}>
         <div className="flex items-center gap-3">
@@ -644,39 +695,50 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
                 {records.map((row) => (
                   <tr
                     key={row.id}
-                    className={`border-b last:border-0 transition-colors ${dark ? "border-neutral-700/40 hover:bg-neutral-800/40" : "border-neutral-100 hover:bg-neutral-50/60"} ${saving[row.id] ? "opacity-70" : ""}`}
+                    className={`border-b last:border-0 transition-colors ${dark ? "border-neutral-700/40 hover:bg-neutral-800/40" : "border-neutral-100 hover:bg-neutral-50/60"}`}
                   >
                     {/* Date */}
                     <td className={tdCls}>
-                      <input
-                        type="date"
-                        value={row.callDate}
-                        onChange={(e) => handleFieldChange(row.id, "callDate", e.target.value)}
-                        onBlur={(e) => updateRecord(row.id, "callDate", e.target.value)}
-                        className={`${inputCls} disabled:opacity-50 disabled:cursor-default`}
-                      />
+                      <div className="flex items-center gap-1">
+                        <input
+                          type="date"
+                          value={row.callDate}
+                          onChange={(e) => handleFieldChange(row.id, "callDate", e.target.value)}
+                          onBlur={(e) => updateRecord(row.id, "callDate", e.target.value)}
+                          className={`${inputCls} disabled:opacity-50 disabled:cursor-default`}
+                        />
+                        <SaveStatus state={fieldState[fieldKey(row.id, "callDate")]} />
+                      </div>
                     </td>
                     {/* Number */}
                     <td className={tdCls}>
-                      <input
-                        type="text"
-                        value={row.number}
-                        placeholder="Phone number"
-                        onChange={(e) => handleFieldChange(row.id, "number", e.target.value)}
-                        onBlur={(e) => updateRecord(row.id, "number", e.target.value || null)}
-                        className={`${inputCls} disabled:opacity-50 disabled:cursor-default`}
-                      />
+                      <div className="flex items-center gap-1">
+                        <input
+                          type="text"
+                          value={row.number}
+                          placeholder="Phone number"
+                          onChange={(e) => handleFieldChange(row.id, "number", e.target.value)}
+                          onBlur={(e) => updateRecord(row.id, "number", e.target.value || null)}
+                          className={`${inputCls} disabled:opacity-50 disabled:cursor-default`}
+                        />
+                        <SaveStatus state={fieldState[fieldKey(row.id, "number")]} />
+                      </div>
                     </td>
                     {/* Reason for Calling */}
                     <td className={tdCls}>
-                      <textarea
-                        value={row.transcript}
-                        placeholder="Reason for calling"
-                        rows={2}
-                        onChange={(e) => handleFieldChange(row.id, "transcript", e.target.value)}
-                        onBlur={(e) => updateRecord(row.id, "transcript", e.target.value || null)}
-                        className={`${inputCls} resize-none disabled:opacity-50 disabled:cursor-default`}
-                      />
+                      <div className="flex items-start gap-1">
+                        <textarea
+                          value={row.transcript}
+                          placeholder="Reason for calling"
+                          rows={2}
+                          onChange={(e) => handleFieldChange(row.id, "transcript", e.target.value)}
+                          onBlur={(e) => updateRecord(row.id, "transcript", e.target.value || null)}
+                          className={`${inputCls} resize-none disabled:opacity-50 disabled:cursor-default`}
+                        />
+                        <span className="mt-1.5">
+                          <SaveStatus state={fieldState[fieldKey(row.id, "transcript")]} />
+                        </span>
+                      </div>
                     </td>
                     {/* Case Link */}
                     <td className={tdCls}>
@@ -701,43 +763,50 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
                             <ExternalLink aria-hidden="true" className="h-3.5 w-3.5" />
                           </a>
                         )}
+                        <SaveStatus state={fieldState[fieldKey(row.id, "caseLink")]} />
                       </div>
                     </td>
                     {/* Specialist */}
                     <td className={tdCls}>
-                      <select
-                        value={row.specialistAssigned}
-                        onChange={(e) => {
-                          handleFieldChange(row.id, "specialistAssigned", e.target.value);
-                          updateRecord(row.id, "specialistAssigned", e.target.value || null);
-                        }}
-                        className={`${inputCls} cursor-pointer disabled:opacity-50 disabled:cursor-default`}
-                      >
-                        <option value="">— Assign —</option>
-                        {/* POC = Point of Contact — non-agent assignment for general inbound tracking */}
-                        <option value="POC">POC</option>
-                        {teamMembers.map((name) => (
-                          <option key={name} value={name}>{name}</option>
-                        ))}
-                      </select>
+                      <div className="flex items-center gap-1">
+                        <select
+                          value={row.specialistAssigned}
+                          onChange={(e) => {
+                            handleFieldChange(row.id, "specialistAssigned", e.target.value);
+                            updateRecord(row.id, "specialistAssigned", e.target.value || null);
+                          }}
+                          className={`${inputCls} cursor-pointer disabled:opacity-50 disabled:cursor-default`}
+                        >
+                          <option value="">— Assign —</option>
+                          {/* POC = Point of Contact — non-agent assignment for general inbound tracking */}
+                          <option value="POC">POC</option>
+                          {teamMembers.map((name) => (
+                            <option key={name} value={name}>{name}</option>
+                          ))}
+                        </select>
+                        <SaveStatus state={fieldState[fieldKey(row.id, "specialistAssigned")]} />
+                      </div>
                     </td>
                     {/* Called back / Resolved */}
                     <td className={`${tdCls} text-center`}>
-                      <button
-                        onClick={() => {
-                          const next = !row.calledBackResolved;
-                          handleFieldChange(row.id, "calledBackResolved", next);
-                          updateRecord(row.id, "calledBackResolved", next);
-                        }}
-                        aria-label={row.calledBackResolved ? "Mark CB undone" : "Mark CB done"}
-                        className={`w-5 h-5 rounded border-2 flex items-center justify-center mx-auto transition-colors ${
-                          row.calledBackResolved
-                            ? "bg-emerald-500 border-emerald-500"
-                            : dark ? "border-neutral-500 hover:border-neutral-400" : "border-neutral-300 hover:border-neutral-400"
-                        }`}
-                      >
-                        {row.calledBackResolved && <Check aria-hidden="true" className="h-3 w-3 text-white" />}
-                      </button>
+                      <div className="flex items-center justify-center gap-1">
+                        <button
+                          onClick={() => {
+                            const next = !row.calledBackResolved;
+                            handleFieldChange(row.id, "calledBackResolved", next);
+                            updateRecord(row.id, "calledBackResolved", next);
+                          }}
+                          aria-label={row.calledBackResolved ? "Mark CB undone" : "Mark CB done"}
+                          className={`w-5 h-5 rounded border-2 flex items-center justify-center shrink-0 transition-colors ${
+                            row.calledBackResolved
+                              ? "bg-emerald-500 border-emerald-500"
+                              : dark ? "border-neutral-500 hover:border-neutral-400" : "border-neutral-300 hover:border-neutral-400"
+                          }`}
+                        >
+                          {row.calledBackResolved && <Check aria-hidden="true" className="h-3 w-3 text-white" />}
+                        </button>
+                        <SaveStatus state={fieldState[fieldKey(row.id, "calledBackResolved")]} />
+                      </div>
                     </td>
                     {/* Delete */}
                     <td className={tdCls}>

--- a/src/components/inbound-calls/InboundCallsClient.tsx
+++ b/src/components/inbound-calls/InboundCallsClient.tsx
@@ -348,6 +348,17 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
     const pendingTick = savedTimerRef.current.get(key);
     if (pendingTick) clearTimeout(pendingTick);
     setFieldState((s) => ({ ...s, [key]: "saving" }));
+
+    // The target week is `getMondayOfDate(callDate)` — the same rule the server
+    // applies — so it can be resolved here and the row moved immediately rather
+    // than after a round trip. The catch below refetches if the write fails.
+    const movedTo =
+      field === "callDate" && typeof value === "string" ? getMondayOfDate(value) : null;
+    if (movedTo && movedTo !== selectedWeek) {
+      setRecords((prev) => prev.filter((r) => r.id !== id));
+      toast.success(`Call moved to ${weekLabel(movedTo)}`);
+    }
+
     try {
       const res = await fetch(`/api/inbound-calls/${id}`, {
         method: "PATCH",
@@ -356,10 +367,6 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
         signal: controller.signal,
       });
       if (!res.ok) throw new Error(`Save failed (${res.status})`);
-      // The server re-files a record into the week its call date falls in, so a
-      // date edit can move the row out of the week on screen.
-      const movedTo =
-        field === "callDate" ? ((await res.json()) as CallRecord).weekStart : null;
 
       setFieldState((s) => ({ ...s, [key]: "saved" }));
       setLiveMessage("Change saved");
@@ -368,11 +375,6 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
         savedTimerRef.current.delete(key);
       }, SAVED_TICK_MS);
       savedTimerRef.current.set(key, timer);
-
-      if (movedTo && movedTo !== selectedWeek && !fetchCancelledRef.current) {
-        setRecords((prev) => prev.filter((r) => r.id !== id));
-        toast.success(`Call moved to ${weekLabel(movedTo)}`);
-      }
     } catch (err) {
       if ((err as Error).name === "AbortError") return;
       setFieldState((s) => ({ ...s, [key]: undefined }));
@@ -446,6 +448,20 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
   const inputCls = `w-full text-xs bg-transparent border-0 outline-none focus:ring-1 focus:ring-blue-500 rounded px-1.5 py-1 ${t.text} placeholder:${t.textMuted}`;
   const thCls = `px-3 py-2.5 text-left text-[13px] font-semibold uppercase tracking-wider ${t.textMuted} whitespace-nowrap`;
   const tdCls = `px-2 py-1.5 align-top`;
+
+  // Ring the field that is being saved, then flash it green. A 12px icon beside
+  // a narrow column is too easy to miss — outlining the field the user just
+  // touched puts the feedback where they are already looking.
+  const fieldCls = (id: number, field: string) => {
+    const state = fieldState[fieldKey(id, field)];
+    const ring =
+      state === "saving"
+        ? "ring-1 ring-blue-400"
+        : state === "saved"
+          ? "ring-1 ring-emerald-400"
+          : "";
+    return `${inputCls} disabled:opacity-50 disabled:cursor-default ${ring}`;
+  };
 
   // ── render ─────────────────────────────────────────────────────────────────
 
@@ -705,7 +721,7 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
                           value={row.callDate}
                           onChange={(e) => handleFieldChange(row.id, "callDate", e.target.value)}
                           onBlur={(e) => updateRecord(row.id, "callDate", e.target.value)}
-                          className={`${inputCls} disabled:opacity-50 disabled:cursor-default`}
+                          className={fieldCls(row.id, "callDate")}
                         />
                         <SaveStatus state={fieldState[fieldKey(row.id, "callDate")]} />
                       </div>
@@ -719,7 +735,7 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
                           placeholder="Phone number"
                           onChange={(e) => handleFieldChange(row.id, "number", e.target.value)}
                           onBlur={(e) => updateRecord(row.id, "number", e.target.value || null)}
-                          className={`${inputCls} disabled:opacity-50 disabled:cursor-default`}
+                          className={fieldCls(row.id, "number")}
                         />
                         <SaveStatus state={fieldState[fieldKey(row.id, "number")]} />
                       </div>
@@ -733,7 +749,7 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
                           rows={2}
                           onChange={(e) => handleFieldChange(row.id, "transcript", e.target.value)}
                           onBlur={(e) => updateRecord(row.id, "transcript", e.target.value || null)}
-                          className={`${inputCls} resize-none disabled:opacity-50 disabled:cursor-default`}
+                          className={`${fieldCls(row.id, "transcript")} resize-none`}
                         />
                         <span className="mt-1.5">
                           <SaveStatus state={fieldState[fieldKey(row.id, "transcript")]} />
@@ -749,7 +765,7 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
                           placeholder="URL or case ID"
                           onChange={(e) => handleFieldChange(row.id, "caseLink", e.target.value)}
                           onBlur={(e) => updateRecord(row.id, "caseLink", e.target.value || null)}
-                          className={`${inputCls} disabled:opacity-50 disabled:cursor-default flex-1 min-w-0`}
+                          className={`${fieldCls(row.id, "caseLink")} flex-1 min-w-0`}
                         />
                         {row.caseLink.trim() && (
                           <a
@@ -775,7 +791,7 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
                             handleFieldChange(row.id, "specialistAssigned", e.target.value);
                             updateRecord(row.id, "specialistAssigned", e.target.value || null);
                           }}
-                          className={`${inputCls} cursor-pointer disabled:opacity-50 disabled:cursor-default`}
+                          className={`${fieldCls(row.id, "specialistAssigned")} cursor-pointer`}
                         >
                           <option value="">— Assign —</option>
                           {/* POC = Point of Contact — non-agent assignment for general inbound tracking */}

--- a/src/components/inbound-calls/InboundCallsClient.tsx
+++ b/src/components/inbound-calls/InboundCallsClient.tsx
@@ -20,6 +20,7 @@ import CsvImportModal, { type ColumnDef } from "@/components/modals/CsvImportMod
 import { bulkImportInboundCalls } from "@/app/(dashboard)/inbound-calls/actions";
 import { parseBool, parseDate } from "@/lib/import/csv-parser";
 import { getMondayOfDate } from "@/lib/formatters";
+import { toast } from "sonner";
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -62,6 +63,17 @@ function isCurrentWeek(weekStart: string): boolean {
   return weekStart === currentWeekStart();
 }
 
+function isFutureWeek(weekStart: string): boolean {
+  return weekStart > currentWeekStart();
+}
+
+// Weeks offered in the picker. Upcoming weeks are included so the POC schedule
+// can be set ahead of time.
+const UPCOMING_WEEKS = 4;
+const PAST_WEEKS = 7;
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
 const DAYS = [
   { num: 1, label: "Monday" },
   { num: 2, label: "Tuesday" },
@@ -74,6 +86,7 @@ const DAYS = [
 
 interface CallRecord {
   id: number;
+  weekStart: string;
   callDate: string;
   createdAt: string;
   number: string;
@@ -161,8 +174,8 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
   useEffect(() => {
     const cur = currentWeekStart();
     const weeks: string[] = [];
-    for (let i = 0; i < 8; i++) {
-      weeks.push(addWeeks(cur, -i));
+    for (let i = UPCOMING_WEEKS; i >= -PAST_WEEKS; i--) {
+      weeks.push(addWeeks(cur, i));
     }
     setAvailableWeeks(weeks);
   }, []);
@@ -214,6 +227,11 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
   useEffect(() => {
     fetchCancelledRef.current = false;
     setPendingDelete(null);
+    // Leave POC edit mode on week change — the draft belongs to the week it was
+    // opened from, and saving it against a different week would wipe that week's
+    // roster (the PUT replaces all assignments for the week).
+    setPocEditMode(false);
+    setPocError(null);
     fetchPoc(selectedWeek);
     fetchRecords(selectedWeek, sortField);
     const patchAborts = patchAbortRef.current;
@@ -271,6 +289,14 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
   // ── record field update ────────────────────────────────────────────────────
 
   const updateRecord = async (id: number, field: string, value: string | boolean | null) => {
+    // A part-typed date input blurs as "" — sending it would 400 and leave the
+    // row displaying a value the server never accepted.
+    if (field === "callDate" && (typeof value !== "string" || !ISO_DATE.test(value))) {
+      toast.error("Enter a complete date before leaving the field");
+      void fetchRecords(selectedWeek, sortField);
+      return;
+    }
+
     patchAbortRef.current.get(id)?.abort();
     const controller = new AbortController();
     patchAbortRef.current.set(id, controller);
@@ -283,8 +309,24 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
         signal: controller.signal,
       });
       if (!res.ok) throw new Error(`Save failed (${res.status})`);
+      // The server re-files a record into the week its call date falls in, so a
+      // date edit can move the row out of the week on screen.
+      if (field === "callDate") {
+        const saved: CallRecord = await res.json();
+        if (fetchCancelledRef.current) return;
+        if (saved.weekStart !== selectedWeek) {
+          setRecords((prev) => prev.filter((r) => r.id !== id));
+          toast.success(`Call moved to ${weekLabel(saved.weekStart)}`);
+        }
+      }
     } catch (err) {
       if ((err as Error).name === "AbortError") return;
+      if (field === "callDate") {
+        // Don't leave a date on screen that isn't in the database.
+        toast.error((err as Error).message);
+        void fetchRecords(selectedWeek, sortField);
+        return;
+      }
       // silently fail — row stays with local edit
     } finally {
       if (patchAbortRef.current.get(id) === controller) {
@@ -312,8 +354,9 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          weekStart: selectedWeek,
-          callDate: todayEasternIso(),
+          // The week is derived from this date server-side. Only "today" belongs
+          // in the current week — any other week gets its own Monday.
+          callDate: isCurrentWeek(selectedWeek) ? todayEasternIso() : selectedWeek,
         }),
         signal: controller.signal,
       });
@@ -399,10 +442,15 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
                 This week
               </span>
             )}
+            {isFutureWeek(selectedWeek) && (
+              <span className={`text-[12px] px-1.5 py-0.5 rounded-full ${dark ? "bg-amber-900/50 text-amber-300" : "bg-amber-100 text-amber-700"}`}>
+                Upcoming
+              </span>
+            )}
             <ChevronDown aria-hidden="true" className="h-3.5 w-3.5 opacity-60" />
           </button>
           {weekMenuOpen && (
-            <div className={`absolute right-0 mt-1 z-20 w-52 rounded-xl border shadow-lg overflow-hidden ${dark ? "bg-neutral-800 border-neutral-700" : "bg-white border-neutral-200"}`}>
+            <div className={`absolute right-0 mt-1 z-20 w-52 max-h-72 overflow-y-auto rounded-xl border shadow-lg ${dark ? "bg-neutral-800 border-neutral-700" : "bg-white border-neutral-200"}`}>
               {availableWeeks.map((w) => (
                 <button
                   key={w}
@@ -415,6 +463,7 @@ export function InboundCallsClient({ teamMembers }: { teamMembers: string[] }) {
                 >
                   <span>{weekLabel(w)}</span>
                   {isCurrentWeek(w) && <span className={`text-[12px] ${dark ? "text-blue-400" : "text-blue-500"}`}>Now</span>}
+                  {isFutureWeek(w) && <span className={`text-[12px] ${dark ? "text-amber-400" : "text-amber-600"}`}>Upcoming</span>}
                 </button>
               ))}
             </div>

--- a/src/components/inbound-calls/__tests__/InboundCallsClient.test.tsx
+++ b/src/components/inbound-calls/__tests__/InboundCallsClient.test.tsx
@@ -29,6 +29,17 @@ const nextWeek = () => {
   return `${dt.getFullYear()}-${String(dt.getMonth() + 1).padStart(2, "0")}-${String(dt.getDate()).padStart(2, "0")}`;
 };
 
+/** A weekday in the current week that is not the record's own call date. */
+const sameWeekOtherDay = () => {
+  const [y, m, d] = thisWeek().split("-").map(Number);
+  for (let offset = 1; offset <= 4; offset++) {
+    const dt = new Date(y, m - 1, d + offset);
+    const iso = `${dt.getFullYear()}-${String(dt.getMonth() + 1).padStart(2, "0")}-${String(dt.getDate()).padStart(2, "0")}`;
+    if (iso !== todayIso()) return iso;
+  }
+  throw new Error("no alternative weekday found in the current week");
+};
+
 const RECORD = () => ({
   id: 1,
   weekStart: thisWeek(),
@@ -140,21 +151,39 @@ describe("InboundCallsClient inline save feedback", () => {
     expect(toastError).not.toHaveBeenCalled();
   });
 
-  it("moves the row out of view as soon as its date lands in another week", async () => {
+  it("saves a picked date immediately, without waiting for the field to lose focus", async () => {
     const { container } = render(<InboundCallsClient teamMembers={["Hunter"]} />);
     await screen.findByDisplayValue("555-0100");
 
     const dateInput = container.querySelector('input[type="date"]') as HTMLInputElement;
     const moved = nextWeek();
 
+    // change only — no blur, mirroring picking a date and not clicking away
     fireEvent.change(dateInput, { target: { value: moved } });
-    fireEvent.blur(dateInput);
 
+    await waitFor(() => expect(patchStarted).toEqual([JSON.stringify({ callDate: moved })]));
     // optimistic: gone before the round trip resolves
-    await waitFor(() => expect(screen.queryByDisplayValue("555-0100")).toBeNull());
+    expect(screen.queryByDisplayValue("555-0100")).toBeNull();
     expect(toastSuccess).toHaveBeenCalledWith(expect.stringContaining("moved to"));
 
     releasePatch();
+  });
+
+  it("does not write twice when a blur follows a change that already saved", async () => {
+    const { container } = render(<InboundCallsClient teamMembers={["Hunter"]} />);
+    await screen.findByDisplayValue("555-0100");
+
+    const dateInput = container.querySelector('input[type="date"]') as HTMLInputElement;
+    // A day inside the current week, so the row stays mounted and its blur
+    // handler still runs — otherwise the optimistic removal hides the duplicate.
+    const sameWeek = sameWeekOtherDay();
+
+    fireEvent.change(dateInput, { target: { value: sameWeek } });
+    fireEvent.blur(dateInput);
+    releasePatch();
+
+    await waitFor(() => expect(patchStarted).toHaveLength(1));
+    expect(patchStarted).toEqual([JSON.stringify({ callDate: sameWeek })]);
   });
 
   it("refuses a part-typed date instead of sending one the server will reject", async () => {

--- a/src/components/inbound-calls/__tests__/InboundCallsClient.test.tsx
+++ b/src/components/inbound-calls/__tests__/InboundCallsClient.test.tsx
@@ -1,0 +1,171 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import { InboundCallsClient } from "../InboundCallsClient";
+import { getMondayOfDate } from "@/lib/formatters";
+
+// The component only needs these for chrome, not for the save behaviour.
+vi.mock("next-themes", () => ({ useTheme: () => ({ resolvedTheme: "light" }) }));
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({ data: { user: { role: "admin" } } }),
+}));
+vi.mock("@/components/modals/CsvImportModal", () => ({ default: () => null }));
+vi.mock("@/app/(dashboard)/inbound-calls/actions", () => ({
+  bulkImportInboundCalls: vi.fn(),
+}));
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: { success: (m: string) => toastSuccess(m), error: (m: string) => toastError(m) },
+}));
+
+const todayIso = () => new Intl.DateTimeFormat("en-CA", { timeZone: "America/New_York" }).format(new Date());
+const thisWeek = () => getMondayOfDate(todayIso());
+const nextWeek = () => {
+  const [y, m, d] = thisWeek().split("-").map(Number);
+  const dt = new Date(y, m - 1, d);
+  dt.setDate(dt.getDate() + 7);
+  return `${dt.getFullYear()}-${String(dt.getMonth() + 1).padStart(2, "0")}-${String(dt.getDate()).padStart(2, "0")}`;
+};
+
+const RECORD = () => ({
+  id: 1,
+  weekStart: thisWeek(),
+  callDate: todayIso(),
+  createdAt: new Date().toISOString(),
+  number: "555-0100",
+  transcript: "caller asked about status",
+  caseLink: "",
+  specialistAssigned: "",
+  calledBackResolved: false,
+});
+
+const json = (body: unknown) =>
+  ({ ok: true, status: 200, json: async () => body }) as unknown as Response;
+
+const abortError = () => Object.assign(new Error("aborted"), { name: "AbortError" });
+
+/** Holds the PATCH open so the in-flight state can be asserted. */
+let releasePatch: () => void;
+let patchGate: Promise<void>;
+/** Requests started. */
+let patchStarted: string[];
+/** Requests that actually completed — an aborted one never lands here, which is
+ *  what makes the "don't cancel a neighbour" test able to fail. */
+let patchCompleted: string[];
+
+beforeEach(() => {
+  toastSuccess.mockClear();
+  toastError.mockClear();
+  patchStarted = [];
+  patchCompleted = [];
+  patchGate = new Promise<void>((r) => {
+    releasePatch = r;
+  });
+
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const u = String(url);
+      if (init?.method === "PATCH") {
+        const body = String(init.body);
+        patchStarted.push(body);
+        // Honour the abort signal the way a real fetch does, so a cancelled
+        // save genuinely never completes.
+        await new Promise<void>((resolve, reject) => {
+          const signal = init.signal;
+          if (signal?.aborted) return reject(abortError());
+          const onAbort = () => reject(abortError());
+          signal?.addEventListener("abort", onAbort);
+          void patchGate.then(() => {
+            signal?.removeEventListener("abort", onAbort);
+            resolve();
+          });
+        });
+        patchCompleted.push(body);
+        return json({ ...RECORD(), ...JSON.parse(body) });
+      }
+      if (u.includes("/api/inbound-calls/poc")) {
+        return json({ assignments: { 1: [], 2: [], 3: [], 4: [], 5: [] } });
+      }
+      if (u.includes("/api/inbound-calls?")) return json({ data: [RECORD()] });
+      return json({});
+    }),
+  );
+});
+
+afterEach(() => {
+  releasePatch();
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("InboundCallsClient inline save feedback", () => {
+  it("rings the field blue while its save is in flight, green once it lands", async () => {
+    render(<InboundCallsClient teamMembers={["Hunter"]} />);
+
+    const numberInput = await screen.findByDisplayValue("555-0100");
+
+    fireEvent.change(numberInput, { target: { value: "555-0199" } });
+    fireEvent.blur(numberInput);
+
+    // in flight — the field the user touched is outlined
+    await waitFor(() => expect(numberInput.className).toContain("ring-blue-400"));
+
+    releasePatch();
+
+    // landed — flashes green
+    await waitFor(() => expect(numberInput.className).toContain("ring-emerald-400"));
+    expect(patchCompleted).toEqual([JSON.stringify({ number: "555-0199" })]);
+  });
+
+  it("does not cancel a neighbouring field's save when focus moves across a row", async () => {
+    render(<InboundCallsClient teamMembers={["Hunter"]} />);
+
+    const numberInput = await screen.findByDisplayValue("555-0100");
+    const reasonInput = await screen.findByDisplayValue("caller asked about status");
+
+    fireEvent.change(numberInput, { target: { value: "555-0199" } });
+    fireEvent.blur(numberInput);
+    fireEvent.change(reasonInput, { target: { value: "new reason" } });
+    fireEvent.blur(reasonInput);
+
+    releasePatch();
+
+    // both writes must COMPLETE — keying aborts by row id cancelled the first
+    await waitFor(() => expect(patchCompleted).toHaveLength(2));
+    expect(patchCompleted).toContain(JSON.stringify({ number: "555-0199" }));
+    expect(patchCompleted).toContain(JSON.stringify({ transcript: "new reason" }));
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("moves the row out of view as soon as its date lands in another week", async () => {
+    const { container } = render(<InboundCallsClient teamMembers={["Hunter"]} />);
+    await screen.findByDisplayValue("555-0100");
+
+    const dateInput = container.querySelector('input[type="date"]') as HTMLInputElement;
+    const moved = nextWeek();
+
+    fireEvent.change(dateInput, { target: { value: moved } });
+    fireEvent.blur(dateInput);
+
+    // optimistic: gone before the round trip resolves
+    await waitFor(() => expect(screen.queryByDisplayValue("555-0100")).toBeNull());
+    expect(toastSuccess).toHaveBeenCalledWith(expect.stringContaining("moved to"));
+
+    releasePatch();
+  });
+
+  it("refuses a part-typed date instead of sending one the server will reject", async () => {
+    const { container } = render(<InboundCallsClient teamMembers={["Hunter"]} />);
+    await screen.findByDisplayValue("555-0100");
+
+    const dateInput = container.querySelector('input[type="date"]') as HTMLInputElement;
+    fireEvent.change(dateInput, { target: { value: "" } });
+    fireEvent.blur(dateInput);
+
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    expect(patchStarted).toHaveLength(0);
+  });
+});

--- a/src/lib/__tests__/formatters.test.ts
+++ b/src/lib/__tests__/formatters.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { getMondayOfDate } from "../formatters";
+
+// getMondayOfDate decides which week an inbound call record is filed under
+// (see api/inbound-calls POST + PATCH), so a regression here silently moves
+// records into the wrong week's table.
+describe("getMondayOfDate", () => {
+  it("returns the same date when given a Monday", () => {
+    expect(getMondayOfDate("2026-08-10")).toBe("2026-08-10");
+  });
+
+  it("walks back to Monday for a mid-week date", () => {
+    expect(getMondayOfDate("2026-08-07")).toBe("2026-08-03");
+    expect(getMondayOfDate("2026-08-15")).toBe("2026-08-10");
+  });
+
+  it("treats Sunday as the end of the preceding Monday-start week", () => {
+    expect(getMondayOfDate("2026-08-16")).toBe("2026-08-10");
+  });
+
+  it("crosses month boundaries", () => {
+    expect(getMondayOfDate("2026-09-01")).toBe("2026-08-31");
+  });
+
+  it("crosses year boundaries", () => {
+    expect(getMondayOfDate("2027-01-03")).toBe("2026-12-28");
+    expect(getMondayOfDate("2027-01-04")).toBe("2027-01-04");
+  });
+
+  it("handles future dates the same as past ones", () => {
+    expect(getMondayOfDate("2027-06-16")).toBe("2027-06-14");
+  });
+
+  it("always returns a Monday", () => {
+    for (let day = 1; day <= 28; day++) {
+      const iso = `2026-08-${String(day).padStart(2, "0")}`;
+      const monday = getMondayOfDate(iso);
+      expect(new Date(`${monday}T00:00:00`).getDay()).toBe(1);
+    }
+  });
+});


### PR DESCRIPTION
Closes #381

## Changes

**Week picker** — spans 4 upcoming weeks through 7 past. Future weeks carry an amber "Upcoming" badge on both the trigger and the menu rows, alongside the existing "This week"/"Now" markers. The menu scrolls (`max-h-72`), since 12 entries would otherwise run off the card.

**POC edit mode closes on week change.** The draft previously survived a week switch while the header re-labelled itself, so saving wrote the old week's roster to the newly selected week — and the PUT deletes all assignments for a week before inserting, so the real roster was silently replaced.

**`week_start` is derived from `call_date` on create and update.** The CSV importer already did this (`actions.ts:36`); the POST/PATCH routes trusted whatever the client sent, so editing a record's date changed the display but left the row filed under its original week. A date edit now re-files the record and the row leaves the table on screen with a toast naming its new week. `weekStart` is dropped from the create schema and returned on GET/POST/PATCH.

**Date save failures are no longer swallowed.** A part-typed date blurs as `""`, which 400'd and was caught by `// silently fail`, leaving a date on screen the database never accepted. Incomplete dates are now rejected client-side with the true value restored; genuine failures surface the status code.

**Tests** — `getMondayOfDate` now decides which week every record files under and had no coverage. Added mid-week, Sunday, month- and year-boundary cases plus a sweep asserting the result is always a Monday.

## Note

The prod data cleanup described in #381 (2 drifted rows corrected, 1 blank row deleted) has already been applied — no migration or backfill rides along with this PR.

Lint clean, 125 tests pass, build green. The two behaviours have not been exercised in a browser yet: saving a roster on a future week, and confirming a date edit relocates the row.