### PR TITLE
Reports By Team: add Yesterday preset and date picker

### DIFF
--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -412,6 +412,11 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
   const weekDays = getWeekDays(monday);
 
   const todayEt = new Intl.DateTimeFormat("en-CA", { timeZone: "America/New_York" }).format(new Date());
+  const yesterdayEt = (() => {
+    const [y, m, d] = todayEt.split("-").map(Number);
+    const date = new Date(y, m - 1, d - 1);
+    return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+  })();
 
   // Days shown in the entry panel — 5 weekdays in week mode, one day in day mode.
   const entryDays =
@@ -446,17 +451,22 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
   const teamWindowMode: TeamWindowMode | null =
     dateMode === "day" && daySel === todayEt
       ? "today"
-      : dateMode === "week" && weekOffset === 0
-        ? "week"
-        : dateMode === "month" && monthSel === nowForInit.getMonth() && yearSel === nowForInit.getFullYear()
-          ? "month"
-          : dateMode === "range" && rangeFrom === ALL_TIME_START && rangeTo === todayEt
-            ? "alltime"
-            : null;
+      : dateMode === "day" && daySel === yesterdayEt
+        ? "yesterday"
+        : dateMode === "week" && weekOffset === 0
+          ? "week"
+          : dateMode === "month" && monthSel === nowForInit.getMonth() && yearSel === nowForInit.getFullYear()
+            ? "month"
+            : dateMode === "range" && rangeFrom === ALL_TIME_START && rangeTo === todayEt
+              ? "alltime"
+              : null;
 
   const changeTeamWindow = (mode: TeamWindowMode) => {
     if (mode === "today") {
       setDaySel(todayEt);
+      changeDateMode("day");
+    } else if (mode === "yesterday") {
+      setDaySel(yesterdayEt);
       changeDateMode("day");
     } else if (mode === "week") {
       setWeekOffset(0);
@@ -475,7 +485,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
   const windowLabel =
     dateMode === "day"
       ? daySel
-        ? fmtRangeDate(daySel) + (daySel === todayEt ? " (Today)" : "")
+        ? fmtRangeDate(daySel) + (daySel === todayEt ? " (Today)" : daySel === yesterdayEt ? " (Yesterday)" : "")
         : "Select a date"
       : dateMode === "month"
         ? `${MONTH_NAMES[monthSel]} ${yearSel}`
@@ -738,6 +748,12 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
             showMiniCards={false}
             windowMode={teamWindowMode}
             onWindowChange={changeTeamWindow}
+            selectedDate={daySel}
+            onDateSelect={(date) => {
+              setDaySel(date);
+              changeDateMode("day");
+            }}
+            maxDate={todayEt}
             loading={loading}
           />
         </div>

--- a/src/components/scoreboard/ScoreboardSummaryCards.tsx
+++ b/src/components/scoreboard/ScoreboardSummaryCards.tsx
@@ -48,10 +48,11 @@ export interface ScoreboardTeam {
 
 // Presets offered by the By Team window toggle. They map onto the page's own
 // date window — the toggle scopes every tile on the card, not just the fees.
-export type TeamWindowMode = "today" | "week" | "month" | "alltime";
+export type TeamWindowMode = "today" | "yesterday" | "week" | "month" | "alltime";
 
 const TEAM_WINDOW_LABELS: Record<TeamWindowMode, string> = {
   today: "Today",
+  yesterday: "Yesterday",
   week: "Week",
   month: "Month",
   alltime: "All Time",
@@ -68,6 +69,12 @@ interface ScoreboardSummaryCardsProps {
    *  (an arbitrary range, or any week/month other than the current). */
   windowMode: TeamWindowMode | null;
   onWindowChange: (mode: TeamWindowMode) => void;
+  /** The single day the "pick a date" control is showing — always the page's
+   *  `daySel`, regardless of whether day mode is the active window. */
+  selectedDate: string;
+  onDateSelect: (date: string) => void;
+  /** Latest date selectable — the picker mirrors the page's own day-nav cap. */
+  maxDate: string;
   /** A refetch is in flight — the figures on screen are the previous window's. */
   loading?: boolean;
 }
@@ -81,6 +88,9 @@ export function ScoreboardSummaryCards({
   showMiniCards = true,
   windowMode,
   onWindowChange,
+  selectedDate,
+  onDateSelect,
+  maxDate,
   loading = false,
 }: ScoreboardSummaryCardsProps) {
   const [t2Days, setT2Days] = useState<60 | 90>(60);
@@ -96,7 +106,13 @@ export function ScoreboardSummaryCards({
   // Every tile on the card covers the page window, so the fees figure is the
   // window-scoped total rather than a separately chosen period.
   const feesLabel = windowMode
-    ? { today: "Fees Today", week: "Fees This Week", month: "Fees This Month", alltime: "Fees All Time" }[windowMode]
+    ? {
+        today: "Fees Today",
+        yesterday: "Fees Yesterday",
+        week: "Fees This Week",
+        month: "Fees This Month",
+        alltime: "Fees All Time",
+      }[windowMode]
     : "Fees";
 
   const copyByTeam = (format: "sheets" | "chat" | "teams") => {
@@ -231,7 +247,7 @@ export function ScoreboardSummaryCards({
               )}
               {/* Window toggle — scopes every tile on the card, not just fees */}
               <div className={`flex items-center rounded-md border overflow-hidden text-[11px] font-semibold ${dark ? "border-neutral-700" : "border-neutral-200"}`}>
-                {(["today", "week", "month", "alltime"] as const).map((mode) => {
+                {(["today", "yesterday", "week", "month", "alltime"] as const).map((mode) => {
                   const active = windowMode === mode;
                   return (
                     <button
@@ -249,6 +265,17 @@ export function ScoreboardSummaryCards({
                   );
                 })}
               </div>
+              {/* Pick any specific day — sets the window to that day regardless
+                  of which preset (if any) is currently active. */}
+              <input
+                type="date"
+                value={selectedDate}
+                max={maxDate}
+                onChange={(e) => e.target.value && onDateSelect(e.target.value)}
+                aria-label="By Team — pick a specific date"
+                title="Pick a specific date"
+                className={`h-[26px] px-2 rounded-md border text-[11px] outline-none cursor-pointer ${dark ? "bg-neutral-900 border-neutral-700 text-neutral-300" : "bg-white border-neutral-200 text-neutral-600"}`}
+              />
               {/* Copy buttons */}
               <button
                 onClick={() => copyByTeam("sheets")}

--- a/src/components/scoreboard/__tests__/ScoreboardSummaryCards.test.tsx
+++ b/src/components/scoreboard/__tests__/ScoreboardSummaryCards.test.tsx
@@ -39,8 +39,9 @@ const T2: ScoreboardTeam = {
 };
 
 const renderCards = (
-  windowMode: "today" | "week" | "month" | "alltime" | null,
+  windowMode: "today" | "yesterday" | "week" | "month" | "alltime" | null,
   onWindowChange = vi.fn(),
+  onDateSelect = vi.fn(),
 ) => {
   const utils = render(
     <ScoreboardSummaryCards
@@ -52,9 +53,12 @@ const renderCards = (
       showMiniCards={false}
       windowMode={windowMode}
       onWindowChange={onWindowChange}
+      selectedDate="2026-08-07"
+      onDateSelect={onDateSelect}
+      maxDate="2026-08-07"
     />,
   );
-  return { ...utils, onWindowChange };
+  return { ...utils, onWindowChange, onDateSelect };
 };
 
 describe("ScoreboardSummaryCards — By Team window", () => {
@@ -76,7 +80,7 @@ describe("ScoreboardSummaryCards — By Team window", () => {
 
   it("highlights nothing when the window matches no preset", () => {
     renderCards(null);
-    for (const name of ["Today", "Week", "Month", "All Time"]) {
+    for (const name of ["Today", "Yesterday", "Week", "Month", "All Time"]) {
       expect(screen.getByRole("button", { name }).getAttribute("aria-pressed")).toBe("false");
     }
   });
@@ -87,9 +91,23 @@ describe("ScoreboardSummaryCards — By Team window", () => {
     expect(onWindowChange).toHaveBeenCalledWith("month");
   });
 
+  it("offers a Yesterday preset so team leads can compare it against Today", () => {
+    const { onWindowChange } = renderCards("today");
+    expect(screen.getByRole("button", { name: "Yesterday" }).getAttribute("aria-pressed")).toBe("false");
+    fireEvent.click(screen.getByRole("button", { name: "Yesterday" }));
+    expect(onWindowChange).toHaveBeenCalledWith("yesterday");
+  });
+
   it("states the window it is showing, so the period is never implicit", () => {
     renderCards("today");
     expect(screen.getByText(/By Team/).textContent).toContain("Fri Aug 7");
+  });
+
+  it("lets a team lead pick an arbitrary date outside the presets", () => {
+    const { onDateSelect } = renderCards("today");
+    const picker = screen.getByLabelText("By Team — pick a specific date");
+    fireEvent.change(picker, { target: { value: "2026-07-30" } });
+    expect(onDateSelect).toHaveBeenCalledWith("2026-07-30");
   });
 });
 
@@ -101,7 +119,8 @@ describe("ScoreboardSummaryCards — refetch feedback", () => {
       <ScoreboardSummaryCards
         summary={SUMMARY} teams={[T2]} label="Week" dark={false}
         t={themeClasses(false)} showMiniCards={false}
-        windowMode="week" onWindowChange={vi.fn()} loading
+        windowMode="week" onWindowChange={vi.fn()}
+        selectedDate="2026-08-07" onDateSelect={vi.fn()} maxDate="2026-08-07" loading
       />,
     );
     expect(screen.getByText(/Updating/)).toBeTruthy();
@@ -113,7 +132,8 @@ describe("ScoreboardSummaryCards — refetch feedback", () => {
       <ScoreboardSummaryCards
         summary={SUMMARY} teams={[T2]} label="Week" dark={false}
         t={themeClasses(false)} showMiniCards={false}
-        windowMode="week" onWindowChange={vi.fn()} loading
+        windowMode="week" onWindowChange={vi.fn()}
+        selectedDate="2026-08-07" onDateSelect={vi.fn()} maxDate="2026-08-07" loading
       />,
     );
     // 174 open cases is still readable mid-refetch — a spinner replacing the
@@ -127,6 +147,7 @@ describe("ScoreboardSummaryCards — refetch feedback", () => {
         summary={SUMMARY} teams={[T2]} label="Week" dark={false}
         t={themeClasses(false)} showMiniCards={false}
         windowMode="week" onWindowChange={vi.fn()}
+        selectedDate="2026-08-07" onDateSelect={vi.fn()} maxDate="2026-08-07"
       />,
     );
     expect(screen.queryByText(/Updating/)).toBeNull();


### PR DESCRIPTION
Closes #411

## Reported by
Ms. Jazz — team leaders check the Reports "By Team" cards specifically and wanted a way to view yesterday's numbers to compare against today's.

## Change
- Added a "Yesterday" option to the By Team window toggle (`ScoreboardSummaryCards.tsx`), alongside the existing Today / Week / Month / All Time.
- Added a date picker next to the toggle so a specific date can be selected directly, not just the two presets.
- Both wire into the existing single-window architecture (`dateMode`/`daySel` in `ScoreboardTracker.tsx`) from #384, so every tile on the card (fees, calls, win sheets, closed/open cases) moves together for whichever day is selected.