### PR TITLE
sync: develop → main

### DIFF
--- a/src/app/api/revenue-by-claim-type/route.ts
+++ b/src/app/api/revenue-by-claim-type/route.ts
@@ -1,0 +1,126 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { db } from "@/lib/db";
+import { sql } from "drizzle-orm";
+
+const WINDOWS = ["today", "week", "month"] as const;
+type Window = (typeof WINDOWS)[number];
+
+const pad = (n: number) => String(n).padStart(2, "0");
+const toISO = (d: Date) => `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+
+// GET /api/revenue-by-claim-type?window=today|week|month
+// Fees collected per claim type within the given window — the windowed
+// counterpart to Overview's "Revenue by Claim Type" chart, which otherwise
+// only shows an all-time Expected/Collected total (see /api/cases, computed
+// client-side). Only Collected has a window here: "Expected" (the total fee
+// owed) has no time dimension, so callers drop it outside "All Time" rather
+// than divide a day's collections by the full lifetime total owed.
+export const GET = async (req: NextRequest) => {
+  const session = await auth();
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { searchParams } = new URL(req.url);
+  const windowParam = searchParams.get("window");
+  if (!WINDOWS.includes(windowParam as Window)) {
+    return NextResponse.json({ error: "Invalid window" }, { status: 400 });
+  }
+  const w = windowParam as Window;
+
+  try {
+    // Local getters, not toISOString() — matches the convention in
+    // /api/scoreboard so "today"/"this week"/"this month" agree with the
+    // Reports page regardless of the server's own timezone.
+    const now = new Date();
+    let startDate: string;
+    let endExclusive: string;
+    if (w === "today") {
+      startDate = toISO(now);
+      const tomorrow = new Date(now);
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      endExclusive = toISO(tomorrow);
+    } else if (w === "week") {
+      const day = now.getDay();
+      const diff = now.getDate() - day + (day === 0 ? -6 : 1);
+      const monday = new Date(now);
+      monday.setDate(diff);
+      startDate = toISO(monday);
+      const nextMonday = new Date(monday);
+      nextMonday.setDate(nextMonday.getDate() + 7);
+      endExclusive = toISO(nextMonday);
+    } else {
+      const firstOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+      startDate = toISO(firstOfMonth);
+      const firstOfNextMonth = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+      endExclusive = toISO(firstOfNextMonth);
+    }
+
+    // Same ledger + legacy-remainder split as /api/scoreboard's fees-collected
+    // windowing: real fee_payments rows are dated by created_at (the day the
+    // payment was entered — matches Notifications' Payments tab and Reports),
+    // while pre-ledger "legacy" amounts (bulk Sheets/MyCase sync, CSV import)
+    // have no per-payment entry timestamp, so they stay dated by fee_records'
+    // own received-date columns.
+    const rows = (await db.execute(sql`
+      WITH payment_sums AS (
+        SELECT case_id, fee_type, SUM(amount::numeric) AS paid_sum
+        FROM fee_payments
+        GROUP BY case_id, fee_type
+      ),
+      legacy_remainder AS (
+        SELECT
+          fr.case_id,
+          c.claim_type_label,
+          GREATEST(fr.t16_fee_received::numeric - COALESCE(p16.paid_sum, 0), 0) AS t16_remainder,
+          fr.t16_fee_received_date,
+          GREATEST(fr.t2_fee_received::numeric - COALESCE(p2.paid_sum, 0), 0) AS t2_remainder,
+          fr.t2_fee_received_date,
+          GREATEST(fr.aux_fee_received::numeric - COALESCE(pa.paid_sum, 0), 0) AS aux_remainder,
+          fr.aux_fee_received_date
+        FROM fee_records fr
+        JOIN cases c ON c.client_id = fr.case_id
+        LEFT JOIN payment_sums p16 ON p16.case_id = fr.case_id AND p16.fee_type = 't16'
+        LEFT JOIN payment_sums p2  ON p2.case_id  = fr.case_id AND p2.fee_type  = 't2'
+        LEFT JOIN payment_sums pa  ON pa.case_id  = fr.case_id AND pa.fee_type  = 'aux'
+      ),
+      collected_in_window AS (
+        SELECT c.claim_type_label AS claim, fp.amount::numeric AS amt
+        FROM fee_payments fp
+        JOIN cases c ON c.client_id = fp.case_id
+        WHERE fp.created_at >= ${startDate}::date AND fp.created_at < ${endExclusive}::date
+
+        UNION ALL
+
+        SELECT claim_type_label AS claim, t16_remainder AS amt FROM legacy_remainder
+        WHERE t16_fee_received_date >= ${startDate}::date AND t16_fee_received_date < ${endExclusive}::date
+          AND t16_remainder > 0.005
+
+        UNION ALL
+
+        SELECT claim_type_label AS claim, t2_remainder AS amt FROM legacy_remainder
+        WHERE t2_fee_received_date >= ${startDate}::date AND t2_fee_received_date < ${endExclusive}::date
+          AND t2_remainder > 0.005
+
+        UNION ALL
+
+        SELECT claim_type_label AS claim, aux_remainder AS amt FROM legacy_remainder
+        WHERE aux_fee_received_date >= ${startDate}::date AND aux_fee_received_date < ${endExclusive}::date
+          AND aux_remainder > 0.005
+      )
+      SELECT
+        CASE WHEN claim IN ('T2_T16', 'CONCURRENT') THEN 'CONC' ELSE claim END AS claim,
+        SUM(amt)::numeric AS collected
+      FROM collected_in_window
+      WHERE claim IS NOT NULL
+      GROUP BY 1
+    `)) as unknown as { claim: string; collected: string }[];
+
+    const claims = rows.map((r) => ({ claim: r.claim, collected: Number(r.collected) }));
+
+    return NextResponse.json({ window: w, claims });
+  } catch (error) {
+    console.error("GET /api/revenue-by-claim-type error:", error);
+    const msg = error instanceof Error ? error.message : String(error);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+};

--- a/src/app/api/scoreboard/route.ts
+++ b/src/app/api/scoreboard/route.ts
@@ -79,6 +79,14 @@ export const GET = async (req: NextRequest) => {
     // per-payment row at all, so it's treated as a single "legacy" payment
     // dated by the fee_records received-date column, sized as whatever part
     // of the lifetime total isn't already accounted for by real ledger rows.
+    //
+    // Real ledger rows are windowed by fee_payments.created_at — the day the
+    // payment was actually entered — to match Notifications' Payments tab
+    // (see /api/fees-received), not received_date (the business date typed
+    // into "Date Received", which can predate entry by any amount of time).
+    // Legacy remainder rows have no per-payment entry timestamp at all, so
+    // they stay windowed by their existing received-date columns — the best
+    // date available for money that arrived before the ledger existed.
     // The four queries below are mutually independent — none reads another's
     // result — so they are started together and awaited as one batch. Run in
     // series they cost four network round trips to the database, which
@@ -108,7 +116,7 @@ export const GET = async (req: NextRequest) => {
         SELECT fr.assigned_to AS agent, fp.amount::numeric AS amt
         FROM fee_payments fp
         JOIN fee_records fr ON fr.case_id = fp.case_id
-        WHERE fp.received_date >= ${startDate}::date AND fp.received_date < ${endExclusive}::date
+        WHERE fp.created_at >= ${startDate}::date AND fp.created_at < ${endExclusive}::date
 
         UNION ALL
 
@@ -130,9 +138,11 @@ export const GET = async (req: NextRequest) => {
       ),
       -- Fixed-window fees always relative to CURRENT_DATE — used by the team
       -- card "Fees Collected" toggle (Today / This Week / This Month / All Time)
-      -- independently of the scoreboard's selected date window.
+      -- independently of the scoreboard's selected date window. Ledger rows
+      -- are dated by created_at (cast to a date, same as the legacy
+      -- columns below) for the same reason as ledger_in_window above.
       fixed_all_fees AS (
-        SELECT fr.assigned_to AS agent, fp.amount::numeric AS amt, fp.received_date AS d
+        SELECT fr.assigned_to AS agent, fp.amount::numeric AS amt, fp.created_at::date AS d
         FROM fee_payments fp
         JOIN fee_records fr ON fr.case_id = fp.case_id
 

--- a/src/components/cases/RevenuePanel.tsx
+++ b/src/components/cases/RevenuePanel.tsx
@@ -1,10 +1,20 @@
 "use client";
 
+import { useCallback, useEffect, useState } from "react";
 import { useTheme } from "next-themes";
 import { ClaimTypeBarChart } from "@/components/charts/ClaimTypeBarChart";
 import { themeClasses } from "@/lib/theme-classes";
 import { fmtFull } from "@/lib/formatters";
 import type { CaseRow, DashboardSummary } from "@/types";
+
+export type RevenueWindowMode = "today" | "week" | "month" | "alltime";
+
+const WINDOW_LABELS: Record<RevenueWindowMode, string> = {
+  today: "Today",
+  week: "Week",
+  month: "Month",
+  alltime: "All Time",
+};
 
 interface RevenuePanelProps {
   stats: DashboardSummary;
@@ -16,8 +26,52 @@ export const RevenuePanel = ({ stats, cases }: RevenuePanelProps) => {
   const dark = resolvedTheme === "dark";
   const t = themeClasses(dark);
 
+  const [windowMode, setWindowMode] = useState<RevenueWindowMode>("alltime");
+  const [windowedClaims, setWindowedClaims] = useState<{ claim: string; collected: number }[] | null>(null);
+  const [windowLoading, setWindowLoading] = useState(false);
+  const [windowError, setWindowError] = useState<string | null>(null);
+
+  const fetchWindowedClaims = useCallback(
+    async (mode: RevenueWindowMode, signal: AbortSignal, cancelledRef: { current: boolean }) => {
+      setWindowLoading(true);
+      setWindowError(null);
+      try {
+        const res = await fetch(`/api/revenue-by-claim-type?window=${mode}`, { signal });
+        if (!res.ok) throw new Error(`Failed to load revenue by claim type (${res.status})`);
+        const json = await res.json();
+        if (cancelledRef.current) return;
+        setWindowedClaims(json.claims ?? []);
+      } catch (err) {
+        if (cancelledRef.current || (err as Error).name === "AbortError") return;
+        setWindowError((err as Error).message);
+      } finally {
+        if (!cancelledRef.current) setWindowLoading(false);
+      }
+    },
+    [],
+  );
+
+  // "All Time" is derived entirely from the `cases` prop (no fetch, matches
+  // the original always-cumulative view). Any narrower window has no local
+  // data to derive from — fees collected in a day/week/month live only in
+  // the payment ledger, not on the case rows this page already has.
+  useEffect(() => {
+    if (windowMode === "alltime") return;
+    const controller = new AbortController();
+    const cancelledRef = { current: false };
+    fetchWindowedClaims(windowMode, controller.signal, cancelledRef);
+    return () => {
+      cancelledRef.current = true;
+      controller.abort();
+    };
+  }, [windowMode, fetchWindowedClaims]);
+
   // Collection rate = paid / expected. It's a standing ratio (not a delta),
   // so no "+" prefix; color reflects how much of the expected fees are in.
+  // Only meaningful for "All Time" — "expected" (the total fee owed) has no
+  // time dimension, so a windowed rate would read as a day's collections
+  // against the full lifetime total owed rather than anything a team lead
+  // could act on.
   const hasExpected = stats.expected > 0;
   const rate = hasExpected ? (stats.paid / stats.expected) * 100 : 0;
   const rateTone = !hasExpected
@@ -32,26 +86,73 @@ export const RevenuePanel = ({ stats, cases }: RevenuePanelProps) => {
           ? "text-red-400"
           : "text-red-500";
 
+  const windowedTotal = windowedClaims?.reduce((sum, c) => sum + c.collected, 0) ?? 0;
+
   return (
     <div className={`rounded-xl border p-4 md:p-5 ${t.card}`}>
-      <h3 className={`text-sm font-bold ${t.text}`}>Revenue by Claim Type</h3>
-      <div className={`text-2xl font-extrabold ${t.text} mt-1`}>
-        {fmtFull(stats.paid)}
-      </div>
-      <div className={`text-[13px] font-medium mt-0.5 ${rateTone}`}>
-        {hasExpected
-          ? `${rate.toFixed(1)}% collection rate`
-          : "No fees expected yet"}
+      <div className="flex items-center justify-between gap-2">
+        <h3 className={`text-sm font-bold ${t.text}`}>Revenue by Claim Type</h3>
+        <div className={`flex items-center rounded-md border overflow-hidden text-[11px] font-semibold shrink-0 ${dark ? "border-neutral-700" : "border-neutral-200"}`}>
+          {(["today", "week", "month", "alltime"] as const).map((mode) => {
+            const active = windowMode === mode;
+            return (
+              <button
+                key={mode}
+                onClick={() => setWindowMode(mode)}
+                aria-pressed={active}
+                className={`px-2.5 py-1 transition-colors ${
+                  active
+                    ? dark
+                      ? "bg-emerald-700 text-white"
+                      : "bg-emerald-600 text-white"
+                    : dark
+                      ? "text-neutral-400 hover:bg-neutral-800"
+                      : "text-neutral-500 hover:bg-neutral-50"
+                }`}
+              >
+                {WINDOW_LABELS[mode]}
+              </button>
+            );
+          })}
+        </div>
       </div>
 
-      <div className="mt-4">
-        <ClaimTypeBarChart cases={cases} />
+      {windowMode === "alltime" ? (
+        <>
+          <div className={`text-2xl font-extrabold ${t.text} mt-1`}>
+            {fmtFull(stats.paid)}
+          </div>
+          <div className={`text-[13px] font-medium mt-0.5 ${rateTone}`}>
+            {hasExpected
+              ? `${rate.toFixed(1)}% collection rate`
+              : "No fees expected yet"}
+          </div>
+        </>
+      ) : windowError ? (
+        <div className={`text-[13px] mt-1 ${dark ? "text-red-400" : "text-red-500"}`} role="alert">
+          {windowError}
+        </div>
+      ) : (
+        <>
+          <div className={`text-2xl font-extrabold ${t.text} mt-1`}>
+            {fmtFull(windowedTotal)}
+          </div>
+          <div className={`text-[13px] font-medium mt-0.5 ${t.textMuted}`}>
+            Collected — {WINDOW_LABELS[windowMode]}
+          </div>
+        </>
+      )}
+
+      <div className="mt-4" aria-busy={windowLoading}>
+        <ClaimTypeBarChart cases={cases} windowedClaims={windowMode === "alltime" ? null : windowedClaims} />
       </div>
       <div className="mt-3 flex items-center gap-4 justify-center">
-        <span className={`flex items-center gap-1.5 text-[12px] ${t.textSub}`}>
-          <span className="w-2.5 h-2.5 rounded-sm bg-indigo-400 opacity-30" />{" "}
-          Expected
-        </span>
+        {windowMode === "alltime" && (
+          <span className={`flex items-center gap-1.5 text-[12px] ${t.textSub}`}>
+            <span className="w-2.5 h-2.5 rounded-sm bg-indigo-400 opacity-30" />{" "}
+            Expected
+          </span>
+        )}
         <span className={`flex items-center gap-1.5 text-[12px] ${t.textSub}`}>
           <span className="w-2.5 h-2.5 rounded-sm bg-emerald-500" /> Collected
         </span>

--- a/src/components/cases/__tests__/RevenuePanel.test.tsx
+++ b/src/components/cases/__tests__/RevenuePanel.test.tsx
@@ -1,0 +1,121 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import { RevenuePanel } from "../RevenuePanel";
+import type { CaseRow, DashboardSummary } from "@/types";
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ resolvedTheme: "light" }),
+}));
+
+const SUMMARY: DashboardSummary = {
+  totalCases: 10,
+  expected: 838_486.81,
+  paid: 373_923,
+  outstanding: 464_563.81,
+  pif: 2,
+  syncErrors: 0,
+  synced: 10,
+  feesCollectedMTD: 0,
+  casesClosedMTD: 0,
+};
+
+const CASE: CaseRow = {
+  id: 1,
+  name: "Watson, Katrina",
+  externalId: null,
+  chronicleId: null,
+  assigned: "Test Agent",
+  level: "HEARING",
+  claim: "T16",
+  date: "2026-01-15",
+  status: "not_started",
+  createdAt: "2026-01-15T00:00:00.000Z",
+  t16Retro: 10000, t16FeeDue: 2500, t16FeeReceived: 0, t16Pending: 2500, t16FeeReceivedDate: null,
+  t2Retro: 0,    t2FeeDue: null,   t2FeeReceived: 0,  t2Pending: 0,    t2FeeReceivedDate: null,
+  auxRetro: 0,   auxFeeDue: null,  auxFeeReceived: 0, auxPending: 0,   auxFeeReceivedDate: null,
+  totalRetroDue: 10000,
+  expected: 2500,
+  paid: 0,
+  pif: null,
+  approvedBy: null,
+  feesConfirmation: null,
+  feesClosedTrigger: null,
+  caseStatus: null,
+  nextFollowUpDate: null,
+  isClosed: false,
+  markedOverpaid: false,
+  closedAt: null,
+  update: "",
+  sync: "synced",
+  daysAfterApproval: 30,
+  approvalCategory: null,
+  feesStatus: null,
+  weekAssignedToAgent: null,
+  monthAssignedToAgent: null,
+  office: "Test Office",
+  notesCount: 0,
+  leaderNotesCount: 0,
+  caseLink: null,
+  winSheetLink: null,
+  winSheetLinkText: null,
+};
+
+describe("RevenuePanel — window toggle", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("defaults to All Time: lifetime paid total, collection rate, no fetch", () => {
+    render(<RevenuePanel stats={SUMMARY} cases={[CASE]} />);
+    expect(screen.getByRole("button", { name: "All Time" }).getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByText(/44\.6%/)).toBeTruthy();
+    expect(screen.getByText("Expected")).toBeTruthy();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("fetches the windowed total when a narrower preset is clicked", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ window: "month", claims: [{ claim: "T2", collected: 12_400 }, { claim: "T16", collected: 3_100 }] }),
+    });
+    render(<RevenuePanel stats={SUMMARY} cases={[CASE]} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Month" }));
+
+    expect(fetch).toHaveBeenCalledWith("/api/revenue-by-claim-type?window=month", expect.anything());
+    await waitFor(() => expect(screen.getByText(/Collected — Month/)).toBeTruthy());
+    expect(screen.getByText(/15,500/)).toBeTruthy(); // windowed total = 12,400 + 3,100
+    // "Expected" legend disappears — there's nothing windowed to pair it with.
+    expect(screen.queryByText("Expected")).toBeNull();
+  });
+
+  it("shows an alert and keeps the toggle usable when the fetch fails", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ok: false, status: 500 });
+    render(<RevenuePanel stats={SUMMARY} cases={[CASE]} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Week" }));
+
+    await waitFor(() => expect(screen.getByRole("alert")).toBeTruthy());
+    expect(screen.getByRole("alert").textContent).toContain("500");
+  });
+
+  it("switching back to All Time drops the fetched window without refetching", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ window: "today", claims: [{ claim: "T2", collected: 900 }] }),
+    });
+    render(<RevenuePanel stats={SUMMARY} cases={[CASE]} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Today" }));
+    await waitFor(() => expect(screen.getByText(/Collected — Today/)).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("button", { name: "All Time" }));
+    expect(screen.getByText(/44\.6%/)).toBeTruthy();
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/charts/ClaimTypeBarChart.tsx
+++ b/src/components/charts/ClaimTypeBarChart.tsx
@@ -5,6 +5,11 @@ import type { CaseRow } from "@/types";
 
 interface ClaimTypeBarChartProps {
   cases: CaseRow[];
+  /** Collected-in-window totals per claim type. When set (any window other
+   *  than "All Time"), the chart renders a single Collected bar per claim
+   *  type instead of the Expected/Collected pair — "Expected" (the total
+   *  fee owed) has no time dimension, so there's nothing to pair it with. */
+  windowedClaims?: { claim: string; collected: number }[] | null;
 }
 
 // Preferred display order for the known worksheet claim types. Any other
@@ -12,7 +17,57 @@ interface ClaimTypeBarChartProps {
 // these, alphabetically — so nothing silently drops out of the chart.
 const CLAIM_ORDER = ["T2", "T16", "CONC", "DWB", "DAC", "AUX"];
 
-export const ClaimTypeBarChart = ({ cases }: ClaimTypeBarChartProps) => {
+const sortByClaimOrder = <T extends { label: string }>(bars: T[]): T[] =>
+  [...bars].sort((a, b) => {
+    const ai = CLAIM_ORDER.indexOf(a.label);
+    const bi = CLAIM_ORDER.indexOf(b.label);
+    if (ai !== -1 && bi !== -1) return ai - bi; // both known → fixed order
+    if (ai !== -1) return -1; // known before unknown
+    if (bi !== -1) return 1;
+    return a.label.localeCompare(b.label); // unknowns alphabetical
+  });
+
+export const ClaimTypeBarChart = ({ cases, windowedClaims }: ClaimTypeBarChartProps) => {
+  if (windowedClaims) {
+    const bars = sortByClaimOrder(
+      windowedClaims
+        .filter((c) => c.claim && c.claim !== "—")
+        .map((c) => ({ label: c.claim, collected: c.collected })),
+    );
+
+    if (bars.length === 0) {
+      return (
+        <div className="flex items-center justify-center h-36 text-[13px] text-neutral-400 dark:text-neutral-500">
+          No fees collected in this window yet
+        </div>
+      );
+    }
+
+    const maxVal = Math.max(...bars.map((b) => b.collected), 1);
+
+    return (
+      <div className="flex items-end gap-6 justify-center h-36 px-4 overflow-x-auto">
+        {bars.map((b) => (
+          <div key={b.label} className="flex flex-col items-center gap-1 shrink-0">
+            <span className="text-[12px] text-neutral-400 dark:text-neutral-500 font-medium">
+              {fmt(b.collected)}
+            </span>
+            <div
+              className="w-8 rounded-t"
+              style={{
+                height: (b.collected / maxVal) * 100 || 2,
+                background: "#10b981",
+              }}
+            />
+            <span className="text-[13px] text-neutral-500 dark:text-neutral-400 font-medium">
+              {b.label}
+            </span>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
   // Aggregate expected/paid per claim type as it actually appears in the
   // data (the API maps T2_T16 → "CONC"). Skip unknown/empty ("—").
   const totals = new Map<string, { expected: number; paid: number }>();
@@ -25,16 +80,7 @@ export const ClaimTypeBarChart = ({ cases }: ClaimTypeBarChartProps) => {
     totals.set(label, cur);
   });
 
-  const bars = Array.from(totals.entries())
-    .map(([label, v]) => ({ label, ...v }))
-    .sort((a, b) => {
-      const ai = CLAIM_ORDER.indexOf(a.label);
-      const bi = CLAIM_ORDER.indexOf(b.label);
-      if (ai !== -1 && bi !== -1) return ai - bi; // both known → fixed order
-      if (ai !== -1) return -1; // known before unknown
-      if (bi !== -1) return 1;
-      return a.label.localeCompare(b.label); // unknowns alphabetical
-    });
+  const bars = sortByClaimOrder(Array.from(totals.entries()).map(([label, v]) => ({ label, ...v })));
 
   if (bars.length === 0) {
     return (

--- a/src/components/charts/__tests__/ClaimTypeBarChart.test.tsx
+++ b/src/components/charts/__tests__/ClaimTypeBarChart.test.tsx
@@ -1,0 +1,110 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { ClaimTypeBarChart } from "../ClaimTypeBarChart";
+import type { CaseRow } from "@/types";
+
+const BASE_CASE: CaseRow = {
+  id: 1,
+  name: "Watson, Katrina",
+  externalId: null,
+  chronicleId: null,
+  assigned: "Test Agent",
+  level: "HEARING",
+  claim: "T16",
+  date: "2026-01-15",
+  status: "not_started",
+  createdAt: "2026-01-15T00:00:00.000Z",
+  t16Retro: 10000, t16FeeDue: 2500, t16FeeReceived: 0, t16Pending: 2500, t16FeeReceivedDate: null,
+  t2Retro: 0,    t2FeeDue: null,   t2FeeReceived: 0,  t2Pending: 0,    t2FeeReceivedDate: null,
+  auxRetro: 0,   auxFeeDue: null,  auxFeeReceived: 0, auxPending: 0,   auxFeeReceivedDate: null,
+  totalRetroDue: 10000,
+  expected: 2500,
+  paid: 0,
+  pif: null,
+  approvedBy: null,
+  feesConfirmation: null,
+  feesClosedTrigger: null,
+  caseStatus: null,
+  nextFollowUpDate: null,
+  isClosed: false,
+  markedOverpaid: false,
+  closedAt: null,
+  update: "",
+  sync: "synced",
+  daysAfterApproval: 30,
+  approvalCategory: null,
+  feesStatus: null,
+  weekAssignedToAgent: null,
+  monthAssignedToAgent: null,
+  office: "Test Office",
+  notesCount: 0,
+  leaderNotesCount: 0,
+  caseLink: null,
+  winSheetLink: null,
+  winSheetLinkText: null,
+};
+
+const caseWith = (overrides: Partial<CaseRow>): CaseRow => ({ ...BASE_CASE, ...overrides });
+
+describe("ClaimTypeBarChart — All Time (cases prop)", () => {
+  afterEach(cleanup);
+
+  it("aggregates expected/paid per claim type and shows both bars' labels", () => {
+    render(
+      <ClaimTypeBarChart
+        cases={[
+          caseWith({ id: 1, claim: "T16", expected: 300_656, paid: 656 }),
+          caseWith({ id: 2, claim: "T2", expected: 792_636, paid: 499_500 }),
+        ]}
+      />,
+    );
+    expect(screen.getByText("T16")).toBeTruthy();
+    expect(screen.getByText("T2")).toBeTruthy();
+    expect(screen.getByText(/300,656/)).toBeTruthy();
+    expect(screen.getByText(/792,636/)).toBeTruthy();
+  });
+
+  it("skips cases with no claim type", () => {
+    render(<ClaimTypeBarChart cases={[caseWith({ claim: "—" })]} />);
+    expect(screen.getByText(/No claim-type data yet/)).toBeTruthy();
+  });
+});
+
+describe("ClaimTypeBarChart — windowed (collected-only)", () => {
+  afterEach(cleanup);
+
+  it("renders a single Collected bar per claim type, no Expected pair", () => {
+    const { container } = render(
+      <ClaimTypeBarChart
+        cases={[]}
+        windowedClaims={[
+          { claim: "T2", collected: 12_400 },
+          { claim: "T16", collected: 3_100 },
+        ]}
+      />,
+    );
+    expect(screen.getByText("T2")).toBeTruthy();
+    expect(screen.getByText("T16")).toBeTruthy();
+    expect(screen.getByText(/12,400/)).toBeTruthy();
+    // Exactly one bar element per claim type — no second (Expected) bar.
+    const bars = container.querySelectorAll('div[style*="background: rgb(16, 185, 129)"], div[style*="background: #10b981"]');
+    expect(bars.length).toBe(2);
+  });
+
+  it("shows an empty state when nothing was collected in the window", () => {
+    render(<ClaimTypeBarChart cases={[]} windowedClaims={[]} />);
+    expect(screen.getByText(/No fees collected in this window yet/)).toBeTruthy();
+  });
+
+  it("ignores the cases prop entirely once windowedClaims is set", () => {
+    render(
+      <ClaimTypeBarChart
+        cases={[caseWith({ claim: "CONC", expected: 999_999, paid: 1 })]}
+        windowedClaims={[{ claim: "T2", collected: 500 }]}
+      />,
+    );
+    expect(screen.queryByText("CONC")).toBeNull();
+    expect(screen.getByText("T2")).toBeTruthy();
+  });
+});

--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -412,6 +412,11 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
   const weekDays = getWeekDays(monday);
 
   const todayEt = new Intl.DateTimeFormat("en-CA", { timeZone: "America/New_York" }).format(new Date());
+  const yesterdayEt = (() => {
+    const [y, m, d] = todayEt.split("-").map(Number);
+    const date = new Date(y, m - 1, d - 1);
+    return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+  })();
 
   // Days shown in the entry panel — 5 weekdays in week mode, one day in day mode.
   const entryDays =
@@ -446,17 +451,22 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
   const teamWindowMode: TeamWindowMode | null =
     dateMode === "day" && daySel === todayEt
       ? "today"
-      : dateMode === "week" && weekOffset === 0
-        ? "week"
-        : dateMode === "month" && monthSel === nowForInit.getMonth() && yearSel === nowForInit.getFullYear()
-          ? "month"
-          : dateMode === "range" && rangeFrom === ALL_TIME_START && rangeTo === todayEt
-            ? "alltime"
-            : null;
+      : dateMode === "day" && daySel === yesterdayEt
+        ? "yesterday"
+        : dateMode === "week" && weekOffset === 0
+          ? "week"
+          : dateMode === "month" && monthSel === nowForInit.getMonth() && yearSel === nowForInit.getFullYear()
+            ? "month"
+            : dateMode === "range" && rangeFrom === ALL_TIME_START && rangeTo === todayEt
+              ? "alltime"
+              : null;
 
   const changeTeamWindow = (mode: TeamWindowMode) => {
     if (mode === "today") {
       setDaySel(todayEt);
+      changeDateMode("day");
+    } else if (mode === "yesterday") {
+      setDaySel(yesterdayEt);
       changeDateMode("day");
     } else if (mode === "week") {
       setWeekOffset(0);
@@ -475,7 +485,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
   const windowLabel =
     dateMode === "day"
       ? daySel
-        ? fmtRangeDate(daySel) + (daySel === todayEt ? " (Today)" : "")
+        ? fmtRangeDate(daySel) + (daySel === todayEt ? " (Today)" : daySel === yesterdayEt ? " (Yesterday)" : "")
         : "Select a date"
       : dateMode === "month"
         ? `${MONTH_NAMES[monthSel]} ${yearSel}`
@@ -738,6 +748,12 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
             showMiniCards={false}
             windowMode={teamWindowMode}
             onWindowChange={changeTeamWindow}
+            selectedDate={daySel}
+            onDateSelect={(date) => {
+              setDaySel(date);
+              changeDateMode("day");
+            }}
+            maxDate={todayEt}
             loading={loading}
           />
         </div>

--- a/src/components/scoreboard/ScoreboardSummaryCards.tsx
+++ b/src/components/scoreboard/ScoreboardSummaryCards.tsx
@@ -48,10 +48,11 @@ export interface ScoreboardTeam {
 
 // Presets offered by the By Team window toggle. They map onto the page's own
 // date window — the toggle scopes every tile on the card, not just the fees.
-export type TeamWindowMode = "today" | "week" | "month" | "alltime";
+export type TeamWindowMode = "today" | "yesterday" | "week" | "month" | "alltime";
 
 const TEAM_WINDOW_LABELS: Record<TeamWindowMode, string> = {
   today: "Today",
+  yesterday: "Yesterday",
   week: "Week",
   month: "Month",
   alltime: "All Time",
@@ -68,6 +69,12 @@ interface ScoreboardSummaryCardsProps {
    *  (an arbitrary range, or any week/month other than the current). */
   windowMode: TeamWindowMode | null;
   onWindowChange: (mode: TeamWindowMode) => void;
+  /** The single day the "pick a date" control is showing — always the page's
+   *  `daySel`, regardless of whether day mode is the active window. */
+  selectedDate: string;
+  onDateSelect: (date: string) => void;
+  /** Latest date selectable — the picker mirrors the page's own day-nav cap. */
+  maxDate: string;
   /** A refetch is in flight — the figures on screen are the previous window's. */
   loading?: boolean;
 }
@@ -81,6 +88,9 @@ export function ScoreboardSummaryCards({
   showMiniCards = true,
   windowMode,
   onWindowChange,
+  selectedDate,
+  onDateSelect,
+  maxDate,
   loading = false,
 }: ScoreboardSummaryCardsProps) {
   const [t2Days, setT2Days] = useState<60 | 90>(60);
@@ -96,7 +106,13 @@ export function ScoreboardSummaryCards({
   // Every tile on the card covers the page window, so the fees figure is the
   // window-scoped total rather than a separately chosen period.
   const feesLabel = windowMode
-    ? { today: "Fees Today", week: "Fees This Week", month: "Fees This Month", alltime: "Fees All Time" }[windowMode]
+    ? {
+        today: "Fees Today",
+        yesterday: "Fees Yesterday",
+        week: "Fees This Week",
+        month: "Fees This Month",
+        alltime: "Fees All Time",
+      }[windowMode]
     : "Fees";
 
   const copyByTeam = (format: "sheets" | "chat" | "teams") => {
@@ -231,7 +247,7 @@ export function ScoreboardSummaryCards({
               )}
               {/* Window toggle — scopes every tile on the card, not just fees */}
               <div className={`flex items-center rounded-md border overflow-hidden text-[11px] font-semibold ${dark ? "border-neutral-700" : "border-neutral-200"}`}>
-                {(["today", "week", "month", "alltime"] as const).map((mode) => {
+                {(["today", "yesterday", "week", "month", "alltime"] as const).map((mode) => {
                   const active = windowMode === mode;
                   return (
                     <button
@@ -249,6 +265,17 @@ export function ScoreboardSummaryCards({
                   );
                 })}
               </div>
+              {/* Pick any specific day — sets the window to that day regardless
+                  of which preset (if any) is currently active. */}
+              <input
+                type="date"
+                value={selectedDate}
+                max={maxDate}
+                onChange={(e) => e.target.value && onDateSelect(e.target.value)}
+                aria-label="By Team — pick a specific date"
+                title="Pick a specific date"
+                className={`h-[26px] px-2 rounded-md border text-[11px] outline-none cursor-pointer ${dark ? "bg-neutral-900 border-neutral-700 text-neutral-300" : "bg-white border-neutral-200 text-neutral-600"}`}
+              />
               {/* Copy buttons */}
               <button
                 onClick={() => copyByTeam("sheets")}

--- a/src/components/scoreboard/__tests__/ScoreboardSummaryCards.test.tsx
+++ b/src/components/scoreboard/__tests__/ScoreboardSummaryCards.test.tsx
@@ -39,8 +39,9 @@ const T2: ScoreboardTeam = {
 };
 
 const renderCards = (
-  windowMode: "today" | "week" | "month" | "alltime" | null,
+  windowMode: "today" | "yesterday" | "week" | "month" | "alltime" | null,
   onWindowChange = vi.fn(),
+  onDateSelect = vi.fn(),
 ) => {
   const utils = render(
     <ScoreboardSummaryCards
@@ -52,9 +53,12 @@ const renderCards = (
       showMiniCards={false}
       windowMode={windowMode}
       onWindowChange={onWindowChange}
+      selectedDate="2026-08-07"
+      onDateSelect={onDateSelect}
+      maxDate="2026-08-07"
     />,
   );
-  return { ...utils, onWindowChange };
+  return { ...utils, onWindowChange, onDateSelect };
 };
 
 describe("ScoreboardSummaryCards — By Team window", () => {
@@ -76,7 +80,7 @@ describe("ScoreboardSummaryCards — By Team window", () => {
 
   it("highlights nothing when the window matches no preset", () => {
     renderCards(null);
-    for (const name of ["Today", "Week", "Month", "All Time"]) {
+    for (const name of ["Today", "Yesterday", "Week", "Month", "All Time"]) {
       expect(screen.getByRole("button", { name }).getAttribute("aria-pressed")).toBe("false");
     }
   });
@@ -87,9 +91,23 @@ describe("ScoreboardSummaryCards — By Team window", () => {
     expect(onWindowChange).toHaveBeenCalledWith("month");
   });
 
+  it("offers a Yesterday preset so team leads can compare it against Today", () => {
+    const { onWindowChange } = renderCards("today");
+    expect(screen.getByRole("button", { name: "Yesterday" }).getAttribute("aria-pressed")).toBe("false");
+    fireEvent.click(screen.getByRole("button", { name: "Yesterday" }));
+    expect(onWindowChange).toHaveBeenCalledWith("yesterday");
+  });
+
   it("states the window it is showing, so the period is never implicit", () => {
     renderCards("today");
     expect(screen.getByText(/By Team/).textContent).toContain("Fri Aug 7");
+  });
+
+  it("lets a team lead pick an arbitrary date outside the presets", () => {
+    const { onDateSelect } = renderCards("today");
+    const picker = screen.getByLabelText("By Team — pick a specific date");
+    fireEvent.change(picker, { target: { value: "2026-07-30" } });
+    expect(onDateSelect).toHaveBeenCalledWith("2026-07-30");
   });
 });
 
@@ -101,7 +119,8 @@ describe("ScoreboardSummaryCards — refetch feedback", () => {
       <ScoreboardSummaryCards
         summary={SUMMARY} teams={[T2]} label="Week" dark={false}
         t={themeClasses(false)} showMiniCards={false}
-        windowMode="week" onWindowChange={vi.fn()} loading
+        windowMode="week" onWindowChange={vi.fn()}
+        selectedDate="2026-08-07" onDateSelect={vi.fn()} maxDate="2026-08-07" loading
       />,
     );
     expect(screen.getByText(/Updating/)).toBeTruthy();
@@ -113,7 +132,8 @@ describe("ScoreboardSummaryCards — refetch feedback", () => {
       <ScoreboardSummaryCards
         summary={SUMMARY} teams={[T2]} label="Week" dark={false}
         t={themeClasses(false)} showMiniCards={false}
-        windowMode="week" onWindowChange={vi.fn()} loading
+        windowMode="week" onWindowChange={vi.fn()}
+        selectedDate="2026-08-07" onDateSelect={vi.fn()} maxDate="2026-08-07" loading
       />,
     );
     // 174 open cases is still readable mid-refetch — a spinner replacing the
@@ -127,6 +147,7 @@ describe("ScoreboardSummaryCards — refetch feedback", () => {
         summary={SUMMARY} teams={[T2]} label="Week" dark={false}
         t={themeClasses(false)} showMiniCards={false}
         windowMode="week" onWindowChange={vi.fn()}
+        selectedDate="2026-08-07" onDateSelect={vi.fn()} maxDate="2026-08-07"
       />,
     );
     expect(screen.queryByText(/Updating/)).toBeNull();


### PR DESCRIPTION
Syncs all changes from develop into main.

## Changes included (since last sync)

- Fix: fees-collected figures now windowed by payment entry date (`created_at`), matching Notifications' Payments tab, instead of the business "date received" (#416)
- Feature: Overview's "Revenue by Claim Type" chart gained a Today/Week/Month/All Time toggle to compare against Reports (#417)
- Feature: Reports' By Team card gained a "Yesterday" preset and a date picker for comparing any specific day (#412)

Audited: lint clean, 149/149 tests passing, build clean (edge/middleware bundle unaffected). No schema/migration changes, no new mutations, no PII exposure.