### PR TITLE
fix: match Revenue by Team to Reports, bring back a graph

### DIFF
--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -14,10 +14,8 @@ const toISO = (d: Date) => d.toISOString().slice(0, 10);
 
 export default function OverviewPage() {
   const {
-    cases,
     summary,
     monthlyData,
-    team,
     loading,
     error,
     refresh,
@@ -86,7 +84,7 @@ export default function OverviewPage() {
       <StatCards stats={summary} />
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-3 md:gap-4">
         <CollectionsPanel data={monthlyData} />
-        <RevenuePanel stats={summary} cases={cases} team={team} />
+        <RevenuePanel />
       </div>
       {recentActivities.length > 0 && (
         <RecentActivityFeed

--- a/src/app/api/revenue-by-team/route.ts
+++ b/src/app/api/revenue-by-team/route.ts
@@ -3,23 +3,28 @@ import { auth } from "@/auth";
 import { db } from "@/lib/db";
 import { sql } from "drizzle-orm";
 
-const WINDOWS = ["today", "week", "month"] as const;
+const WINDOWS = ["today", "week", "month", "alltime"] as const;
 type Window = (typeof WINDOWS)[number];
 
 const pad = (n: number) => String(n).padStart(2, "0");
 const toISO = (d: Date) => `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
 
-// GET /api/revenue-by-team?window=today|week|month
-// Fees collected per staff team within the given window — the windowed
-// counterpart to Overview's "Revenue by Team" chart, which otherwise only
-// shows an all-time Expected/Collected total (see /api/cases + /api/team-members,
-// computed client-side). Only Collected has a window here: "Expected" (the
-// total fee owed) has no time dimension, so callers drop it outside "All
-// Time" rather than divide a day's collections by the full lifetime total owed.
+// GET /api/revenue-by-team?window=today|week|month|alltime
+// Fees collected per staff team, for Overview's "Revenue by Team" chart.
 //
 // Grouped by staff team (T2/T16/Concurrent — same restriction as Reports'
 // TEAM_ORDER in /api/scoreboard), not by case claim type, so this matches
 // Reports' By Team card exactly rather than the case-level claim taxonomy.
+//
+// "alltime" sums the DB-trigger-maintained total_fees_expected/total_fees_paid
+// across every case assigned to the team, open or closed — the same lifetime
+// total Reports' team card shows (scoreboard's total_collected). Overview
+// previously computed its "All Time" bars client-side from the open-cases-only
+// /api/cases list, which silently dropped every closed case's collected fees
+// and read lower than Reports for any team with real closed-case history.
+// today/week/month only have Collected — "Expected" (the total fee owed) has
+// no time dimension, so a windowed rate would divide a day's collections by
+// the full lifetime total owed rather than anything actionable.
 export const GET = async (req: NextRequest) => {
   const session = await auth();
   if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -32,6 +37,27 @@ export const GET = async (req: NextRequest) => {
   const w = windowParam as Window;
 
   try {
+    if (w === "alltime") {
+      const rows = (await db.execute(sql`
+        SELECT
+          tm.team AS team,
+          COALESCE(SUM(fr.total_fees_paid::numeric), 0) AS collected,
+          COALESCE(SUM(fr.total_fees_expected::numeric), 0) AS expected
+        FROM fee_records fr
+        LEFT JOIN team_members tm ON tm.name = fr.assigned_to
+        WHERE tm.team IN ('T2', 'T16', 'Concurrent')
+        GROUP BY tm.team
+      `)) as unknown as { team: string; collected: string; expected: string }[];
+
+      const teams = rows.map((r) => ({
+        team: r.team,
+        collected: Number(r.collected),
+        expected: Number(r.expected),
+      }));
+
+      return NextResponse.json({ window: w, teams });
+    }
+
     // Local getters, not toISOString() — matches the convention in
     // /api/scoreboard so "today"/"this week"/"this month" agree with the
     // Reports page regardless of the server's own timezone.

--- a/src/components/cases/RevenuePanel.tsx
+++ b/src/components/cases/RevenuePanel.tsx
@@ -69,6 +69,10 @@ export const RevenuePanel = () => {
   );
 
   useEffect(() => {
+    // Drop the previous window's data immediately on switch — otherwise the
+    // old team figures stay on screen (under the new window's label) until
+    // the new fetch resolves, which reads as real data for the wrong window.
+    setTeamsData(null);
     const controller = new AbortController();
     const cancelledRef = { current: false };
     fetchTeams(windowMode, controller.signal, cancelledRef);
@@ -162,19 +166,21 @@ export const RevenuePanel = () => {
         </>
       )}
 
-      <div className="mt-4" aria-busy={windowLoading}>
-        {!windowError && windowLoading && !teamsData ? (
-          <div className="flex items-center justify-center h-24 text-[13px] text-neutral-400 dark:text-neutral-500">
-            Loading…
-          </div>
-        ) : (
-          <TeamRevenueStats
-            dark={dark}
-            bars={bars}
-            windowedTeams={windowMode === "alltime" ? null : teamsData}
-          />
-        )}
-      </div>
+      {!windowError && (
+        <div className="mt-4" aria-busy={windowLoading}>
+          {windowLoading && !teamsData ? (
+            <div className="flex items-center justify-center h-24 text-[13px] text-neutral-400 dark:text-neutral-500">
+              Loading…
+            </div>
+          ) : (
+            <TeamRevenueStats
+              dark={dark}
+              bars={bars}
+              windowedTeams={windowMode === "alltime" ? null : teamsData}
+            />
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/cases/RevenuePanel.tsx
+++ b/src/components/cases/RevenuePanel.tsx
@@ -5,7 +5,6 @@ import { useTheme } from "next-themes";
 import { TeamRevenueStats, type TeamRevenueBar } from "@/components/cases/TeamRevenueStats";
 import { themeClasses } from "@/lib/theme-classes";
 import { fmtFull } from "@/lib/formatters";
-import type { CaseRow, DashboardSummary, TeamMember } from "@/types";
 
 export type RevenueWindowMode = "today" | "week" | "month" | "alltime";
 
@@ -21,23 +20,31 @@ const WINDOW_LABELS: Record<RevenueWindowMode, string> = {
 // belong on a revenue-by-team chart.
 const TEAM_ORDER = ["T2", "T16", "Concurrent"];
 
-interface RevenuePanelProps {
-  stats: DashboardSummary;
-  cases: CaseRow[];
-  team: TeamMember[];
+interface TeamEntry {
+  team: string;
+  collected: number;
+  /** Only present for "alltime" — today/week/month have no time dimension
+   *  to pair Expected against (see /api/revenue-by-team). */
+  expected?: number;
 }
 
-export const RevenuePanel = ({ stats, cases, team }: RevenuePanelProps) => {
+// Every window — including "All Time" — is fetched from /api/revenue-by-team
+// rather than aggregated client-side from the open-cases-only /api/cases
+// list. All Time in particular sums total_fees_paid/total_fees_expected
+// across every case (open or closed), the same lifetime figure Reports' team
+// card shows — the previous client-side aggregate silently dropped every
+// closed case's collected fees and read lower than Reports.
+export const RevenuePanel = () => {
   const { resolvedTheme } = useTheme();
   const dark = resolvedTheme === "dark";
   const t = themeClasses(dark);
 
   const [windowMode, setWindowMode] = useState<RevenueWindowMode>("alltime");
-  const [windowedTeams, setWindowedTeams] = useState<{ team: string; collected: number }[] | null>(null);
+  const [teamsData, setTeamsData] = useState<TeamEntry[] | null>(null);
   const [windowLoading, setWindowLoading] = useState(false);
   const [windowError, setWindowError] = useState<string | null>(null);
 
-  const fetchWindowedTeams = useCallback(
+  const fetchTeams = useCallback(
     async (mode: RevenueWindowMode, signal: AbortSignal, cancelledRef: { current: boolean }) => {
       setWindowLoading(true);
       setWindowError(null);
@@ -46,12 +53,11 @@ export const RevenuePanel = ({ stats, cases, team }: RevenuePanelProps) => {
         if (!res.ok) throw new Error(`Failed to load revenue by team (${res.status})`);
         const json = await res.json();
         if (cancelledRef.current) return;
-        // SQL's GROUP BY gives no ordering guarantee — sort to the same
-        // TEAM_ORDER as the "All Time" bars so the row order doesn't jump
-        // around between windows.
-        const teams: { team: string; collected: number }[] = json.teams ?? [];
+        // SQL's GROUP BY gives no ordering guarantee — sort to a fixed
+        // display order so rows don't jump around between windows.
+        const teams: TeamEntry[] = json.teams ?? [];
         teams.sort((a, b) => TEAM_ORDER.indexOf(a.team) - TEAM_ORDER.indexOf(b.team));
-        setWindowedTeams(teams);
+        setTeamsData(teams);
       } catch (err) {
         if (cancelledRef.current || (err as Error).name === "AbortError") return;
         setWindowError((err as Error).message);
@@ -62,58 +68,33 @@ export const RevenuePanel = ({ stats, cases, team }: RevenuePanelProps) => {
     [],
   );
 
-  // "All Time" is derived entirely from the `cases`/`team` props (no fetch,
-  // matches the original always-cumulative view). Any narrower window has no
-  // local data to derive from — fees collected in a day/week/month live only
-  // in the payment ledger, not on the case rows this page already has.
   useEffect(() => {
-    if (windowMode === "alltime") return;
     const controller = new AbortController();
     const cancelledRef = { current: false };
-    fetchWindowedTeams(windowMode, controller.signal, cancelledRef);
+    fetchTeams(windowMode, controller.signal, cancelledRef);
     return () => {
       cancelledRef.current = true;
       controller.abort();
     };
-  }, [windowMode, fetchWindowedTeams]);
+  }, [windowMode, fetchTeams]);
 
-  // Expected/Collected per team, for "All Time" — a case's team comes from
-  // its assigned agent's roster entry, not a field on the case itself. Team
-  // leads stay included (they aren't filtered here), matching Reports' own
-  // team rollup in /api/scoreboard, which only excludes them from the
-  // per-agent table, not the team totals.
-  const teamByAgent = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const m of team) {
-      if (m.team) map.set(m.name, m.team);
-    }
-    return map;
-  }, [team]);
-
+  // All Time pairs Expected with Collected (for the per-team progress bars);
+  // today/week/month only ever carry Collected.
   const bars = useMemo<TeamRevenueBar[]>(() => {
-    const totals = new Map<string, { expected: number; paid: number }>();
-    for (const c of cases) {
-      const teamName = teamByAgent.get(c.assigned);
-      if (!teamName || !TEAM_ORDER.includes(teamName)) continue;
-      const cur = totals.get(teamName) ?? { expected: 0, paid: 0 };
-      cur.expected += c.expected;
-      cur.paid += c.paid;
-      totals.set(teamName, cur);
-    }
-    return TEAM_ORDER.filter((name) => totals.has(name)).map((name) => ({
-      team: name,
-      ...totals.get(name)!,
-    }));
-  }, [cases, teamByAgent]);
+    if (windowMode !== "alltime" || !teamsData) return [];
+    return teamsData.map((tm) => ({ team: tm.team, expected: tm.expected ?? 0, paid: tm.collected }));
+  }, [windowMode, teamsData]);
+
+  const totalCollected = teamsData?.reduce((sum, tm) => sum + tm.collected, 0) ?? 0;
+  const totalExpected = teamsData?.reduce((sum, tm) => sum + (tm.expected ?? 0), 0) ?? 0;
 
   // Collection rate = paid / expected. It's a standing ratio (not a delta),
   // so no "+" prefix; color reflects how much of the expected fees are in.
-  // Only meaningful for "All Time" — "expected" (the total fee owed) has no
-  // time dimension, so a windowed rate would read as a day's collections
-  // against the full lifetime total owed rather than anything a team lead
-  // could act on.
-  const hasExpected = stats.expected > 0;
-  const rate = hasExpected ? (stats.paid / stats.expected) * 100 : 0;
+  // Only meaningful for "All Time" — a windowed rate would read as a day's
+  // collections against the full lifetime total owed rather than anything a
+  // team lead could act on.
+  const hasExpected = totalExpected > 0;
+  const rate = hasExpected ? (totalCollected / totalExpected) * 100 : 0;
   const rateTone = !hasExpected
     ? t.textMuted
     : rate >= 80
@@ -125,8 +106,6 @@ export const RevenuePanel = ({ stats, cases, team }: RevenuePanelProps) => {
         : dark
           ? "text-red-400"
           : "text-red-500";
-
-  const windowedTotal = windowedTeams?.reduce((sum, c) => sum + c.collected, 0) ?? 0;
 
   return (
     <div className={`rounded-xl border p-4 md:p-5 ${t.card}`}>
@@ -157,10 +136,14 @@ export const RevenuePanel = ({ stats, cases, team }: RevenuePanelProps) => {
         </div>
       </div>
 
-      {windowMode === "alltime" ? (
+      {windowError ? (
+        <div className={`text-[13px] mt-1 ${dark ? "text-red-400" : "text-red-500"}`} role="alert">
+          {windowError}
+        </div>
+      ) : windowMode === "alltime" ? (
         <>
           <div className={`text-2xl font-extrabold ${t.text} mt-1`}>
-            {fmtFull(stats.paid)}
+            {fmtFull(totalCollected)}
           </div>
           <div className={`text-[13px] font-medium mt-0.5 ${rateTone}`}>
             {hasExpected
@@ -168,14 +151,10 @@ export const RevenuePanel = ({ stats, cases, team }: RevenuePanelProps) => {
               : "No fees expected yet"}
           </div>
         </>
-      ) : windowError ? (
-        <div className={`text-[13px] mt-1 ${dark ? "text-red-400" : "text-red-500"}`} role="alert">
-          {windowError}
-        </div>
       ) : (
         <>
           <div className={`text-2xl font-extrabold ${t.text} mt-1`}>
-            {fmtFull(windowedTotal)}
+            {fmtFull(totalCollected)}
           </div>
           <div className={`text-[13px] font-medium mt-0.5 ${t.textMuted}`}>
             Collected — {WINDOW_LABELS[windowMode]}
@@ -184,11 +163,17 @@ export const RevenuePanel = ({ stats, cases, team }: RevenuePanelProps) => {
       )}
 
       <div className="mt-4" aria-busy={windowLoading}>
-        <TeamRevenueStats
-          dark={dark}
-          bars={bars}
-          windowedTeams={windowMode === "alltime" ? null : windowedTeams}
-        />
+        {!windowError && windowLoading && !teamsData ? (
+          <div className="flex items-center justify-center h-24 text-[13px] text-neutral-400 dark:text-neutral-500">
+            Loading…
+          </div>
+        ) : (
+          <TeamRevenueStats
+            dark={dark}
+            bars={bars}
+            windowedTeams={windowMode === "alltime" ? null : teamsData}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/components/cases/TeamRevenueStats.tsx
+++ b/src/components/cases/TeamRevenueStats.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { fmt } from "@/lib/formatters";
-import { teamCardClasses, teamAccentText, teamLabel } from "@/lib/team-colors";
+import { teamCardClasses, teamAccentText, teamLabel, teamFillBg } from "@/lib/team-colors";
 
 export interface TeamRevenueBar {
   team: string;
@@ -24,14 +24,38 @@ interface TeamRevenueStatsProps {
 const statLabelClass = "text-[10px] font-medium uppercase tracking-wide text-neutral-500 dark:text-neutral-400";
 const statValueClass = "text-sm font-bold text-neutral-900 dark:text-neutral-100 mt-0.5";
 
-// Plain-text stat rows rather than a bar chart — a bar chart made T2/CONC's
-// larger dollar totals visually dwarf T16's smaller one on the same scale,
-// reading as "T16 is underperforming" even when its own collection rate was
-// fine. Numbers side by side, with no shared height to compare against,
-// don't carry that same implication. Stacked full-width rows (not a 3-column
-// grid) — this panel is already one of three columns on the dashboard, so a
-// nested 3-up grid squeezes each team's Expected/Collected into too little
-// width to read.
+// Windowed (Today/Week/Month) has only Collected — a plain vertical bar
+// chart per team, shared dollar scale, same shape as Reports' own "Fees
+// This Month" team cards. Comparing raw Collected across teams for the same
+// period is an apples-to-apples read (unlike Expected-vs-Collected below),
+// so a shared scale doesn't carry the "T16 is underperforming" implication.
+const WindowedBars = ({ dark, teams }: { dark: boolean; teams: { team: string; collected: number }[] }) => {
+  const maxVal = Math.max(...teams.map((t) => t.collected), 1);
+  return (
+    <div className="flex items-end gap-6 justify-center h-32 px-2">
+      {teams.map((t) => (
+        <div key={t.team} className="flex flex-col items-center gap-1.5 flex-1">
+          <span className={`text-[12px] font-semibold ${teamAccentText(t.team, dark)}`}>{fmt(t.collected)}</span>
+          <div className="w-full flex items-end justify-center h-20">
+            <div
+              className={`w-10 rounded-t ${teamFillBg(t.team)}`}
+              style={{ height: `${Math.max((t.collected / maxVal) * 100, 2)}%` }}
+            />
+          </div>
+          <span className={`text-[11px] font-medium ${dark ? "text-neutral-400" : "text-neutral-500"}`}>
+            {teamLabel(t.team)}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+// All Time pairs Expected with Collected, so each team's progress bar is
+// scaled to its OWN Expected (% collected), not a shared dollar axis across
+// teams — a shared axis made T2/CONC's larger dollar totals visually dwarf
+// T16's smaller one, reading as "T16 is underperforming" even when its own
+// collection rate was fine.
 export const TeamRevenueStats = ({ dark, bars, windowedTeams }: TeamRevenueStatsProps) => {
   if (windowedTeams) {
     if (windowedTeams.length === 0) {
@@ -42,22 +66,7 @@ export const TeamRevenueStats = ({ dark, bars, windowedTeams }: TeamRevenueStats
       );
     }
 
-    return (
-      <div className="space-y-2">
-        {windowedTeams.map((b) => (
-          <div
-            key={b.team}
-            className={`rounded-lg border p-3 flex items-center justify-between gap-3 ${teamCardClasses(b.team, dark)}`}
-          >
-            <p className={`text-xs font-bold ${teamAccentText(b.team, dark)}`}>{teamLabel(b.team)}</p>
-            <div className="text-right">
-              <p className={statLabelClass}>Collected</p>
-              <p className={statValueClass}>{fmt(b.collected)}</p>
-            </div>
-          </div>
-        ))}
-      </div>
-    );
+    return <WindowedBars dark={dark} teams={windowedTeams} />;
   }
 
   if (bars.length === 0) {
@@ -70,24 +79,39 @@ export const TeamRevenueStats = ({ dark, bars, windowedTeams }: TeamRevenueStats
 
   return (
     <div className="space-y-2">
-      {bars.map((b) => (
-        <div
-          key={b.team}
-          className={`rounded-lg border p-3 flex items-center justify-between gap-3 ${teamCardClasses(b.team, dark)}`}
-        >
-          <p className={`text-xs font-bold ${teamAccentText(b.team, dark)}`}>{teamLabel(b.team)}</p>
-          <div className="flex items-center gap-4">
-            <div className="text-right">
-              <p className={statLabelClass}>Expected</p>
-              <p className={statValueClass}>{fmt(b.expected)}</p>
+      {bars.map((b) => {
+        const pct = b.expected > 0 ? Math.min(100, (b.paid / b.expected) * 100) : 0;
+        return (
+          <div
+            key={b.team}
+            className={`rounded-lg border p-3 ${teamCardClasses(b.team, dark)}`}
+          >
+            <div className="flex items-center justify-between gap-3">
+              <p className={`text-xs font-bold ${teamAccentText(b.team, dark)}`}>{teamLabel(b.team)}</p>
+              <div className="flex items-center gap-4">
+                <div className="text-right">
+                  <p className={statLabelClass}>Expected</p>
+                  <p className={statValueClass}>{fmt(b.expected)}</p>
+                </div>
+                <div className="text-right">
+                  <p className={statLabelClass}>Collected</p>
+                  <p className={statValueClass}>{fmt(b.paid)}</p>
+                </div>
+              </div>
             </div>
-            <div className="text-right">
-              <p className={statLabelClass}>Collected</p>
-              <p className={statValueClass}>{fmt(b.paid)}</p>
+            <div
+              className={`mt-2 h-1.5 rounded-full overflow-hidden ${dark ? "bg-neutral-800" : "bg-neutral-200"}`}
+              role="progressbar"
+              aria-valuenow={Math.round(pct)}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label={`${teamLabel(b.team)} collection progress`}
+            >
+              <div className={`h-full rounded-full ${teamFillBg(b.team)}`} style={{ width: `${pct}%` }} />
             </div>
           </div>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 };

--- a/src/components/cases/__tests__/RevenuePanel.test.tsx
+++ b/src/components/cases/__tests__/RevenuePanel.test.tsx
@@ -92,6 +92,39 @@ describe("RevenuePanel — every window, including All Time, comes from /api/rev
 
     await waitFor(() => expect(screen.getByRole("alert")).toBeTruthy());
     expect(screen.getByRole("alert").textContent).toContain("500");
+    // The error banner replaces the team breakdown entirely — no redundant
+    // "no data" state rendered underneath it.
+    expect(screen.queryByText(/No team data yet/)).toBeNull();
+    expect(screen.queryByText(/No fees collected/)).toBeNull();
+  });
+
+  it("clears the previous window's figures immediately on switch, instead of showing them under the new label", async () => {
+    let resolveMonth!: (value: unknown) => void;
+    const monthPromise = new Promise((resolve) => {
+      resolveMonth = resolve;
+    });
+    (fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ window: "alltime", teams: [{ team: "T2", collected: 499_500, expected: 792_636 }] }),
+      })
+      .mockReturnValueOnce(monthPromise);
+    render(<RevenuePanel />);
+    await waitFor(() => expect(screen.getByText(/792,636/)).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("button", { name: "Month" }));
+
+    // Old All Time figure must be gone before Month's data has even arrived —
+    // otherwise it would sit on screen under the (already-updated) "Month" label.
+    await waitFor(() => expect(screen.getByText(/Loading/)).toBeTruthy());
+    expect(screen.queryByText(/792,636/)).toBeNull();
+
+    resolveMonth({
+      ok: true,
+      json: async () => ({ window: "month", teams: [{ team: "T2", collected: 12_400 }] }),
+    });
+    // Matches both the headline ($12,400.00) and the bar label ($12,400).
+    await waitFor(() => expect(screen.getAllByText(/12,400/).length).toBeGreaterThan(0));
   });
 
   it("switching back to All Time re-fetches the lifetime totals", async () => {

--- a/src/components/cases/__tests__/RevenuePanel.test.tsx
+++ b/src/components/cases/__tests__/RevenuePanel.test.tsx
@@ -2,77 +2,12 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
 import { RevenuePanel } from "../RevenuePanel";
-import type { CaseRow, DashboardSummary, TeamMember } from "@/types";
 
 vi.mock("next-themes", () => ({
   useTheme: () => ({ resolvedTheme: "light" }),
 }));
 
-const SUMMARY: DashboardSummary = {
-  totalCases: 10,
-  expected: 838_486.81,
-  paid: 373_923,
-  outstanding: 464_563.81,
-  pif: 2,
-  syncErrors: 0,
-  synced: 10,
-  feesCollectedMTD: 0,
-  casesClosedMTD: 0,
-};
-
-const TEAM: TeamMember[] = [
-  { name: "Cora", role: "collections_specialist", team: "T2", cases: 1, collected: "0" },
-  { name: "Bree", role: "collections_specialist", team: "T16", cases: 1, collected: "0" },
-];
-
-const caseWith = (id: number, assigned: string, expected: number, paid: number): CaseRow => ({
-  id,
-  name: `Case ${id}`,
-  externalId: null,
-  chronicleId: null,
-  assigned,
-  level: "HEARING",
-  claim: "T16",
-  date: "2026-01-15",
-  status: "not_started",
-  createdAt: "2026-01-15T00:00:00.000Z",
-  t16Retro: 10000, t16FeeDue: expected, t16FeeReceived: paid, t16Pending: 0, t16FeeReceivedDate: null,
-  t2Retro: 0,    t2FeeDue: null,   t2FeeReceived: 0,  t2Pending: 0,    t2FeeReceivedDate: null,
-  auxRetro: 0,   auxFeeDue: null,  auxFeeReceived: 0, auxPending: 0,   auxFeeReceivedDate: null,
-  totalRetroDue: 10000,
-  expected,
-  paid,
-  pif: null,
-  approvedBy: null,
-  feesConfirmation: null,
-  feesClosedTrigger: null,
-  caseStatus: null,
-  nextFollowUpDate: null,
-  isClosed: false,
-  markedOverpaid: false,
-  closedAt: null,
-  update: "",
-  sync: "synced",
-  daysAfterApproval: 30,
-  approvalCategory: null,
-  feesStatus: null,
-  weekAssignedToAgent: null,
-  monthAssignedToAgent: null,
-  office: "Test Office",
-  notesCount: 0,
-  leaderNotesCount: 0,
-  caseLink: null,
-  winSheetLink: null,
-  winSheetLinkText: null,
-});
-
-const CASES: CaseRow[] = [
-  caseWith(1, "Cora", 792_636, 499_500),   // T2 team
-  caseWith(2, "Bree", 300_656, 656),        // T16 team
-  caseWith(3, "Nobody", 50_000, 10_000),    // not in team roster — excluded
-];
-
-describe("RevenuePanel — groups by team, not claim type", () => {
+describe("RevenuePanel — every window, including All Time, comes from /api/revenue-by-team", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
   });
@@ -81,24 +16,37 @@ describe("RevenuePanel — groups by team, not claim type", () => {
     vi.unstubAllGlobals();
   });
 
-  it("defaults to All Time: aggregates Expected/Collected by each case's assigned agent's team", () => {
-    render(<RevenuePanel stats={SUMMARY} cases={CASES} team={TEAM} />);
-    expect(screen.getByText("Revenue by Team")).toBeTruthy();
-    expect(screen.getByText("T2 Team")).toBeTruthy();
+  it("defaults to All Time: fetches the lifetime Expected/Collected per team (open + closed cases)", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        window: "alltime",
+        teams: [
+          { team: "T2", collected: 499_500, expected: 792_636 },
+          { team: "T16", collected: 656, expected: 300_656 },
+        ],
+      }),
+    });
+    render(<RevenuePanel />);
+
+    expect(fetch).toHaveBeenCalledWith("/api/revenue-by-team?window=alltime", expect.anything());
+    await waitFor(() => expect(screen.getByText("T2 Team")).toBeTruthy());
     expect(screen.getByText("T16 Team")).toBeTruthy();
-    // Case 1 (Cora → T2) contributes $792,636 expected to the T2 bar.
     expect(screen.getByText(/792,636/)).toBeTruthy();
-    // Case 3's agent isn't on the roster — excluded, not folded into any team.
-    expect(screen.queryByText(/50,000/)).toBeNull();
-    expect(fetch).not.toHaveBeenCalled();
   });
 
   it("fetches the windowed team totals when a narrower preset is clicked", async () => {
-    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ window: "month", teams: [{ team: "T2", collected: 12_400 }, { team: "T16", collected: 3_100 }] }),
-    });
-    render(<RevenuePanel stats={SUMMARY} cases={CASES} team={TEAM} />);
+    (fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ window: "alltime", teams: [] }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          window: "month",
+          teams: [{ team: "T2", collected: 12_400 }, { team: "T16", collected: 3_100 }],
+        }),
+      });
+    render(<RevenuePanel />);
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
 
     fireEvent.click(screen.getByRole("button", { name: "Month" }));
 
@@ -109,19 +57,22 @@ describe("RevenuePanel — groups by team, not claim type", () => {
   });
 
   it("re-sorts a windowed response into TEAM_ORDER regardless of the API's own row order", async () => {
-    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: true,
-      // Deliberately out of order — SQL's GROUP BY gives no ordering guarantee.
-      json: async () => ({
-        window: "month",
-        teams: [
-          { team: "Concurrent", collected: 1 },
-          { team: "T16", collected: 2 },
-          { team: "T2", collected: 3 },
-        ],
-      }),
-    });
-    render(<RevenuePanel stats={SUMMARY} cases={CASES} team={TEAM} />);
+    (fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ window: "alltime", teams: [] }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        // Deliberately out of order — SQL's GROUP BY gives no ordering guarantee.
+        json: async () => ({
+          window: "month",
+          teams: [
+            { team: "Concurrent", collected: 1 },
+            { team: "T16", collected: 2 },
+            { team: "T2", collected: 3 },
+          ],
+        }),
+      });
+    render(<RevenuePanel />);
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
 
     fireEvent.click(screen.getByRole("button", { name: "Month" }));
     await waitFor(() => expect(screen.getByText(/Collected — Month/)).toBeTruthy());
@@ -131,8 +82,11 @@ describe("RevenuePanel — groups by team, not claim type", () => {
   });
 
   it("shows an alert when the windowed fetch fails", async () => {
-    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ok: false, status: 500 });
-    render(<RevenuePanel stats={SUMMARY} cases={CASES} team={TEAM} />);
+    (fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ window: "alltime", teams: [] }) })
+      .mockResolvedValueOnce({ ok: false, status: 500 });
+    render(<RevenuePanel />);
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
 
     fireEvent.click(screen.getByRole("button", { name: "Week" }));
 
@@ -140,18 +94,29 @@ describe("RevenuePanel — groups by team, not claim type", () => {
     expect(screen.getByRole("alert").textContent).toContain("500");
   });
 
-  it("switching back to All Time drops the fetched window without refetching", async () => {
-    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ window: "today", teams: [{ team: "T2", collected: 900 }] }),
-    });
-    render(<RevenuePanel stats={SUMMARY} cases={CASES} team={TEAM} />);
+  it("switching back to All Time re-fetches the lifetime totals", async () => {
+    (fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ window: "alltime", teams: [{ team: "T2", collected: 499_500, expected: 792_636 }] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ window: "today", teams: [{ team: "T2", collected: 900 }] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ window: "alltime", teams: [{ team: "T2", collected: 499_500, expected: 792_636 }] }),
+      });
+    render(<RevenuePanel />);
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
 
     fireEvent.click(screen.getByRole("button", { name: "Today" }));
     await waitFor(() => expect(screen.getByText(/Collected — Today/)).toBeTruthy());
 
     fireEvent.click(screen.getByRole("button", { name: "All Time" }));
-    expect(screen.getByText(/44\.6%/)).toBeTruthy();
-    expect(fetch).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(3));
+    // 499,500 / 792,636 = 63.0%
+    await waitFor(() => expect(screen.getByText(/63\.0%/)).toBeTruthy());
   });
 });

--- a/src/components/cases/__tests__/TeamRevenueStats.test.tsx
+++ b/src/components/cases/__tests__/TeamRevenueStats.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { render, screen, cleanup } from "@testing-library/react";
 import { TeamRevenueStats } from "../TeamRevenueStats";
 
-describe("TeamRevenueStats — All Time (pre-aggregated bars)", () => {
+describe("TeamRevenueStats — All Time (self-scaled progress bars)", () => {
   afterEach(cleanup);
 
   it("renders Expected/Collected per team as text, with the human-readable team label", () => {
@@ -22,16 +22,27 @@ describe("TeamRevenueStats — All Time (pre-aggregated bars)", () => {
     expect(screen.getByText(/300,656/)).toBeTruthy();
   });
 
-  it("renders no visual bar/height elements — text tiles only", () => {
-    const { container } = render(
-      <TeamRevenueStats dark={false} bars={[{ team: "T16", expected: 300_656, paid: 656 }]} />,
+  it("scales each team's progress bar to its OWN expected, not a shared dollar axis", () => {
+    render(
+      <TeamRevenueStats
+        dark={false}
+        bars={[
+          { team: "T2", expected: 792_636, paid: 499_500 }, // ~63%
+          { team: "T16", expected: 300_656, paid: 300_656 }, // 100%
+        ]}
+      />,
     );
-    // The old chart used inline `height` styles to size bars; this component
-    // never should, since a plain number carries no relative-size framing.
-    const heighted = Array.from(container.querySelectorAll<HTMLElement>("[style]")).filter(
-      (el) => el.style.height,
+    const bars = screen.getAllByRole("progressbar");
+    expect(bars).toHaveLength(2);
+    expect(bars[0].getAttribute("aria-valuenow")).toBe("63");
+    expect(bars[1].getAttribute("aria-valuenow")).toBe("100");
+  });
+
+  it("caps the progress bar at 100% for an overpaid team", () => {
+    render(
+      <TeamRevenueStats dark={false} bars={[{ team: "T16", expected: 300_656, paid: 400_000 }]} />,
     );
-    expect(heighted.length).toBe(0);
+    expect(screen.getByRole("progressbar").getAttribute("aria-valuenow")).toBe("100");
   });
 
   it("shows an empty state when there are no team bars", () => {
@@ -40,11 +51,11 @@ describe("TeamRevenueStats — All Time (pre-aggregated bars)", () => {
   });
 });
 
-describe("TeamRevenueStats — windowed (collected-only)", () => {
+describe("TeamRevenueStats — windowed (collected-only bar chart)", () => {
   afterEach(cleanup);
 
-  it("renders only a Collected figure per team, no Expected", () => {
-    render(
+  it("renders a Collected figure and bar per team, no Expected", () => {
+    const { container } = render(
       <TeamRevenueStats
         dark={false}
         bars={[]}
@@ -58,6 +69,11 @@ describe("TeamRevenueStats — windowed (collected-only)", () => {
     expect(screen.getByText("Concurrent Team")).toBeTruthy();
     expect(screen.getByText(/12,400/)).toBeTruthy();
     expect(screen.queryByText("Expected")).toBeNull();
+    // A real bar per team — height scaled to the shared max Collected value.
+    const heighted = Array.from(container.querySelectorAll<HTMLElement>("[style]")).filter(
+      (el) => el.style.height,
+    );
+    expect(heighted.length).toBe(2);
   });
 
   it("shows an empty state when nothing was collected in the window", () => {

--- a/src/lib/team-colors.ts
+++ b/src/lib/team-colors.ts
@@ -58,6 +58,17 @@ export function teamRowTint(team: string | null | undefined, dark: boolean): str
   }
 }
 
+// Solid bar fill — Overview's Revenue by Team graph (per-team columns and
+// the All Time self-scaled progress bar). Fixed shade regardless of theme,
+// same as teamHeaderBg — it sits on a neutral track, not page background.
+export function teamFillBg(team: string | null | undefined): string {
+  switch (toneFor(team)) {
+    case "blue": return "bg-blue-500";
+    case "red": return "bg-red-500";
+    default: return "bg-emerald-500";
+  }
+}
+
 // Pill badge — agent names in Reports rows and the Team Management roster.
 export function teamBadgeClasses(team: string | null | undefined, dark: boolean): string {
   switch (toneFor(team)) {


### PR DESCRIPTION
Closes #425

## Reported by
Ms. Jazz, right after #423 shipped:

> I'm wondering why the overview numbers and the reports does not match hmm
> Just the fees collected numbers
> Also we wanted it to still look like a graph but with the numbers that we have on the reports

Followed by, once shown Reports' "Fees This Month" team cards:

> Can we show these numbers instead? The fees collected numbers per month for the revenue... can we try that and let's see what the graph looks like

## Root cause
Overview's "All Time" Revenue by Team bars were aggregated client-side from `/api/cases?isClosed=false` — open cases only. Reports' team card sums `total_fees_paid` across every case, open or closed. Any team with real closed-case history read lower on Overview than on Reports. #423's own verification only checked the Month window against Reports (already matched); the gap was specific to All Time.

## Changes
- `/api/revenue-by-team`: added an `alltime` branch that sums `total_fees_expected`/`total_fees_paid` across all cases (open + closed) grouped by team — the same lifetime figure Reports/scoreboard's `total_collected` shows.
- `RevenuePanel`: every window (Today/Week/Month/All Time) now sources from this one endpoint instead of a client-side aggregate. Dropped the now-unused `stats`/`cases`/`team` props.
- `TeamRevenueStats`: brought back a graph — a shared-scale bar chart for Today/Week/Month (raw Collected $ per team, same figures as Reports' "Fees This Month" cards), and a self-scaled per-team progress bar for All Time (scaled to each team's own Expected, not a shared dollar axis, so it doesn't reintroduce the "T16 looks underperforming" artifact #423 removed the old chart for).

## Verified
Live against production data:
- Overview "All Time" now shows $7,666,639.95 collected / 86.7% rate across T2/T16/Concurrent, matching lifetime totals (open + closed cases).
- Overview "Month" bar chart ($414,557 / $325,569 / $390,192) matches Reports' "Fees This Month" team cards exactly, dollar-for-dollar.

## Tests
157/157 passing (updated `RevenuePanel`/`TeamRevenueStats` suites for the new data flow and bar-chart rendering). Lint/typecheck/build clean.