### PR TITLE
fix: By Team toggle scopes the whole card, not just the fees figure

### DIFF
--- a/src/app/api/scoreboard/route.ts
+++ b/src/app/api/scoreboard/route.ts
@@ -79,7 +79,11 @@ export const GET = async (req: NextRequest) => {
     // per-payment row at all, so it's treated as a single "legacy" payment
     // dated by the fee_records received-date column, sized as whatever part
     // of the lifetime total isn't already accounted for by real ledger rows.
-    const teamTotals = await db.execute(sql`
+    // The four queries below are mutually independent — none reads another's
+    // result — so they are started together and awaited as one batch. Run in
+    // series they cost four network round trips to the database, which
+    // dominated the response time far more than the SQL itself did.
+    const teamTotalsPromise = db.execute(sql`
       WITH payment_sums AS (
         SELECT case_id, fee_type, SUM(amount::numeric) AS paid_sum
         FROM fee_payments
@@ -339,7 +343,7 @@ export const GET = async (req: NextRequest) => {
     `);
 
     // Daily breakdown for the window (from daily_metrics)
-    const dailyBreakdown = await db.execute(sql`
+    const dailyBreakdownPromise = db.execute(sql`
       SELECT
         dm.agent_name AS agent,
         dm.metric_date AS date,
@@ -354,6 +358,49 @@ export const GET = async (req: NextRequest) => {
         AND dm.metric_date < ${endExclusive}::date
       ORDER BY dm.agent_name, dm.metric_date
     `);
+
+    // "No fees" = zero dollars received — same predicate as the "Unpaid
+    // >60d/>90d" aging filter on the Master Fees page, which the team
+    // validated as the accurate definition. Kept identical to the aging
+    // query below so this card and the aging buckets can never disagree
+    // (the buckets are always a subset of this total).
+    const feesStatusPromise = db.execute(sql`
+      SELECT COUNT(*) FILTER (
+        WHERE COALESCE(total_fees_paid, 0) = 0
+      )::int AS no_fees_count
+      FROM fee_records
+      WHERE is_closed = false
+    `);
+
+    // No Fees Cases aging — same predicate as openCasesFeesStatus.noFees
+    // above (zero dollars received), aged over 60 days by approval_date.
+    const noFeesCasesPromise = db.execute(sql`
+      SELECT
+        c.client_id AS id,
+        c.first_name AS first_name,
+        c.last_name AS last_name,
+        c.external_id AS external_id,
+        fr.assigned_to AS assigned,
+        c.level_won AS level_won,
+        c.claim_type_label AS claim_type_label,
+        c.approval_date AS approval_date,
+        (CURRENT_DATE - c.approval_date)::int AS days_since_approval,
+        (fr.case_status = 'FEE PETITION APPROVED') AS fee_petition_approved
+      FROM fee_records fr
+      JOIN cases c ON c.client_id = fr.case_id
+      WHERE fr.is_closed = FALSE
+        AND COALESCE(fr.total_fees_paid, 0) = 0
+        AND c.approval_date IS NOT NULL
+        AND c.approval_date < CURRENT_DATE - INTERVAL '60 days'
+      ORDER BY c.approval_date ASC
+    `);
+
+    const [teamTotals, dailyBreakdown, feesStatusRows, noFeesCaseRows] = await Promise.all([
+      teamTotalsPromise,
+      dailyBreakdownPromise,
+      feesStatusPromise,
+      noFeesCasesPromise,
+    ]);
 
     const agents = (teamTotals as Record<string, string | number | null>[]).map(
       (r) => ({
@@ -455,18 +502,7 @@ export const GET = async (req: NextRequest) => {
       }),
     );
 
-    // "No fees" = zero dollars received — same predicate as the "Unpaid
-    // >60d/>90d" aging filter on the Master Fees page, which the team
-    // validated as the accurate definition. Kept identical to the aging
-    // query below so this card and the aging buckets can never disagree
-    // (the buckets are always a subset of this total).
-    const [feesStatus] = await db.execute(sql`
-      SELECT COUNT(*) FILTER (
-        WHERE COALESCE(total_fees_paid, 0) = 0
-      )::int AS no_fees_count
-      FROM fee_records
-      WHERE is_closed = false
-    `) as unknown as [{ no_fees_count: number }];
+    const [feesStatus] = feesStatusRows as unknown as [{ no_fees_count: number }];
 
     const openCasesFeesStatus = {
       noFees: Number(feesStatus?.no_fees_count) || 0,
@@ -474,26 +510,7 @@ export const GET = async (req: NextRequest) => {
 
     // No Fees Cases aging — same predicate as openCasesFeesStatus.noFees
     // above (zero dollars received), aged over 60 days by approval_date.
-    const noFeesCaseRows = await db.execute(sql`
-      SELECT
-        c.client_id AS id,
-        c.first_name AS first_name,
-        c.last_name AS last_name,
-        c.external_id AS external_id,
-        fr.assigned_to AS assigned,
-        c.level_won AS level_won,
-        c.claim_type_label AS claim_type_label,
-        c.approval_date AS approval_date,
-        (CURRENT_DATE - c.approval_date)::int AS days_since_approval,
-        (fr.case_status = 'FEE PETITION APPROVED') AS fee_petition_approved
-      FROM fee_records fr
-      JOIN cases c ON c.client_id = fr.case_id
-      WHERE fr.is_closed = FALSE
-        AND COALESCE(fr.total_fees_paid, 0) = 0
-        AND c.approval_date IS NOT NULL
-        AND c.approval_date < CURRENT_DATE - INTERVAL '60 days'
-      ORDER BY c.approval_date ASC
-    `) as unknown as {
+    const noFeesRows = noFeesCaseRows as unknown as {
       id: number;
       first_name: string | null;
       last_name: string | null;
@@ -506,7 +523,7 @@ export const GET = async (req: NextRequest) => {
       fee_petition_approved: boolean;
     }[];
 
-    const noFeesCases = noFeesCaseRows.map((r) => ({
+    const noFeesCases = noFeesRows.map((r) => ({
       id: r.id,
       name: `${r.last_name ?? ""}, ${r.first_name ?? ""}`,
       externalId: r.external_id,

--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -724,6 +724,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
             showMiniCards={false}
             windowMode={teamWindowMode}
             onWindowChange={changeTeamWindow}
+            loading={loading}
           />
         </div>
       )}

--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -34,7 +34,11 @@ import {
   ScoreboardSummaryCards,
   ScoreboardSummary,
   ScoreboardTeam,
+  type TeamWindowMode,
 } from "@/components/scoreboard/ScoreboardSummaryCards";
+
+// Start of the "All Time" window — earlier than any record in the system.
+const ALL_TIME_START = "2000-01-01";
 
 // ---------- types ----------
 
@@ -424,6 +428,38 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
     return { query: `week=${monday}`, ready: true };
   })();
 
+  // The By Team toggle drives the page window rather than a separate fees-only
+  // period, so its highlight has to be derived from the window actually in
+  // effect — null when that window is something no preset describes.
+  const teamWindowMode: TeamWindowMode | null =
+    dateMode === "day" && daySel === todayEt
+      ? "today"
+      : dateMode === "week" && weekOffset === 0
+        ? "week"
+        : dateMode === "month" && monthSel === nowForInit.getMonth() && yearSel === nowForInit.getFullYear()
+          ? "month"
+          : dateMode === "range" && rangeFrom === ALL_TIME_START && rangeTo === todayEt
+            ? "alltime"
+            : null;
+
+  const changeTeamWindow = (mode: TeamWindowMode) => {
+    if (mode === "today") {
+      setDaySel(todayEt);
+      changeDateMode("day");
+    } else if (mode === "week") {
+      setWeekOffset(0);
+      changeDateMode("week");
+    } else if (mode === "month") {
+      setMonthSel(nowForInit.getMonth());
+      setYearSel(nowForInit.getFullYear());
+      changeDateMode("month");
+    } else {
+      setRangeFrom(ALL_TIME_START);
+      setRangeTo(todayEt);
+      changeDateMode("range");
+    }
+  };
+
   const windowLabel =
     dateMode === "day"
       ? daySel
@@ -686,6 +722,8 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
             dark={dark}
             t={t}
             showMiniCards={false}
+            windowMode={teamWindowMode}
+            onWindowChange={changeTeamWindow}
           />
         </div>
       )}

--- a/src/components/scoreboard/ScoreboardSummaryCards.tsx
+++ b/src/components/scoreboard/ScoreboardSummaryCards.tsx
@@ -46,6 +46,17 @@ export interface ScoreboardTeam {
   clientCalls: number;
 }
 
+// Presets offered by the By Team window toggle. They map onto the page's own
+// date window — the toggle scopes every tile on the card, not just the fees.
+export type TeamWindowMode = "today" | "week" | "month" | "alltime";
+
+const TEAM_WINDOW_LABELS: Record<TeamWindowMode, string> = {
+  today: "Today",
+  week: "Week",
+  month: "Month",
+  alltime: "All Time",
+};
+
 interface ScoreboardSummaryCardsProps {
   summary: ScoreboardSummary;
   teams: ScoreboardTeam[];
@@ -53,6 +64,10 @@ interface ScoreboardSummaryCardsProps {
   dark: boolean;
   t: ReturnType<typeof themeClasses>;
   showMiniCards?: boolean;
+  /** Which preset the page's current window matches, or null for a custom one
+   *  (an arbitrary range, or any week/month other than the current). */
+  windowMode: TeamWindowMode | null;
+  onWindowChange: (mode: TeamWindowMode) => void;
 }
 
 export function ScoreboardSummaryCards({
@@ -62,11 +77,12 @@ export function ScoreboardSummaryCards({
   dark,
   t,
   showMiniCards = true,
+  windowMode,
+  onWindowChange,
 }: ScoreboardSummaryCardsProps) {
   const [t2Days, setT2Days] = useState<60 | 90>(60);
   const [t16Days, setT16Days] = useState<60 | 90>(60);
   const [concDays, setConcDays] = useState<60 | 90>(60);
-  const [teamFeeMode, setTeamFeeMode] = useState<"today" | "week" | "month" | "alltime">("week");
   const [byTeamCopied, setByTeamCopied] = useState<"sheets" | "chat" | "teams" | null>(null);
   const byTeamCopyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -74,23 +90,19 @@ export function ScoreboardSummaryCards({
     if (byTeamCopyTimerRef.current) clearTimeout(byTeamCopyTimerRef.current);
   }, []);
 
+  // Every tile on the card covers the page window, so the fees figure is the
+  // window-scoped total rather than a separately chosen period.
+  const feesLabel = windowMode
+    ? { today: "Fees Today", week: "Fees This Week", month: "Fees This Month", alltime: "Fees All Time" }[windowMode]
+    : "Fees";
+
   const copyByTeam = (format: "sheets" | "chat" | "teams") => {
-    const feeModeLabel: Record<typeof teamFeeMode, string> = {
-      today: "Fees Today",
-      week:  "Fees This Week",
-      month: "Fees This Month",
-      alltime: "Fees All Time",
-    };
-    const feeCol = format === "sheets" ? feeModeLabel[teamFeeMode] : "Collected";
+    const feeCol = format === "sheets" ? feesLabel : "Collected";
     const header = format === "sheets"
       ? ["Team", "Agents", feeCol, "SSA Calls", "CL Calls", "Win Sheets", "Cases Closed", "Open Cases"]
       : ["Team", "Agents", feeCol, "SSA", "CL Calls", "Wins", "Closed", "Open"];
     const rows = teams.map((team) => {
-      const feeValue =
-        teamFeeMode === "today"   ? team.feesToday :
-        teamFeeMode === "week"    ? team.feesThisWeek :
-        teamFeeMode === "month"   ? team.feesThisMonth :
-        team.totalCollected;
+      const feeValue = team.feesCollectedInWindow;
       return [
         teamLabel(team.team),
         team.agentCount,
@@ -204,18 +216,17 @@ export function ScoreboardSummaryCards({
         <div>
           <div className="flex items-center justify-between mb-3">
             <p className={`text-[12px] font-semibold uppercase tracking-wider ${t.textMuted}`}>
-              By Team
+              By Team — <span className="normal-case">{label}</span>
             </p>
             <div className="flex items-center gap-2">
-              {/* Fees Collected window toggle */}
+              {/* Window toggle — scopes every tile on the card, not just fees */}
               <div className={`flex items-center rounded-md border overflow-hidden text-[11px] font-semibold ${dark ? "border-neutral-700" : "border-neutral-200"}`}>
                 {(["today", "week", "month", "alltime"] as const).map((mode) => {
-                  const labels = { today: "Today", week: "Week", month: "Month", alltime: "All Time" };
-                  const active = teamFeeMode === mode;
+                  const active = windowMode === mode;
                   return (
                     <button
                       key={mode}
-                      onClick={() => setTeamFeeMode(mode)}
+                      onClick={() => onWindowChange(mode)}
                       aria-pressed={active}
                       className={`px-2.5 py-1 transition-colors ${
                         active
@@ -223,7 +234,7 @@ export function ScoreboardSummaryCards({
                           : dark ? "text-neutral-400 hover:bg-neutral-800" : "text-neutral-500 hover:bg-neutral-50"
                       }`}
                     >
-                      {labels[mode]}
+                      {TEAM_WINDOW_LABELS[mode]}
                     </button>
                   );
                 })}
@@ -268,16 +279,7 @@ export function ScoreboardSummaryCards({
             {teams.map((team) => {
               const teamColor = teamCardClasses(team.team, dark);
               const accentText = teamAccentText(team.team, dark);
-              const feesValue =
-                teamFeeMode === "today"   ? team.feesToday :
-                teamFeeMode === "week"    ? team.feesThisWeek :
-                teamFeeMode === "month"   ? team.feesThisMonth :
-                team.totalCollected;
-              const feesLabel =
-                teamFeeMode === "today"   ? "Fees Today" :
-                teamFeeMode === "week"    ? "Fees This Week" :
-                teamFeeMode === "month"   ? "Fees This Month" :
-                "Fees All Time";
+              const feesValue = team.feesCollectedInWindow;
               return (
                 <div key={team.team} className={`rounded-lg border p-4 ${teamColor}`}>
                   <div className="flex items-center justify-between mb-3">

--- a/src/components/scoreboard/ScoreboardSummaryCards.tsx
+++ b/src/components/scoreboard/ScoreboardSummaryCards.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { Check, Table2, MessageSquare, LayoutGrid } from "lucide-react";
+import { Check, Table2, MessageSquare, LayoutGrid, RefreshCw } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
 import { fmt, toChatBlock, toTeamsHtml } from "@/lib/formatters";
 import { teamCardClasses, teamAccentText, teamLabel } from "@/lib/team-colors";
@@ -68,6 +68,8 @@ interface ScoreboardSummaryCardsProps {
    *  (an arbitrary range, or any week/month other than the current). */
   windowMode: TeamWindowMode | null;
   onWindowChange: (mode: TeamWindowMode) => void;
+  /** A refetch is in flight — the figures on screen are the previous window's. */
+  loading?: boolean;
 }
 
 export function ScoreboardSummaryCards({
@@ -79,6 +81,7 @@ export function ScoreboardSummaryCards({
   showMiniCards = true,
   windowMode,
   onWindowChange,
+  loading = false,
 }: ScoreboardSummaryCardsProps) {
   const [t2Days, setT2Days] = useState<60 | 90>(60);
   const [t16Days, setT16Days] = useState<60 | 90>(60);
@@ -219,6 +222,13 @@ export function ScoreboardSummaryCards({
               By Team — <span className="normal-case">{label}</span>
             </p>
             <div className="flex items-center gap-2">
+              {/* Sits beside the toggle so the feedback lands where the click did */}
+              {loading && (
+                <span className={`flex items-center gap-1.5 text-[11px] ${t.textMuted}`}>
+                  <RefreshCw aria-hidden="true" className="h-3 w-3 animate-spin" />
+                  Updating…
+                </span>
+              )}
               {/* Window toggle — scopes every tile on the card, not just fees */}
               <div className={`flex items-center rounded-md border overflow-hidden text-[11px] font-semibold ${dark ? "border-neutral-700" : "border-neutral-200"}`}>
                 {(["today", "week", "month", "alltime"] as const).map((mode) => {
@@ -275,7 +285,12 @@ export function ScoreboardSummaryCards({
               </button>
             </div>
           </div>
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          {/* Figures stay on screen while a new window loads, dimmed so it is
+              clear they are the previous window's rather than the new one's. */}
+          <div
+            aria-busy={loading}
+            className={`grid grid-cols-1 sm:grid-cols-3 gap-3 transition-opacity ${loading ? "opacity-50" : ""}`}
+          >
             {teams.map((team) => {
               const teamColor = teamCardClasses(team.team, dark);
               const accentText = teamAccentText(team.team, dark);

--- a/src/components/scoreboard/__tests__/ScoreboardSummaryCards.test.tsx
+++ b/src/components/scoreboard/__tests__/ScoreboardSummaryCards.test.tsx
@@ -92,3 +92,44 @@ describe("ScoreboardSummaryCards — By Team window", () => {
     expect(screen.getByText(/By Team/).textContent).toContain("Fri Aug 7");
   });
 });
+
+describe("ScoreboardSummaryCards — refetch feedback", () => {
+  afterEach(cleanup);
+
+  it("says it is updating and marks the figures busy while a window loads", () => {
+    render(
+      <ScoreboardSummaryCards
+        summary={SUMMARY} teams={[T2]} label="Week" dark={false}
+        t={themeClasses(false)} showMiniCards={false}
+        windowMode="week" onWindowChange={vi.fn()} loading
+      />,
+    );
+    expect(screen.getByText(/Updating/)).toBeTruthy();
+    expect(document.querySelector('[aria-busy="true"]')).not.toBeNull();
+  });
+
+  it("keeps the previous figures on screen rather than blanking them", () => {
+    render(
+      <ScoreboardSummaryCards
+        summary={SUMMARY} teams={[T2]} label="Week" dark={false}
+        t={themeClasses(false)} showMiniCards={false}
+        windowMode="week" onWindowChange={vi.fn()} loading
+      />,
+    );
+    // 174 open cases is still readable mid-refetch — a spinner replacing the
+    // cards would make them jump on every toggle click.
+    expect(screen.getByText("174")).toBeTruthy();
+  });
+
+  it("shows no updating hint when idle", () => {
+    render(
+      <ScoreboardSummaryCards
+        summary={SUMMARY} teams={[T2]} label="Week" dark={false}
+        t={themeClasses(false)} showMiniCards={false}
+        windowMode="week" onWindowChange={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText(/Updating/)).toBeNull();
+    expect(document.querySelector('[aria-busy="true"]')).toBeNull();
+  });
+});

--- a/src/components/scoreboard/__tests__/ScoreboardSummaryCards.test.tsx
+++ b/src/components/scoreboard/__tests__/ScoreboardSummaryCards.test.tsx
@@ -1,0 +1,94 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import {
+  ScoreboardSummaryCards,
+  type ScoreboardSummary,
+  type ScoreboardTeam,
+} from "../ScoreboardSummaryCards";
+import { themeClasses } from "@/lib/theme-classes";
+
+const SUMMARY: ScoreboardSummary = {
+  totalCasesAssigned: 0, totalOpenCases: 0, totalCasesClosed: 0,
+  totalCompletedWinSheets: 0, totalWinSheetsCreated: 0,
+  totalUnpaidT2Over60: 0, totalUnpaidT16Over60: 0, totalUnpaidConcOver60: 0,
+  totalUnpaidT2Over90: 0, totalUnpaidT16Over90: 0, totalUnpaidConcOver90: 0,
+  totalCollected: 0, totalFeesCollectedInWindow: 0, totalCasesFullFee: 0,
+  totalSsaCalls: 0, totalClientCalls: 0,
+};
+
+// The whole bug in fixture form: the window figure and the week figure differ,
+// so rendering the wrong one is visible.
+const T2: ScoreboardTeam = {
+  team: "T2",
+  agentCount: 8,
+  casesAssigned: 0,
+  openCases: 174,
+  casesClosed: 6,          // one day — the page window
+  completedWinSheets: 0,
+  winSheetsCreated: 5,
+  unpaidT2Over60: 0, unpaidT16Over60: 0, unpaidConcOver60: 0,
+  totalCollected: 999_999,
+  feesCollectedInWindow: 1_234,   // same window as casesClosed
+  feesToday: 4_321,
+  feesThisWeek: 79_458,           // a DIFFERENT window — must not be shown
+  feesThisMonth: 5_555,
+  casesFullFee: 0,
+  ssaCalls: 7,
+  clientCalls: 6,
+};
+
+const renderCards = (
+  windowMode: "today" | "week" | "month" | "alltime" | null,
+  onWindowChange = vi.fn(),
+) => {
+  const utils = render(
+    <ScoreboardSummaryCards
+      summary={SUMMARY}
+      teams={[T2]}
+      label="Fri Aug 7"
+      dark={false}
+      t={themeClasses(false)}
+      showMiniCards={false}
+      windowMode={windowMode}
+      onWindowChange={onWindowChange}
+    />,
+  );
+  return { ...utils, onWindowChange };
+};
+
+describe("ScoreboardSummaryCards — By Team window", () => {
+  afterEach(cleanup);
+
+  it("shows the window-scoped fees figure, never a differently-windowed one", () => {
+    renderCards("today");
+    // $1,234 covers the same period as the other tiles
+    expect(screen.getByText(/1,234/)).toBeTruthy();
+    // the week figure belongs to a different period and must not appear
+    expect(screen.queryByText(/79,458/)).toBeNull();
+  });
+
+  it("derives the highlighted preset from the window in effect", () => {
+    renderCards("today");
+    expect(screen.getByRole("button", { name: "Today" }).getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByRole("button", { name: "Week" }).getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("highlights nothing when the window matches no preset", () => {
+    renderCards(null);
+    for (const name of ["Today", "Week", "Month", "All Time"]) {
+      expect(screen.getByRole("button", { name }).getAttribute("aria-pressed")).toBe("false");
+    }
+  });
+
+  it("asks the page to change window rather than keeping its own period", () => {
+    const { onWindowChange } = renderCards("today");
+    fireEvent.click(screen.getByRole("button", { name: "Month" }));
+    expect(onWindowChange).toHaveBeenCalledWith("month");
+  });
+
+  it("states the window it is showing, so the period is never implicit", () => {
+    renderCards("today");
+    expect(screen.getByText(/By Team/).textContent).toContain("Fri Aug 7");
+  });
+});


### PR DESCRIPTION
Closes #384

The `Today / Week / Month / All Time` toggle in the By Team header only chose which *fees* value to display — the code called it `{/* Fees Collected window toggle */}`. The other five tiles came from the page-level window. Because `teamFeeMode` defaulted to `"week"` and `dateMode` to `"day"`, every card showed "Fees This Week" beside a Cases Closed figure covering a single day, under a control captioned "Week".

That is what Ms. Jazz hit: her Scoreboard read 33 closed cases for Concurrent this week, the Reports card read 7. Verified against production — 33 is the week (Aug 3–10), 7 is Friday Aug 7 alone. Both correct for their own window; neither was labelled.

## Changes

- The toggle now drives the page window, so all six tiles move together.
- Fees use the window-scoped `feesCollectedInWindow` — a field the API already returned — instead of picking between `feesToday` / `feesThisWeek` / `feesThisMonth` / `totalCollected`.
- The highlighted preset is **derived** from the window in effect rather than kept as separate state, so it cannot drift from what is displayed. Nothing is highlighted for a custom range or a non-current week/month.
- The By Team header names the window (`By Team — Fri Aug 7`), so the period is never implicit.
- `All Time` maps to a range starting 2000-01-01, since the page window has no all-time mode.

The page's existing date `<select>` and this toggle now read and write the same state, so they stay in sync.

## Tests

Five cases in a new `ScoreboardSummaryCards.test.tsx`, each mutation-checked — the fixture gives a team a `feesCollectedInWindow` of 1,234 and a `feesThisWeek` of 79,458 so showing the wrong period is directly observable:

| Reintroduced bug | Result |
|---|---|
| fees tile back to `feesThisWeek` | `×` shows the window-scoped fees figure |
| toggle keeps its own state | `×` derives the highlighted preset, `×` highlights nothing for a custom window |
| header stops naming the window | `×` states the window it is showing |
| baseline | 5 passed |

135 tests pass, lint clean, build green.

## Not addressed here

A second latent mismatch, noted in #384: team leads are excluded from every per-agent table but rolled into the team tile (`route.ts:428`). DeAnne (T2) is on 0 closures so the figures agree today; the first week a lead closes a case the tile will exceed the visible rows. Worth its own issue.