### PR TITLE
fix: simplify Revenue by Team to a Month-only bar chart

### DIFF
--- a/src/components/cases/RevenuePanel.tsx
+++ b/src/components/cases/RevenuePanel.tsx
@@ -1,183 +1,84 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTheme } from "next-themes";
-import { TeamRevenueStats, type TeamRevenueBar } from "@/components/cases/TeamRevenueStats";
+import { TeamRevenueStats, type TeamRevenueEntry } from "@/components/cases/TeamRevenueStats";
 import { themeClasses } from "@/lib/theme-classes";
 import { fmtFull } from "@/lib/formatters";
-
-export type RevenueWindowMode = "today" | "week" | "month" | "alltime";
-
-const WINDOW_LABELS: Record<RevenueWindowMode, string> = {
-  today: "Today",
-  week: "Week",
-  month: "Month",
-  alltime: "All Time",
-};
 
 // Same restriction as Reports' TEAM_ORDER in /api/scoreboard — only these
 // three are real collections teams; Fee Petition and unassigned agents don't
 // belong on a revenue-by-team chart.
 const TEAM_ORDER = ["T2", "T16", "Concurrent"];
 
-interface TeamEntry {
-  team: string;
-  collected: number;
-  /** Only present for "alltime" — today/week/month have no time dimension
-   *  to pair Expected against (see /api/revenue-by-team). */
-  expected?: number;
-}
-
-// Every window — including "All Time" — is fetched from /api/revenue-by-team
-// rather than aggregated client-side from the open-cases-only /api/cases
-// list. All Time in particular sums total_fees_paid/total_fees_expected
-// across every case (open or closed), the same lifetime figure Reports' team
-// card shows — the previous client-side aggregate silently dropped every
-// closed case's collected fees and read lower than Reports.
+// Always shows the current month's Collected per team as a bar chart —
+// matches Reports' "Fees This Month" team cards exactly (same
+// /api/revenue-by-team?window=month endpoint, same dollar-for-dollar
+// figures). The Today/Week/All Time toggle and the Expected/Collected
+// pairing were dropped at Jazz/Lori's request — this panel reads as a
+// simple graph, not a data table.
 export const RevenuePanel = () => {
   const { resolvedTheme } = useTheme();
   const dark = resolvedTheme === "dark";
   const t = themeClasses(dark);
 
-  const [windowMode, setWindowMode] = useState<RevenueWindowMode>("alltime");
-  const [teamsData, setTeamsData] = useState<TeamEntry[] | null>(null);
-  const [windowLoading, setWindowLoading] = useState(false);
-  const [windowError, setWindowError] = useState<string | null>(null);
+  const [teams, setTeams] = useState<TeamRevenueEntry[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  const fetchTeams = useCallback(
-    async (mode: RevenueWindowMode, signal: AbortSignal, cancelledRef: { current: boolean }) => {
-      setWindowLoading(true);
-      setWindowError(null);
+  useEffect(() => {
+    const controller = new AbortController();
+    const cancelledRef = { current: false };
+    (async () => {
+      setLoading(true);
+      setError(null);
       try {
-        const res = await fetch(`/api/revenue-by-team?window=${mode}`, { signal });
+        const res = await fetch("/api/revenue-by-team?window=month", { signal: controller.signal });
         if (!res.ok) throw new Error(`Failed to load revenue by team (${res.status})`);
         const json = await res.json();
         if (cancelledRef.current) return;
-        // SQL's GROUP BY gives no ordering guarantee — sort to a fixed
-        // display order so rows don't jump around between windows.
-        const teams: TeamEntry[] = json.teams ?? [];
-        teams.sort((a, b) => TEAM_ORDER.indexOf(a.team) - TEAM_ORDER.indexOf(b.team));
-        setTeamsData(teams);
+        // SQL's GROUP BY gives no ordering guarantee — sort to a fixed display order.
+        const rows: TeamRevenueEntry[] = json.teams ?? [];
+        rows.sort((a, b) => TEAM_ORDER.indexOf(a.team) - TEAM_ORDER.indexOf(b.team));
+        setTeams(rows);
       } catch (err) {
         if (cancelledRef.current || (err as Error).name === "AbortError") return;
-        setWindowError((err as Error).message);
+        setError((err as Error).message);
       } finally {
-        if (!cancelledRef.current) setWindowLoading(false);
+        if (!cancelledRef.current) setLoading(false);
       }
-    },
-    [],
-  );
-
-  useEffect(() => {
-    // Drop the previous window's data immediately on switch — otherwise the
-    // old team figures stay on screen (under the new window's label) until
-    // the new fetch resolves, which reads as real data for the wrong window.
-    setTeamsData(null);
-    const controller = new AbortController();
-    const cancelledRef = { current: false };
-    fetchTeams(windowMode, controller.signal, cancelledRef);
+    })();
     return () => {
       cancelledRef.current = true;
       controller.abort();
     };
-  }, [windowMode, fetchTeams]);
+  }, []);
 
-  // All Time pairs Expected with Collected (for the per-team progress bars);
-  // today/week/month only ever carry Collected.
-  const bars = useMemo<TeamRevenueBar[]>(() => {
-    if (windowMode !== "alltime" || !teamsData) return [];
-    return teamsData.map((tm) => ({ team: tm.team, expected: tm.expected ?? 0, paid: tm.collected }));
-  }, [windowMode, teamsData]);
-
-  const totalCollected = teamsData?.reduce((sum, tm) => sum + tm.collected, 0) ?? 0;
-  const totalExpected = teamsData?.reduce((sum, tm) => sum + (tm.expected ?? 0), 0) ?? 0;
-
-  // Collection rate = paid / expected. It's a standing ratio (not a delta),
-  // so no "+" prefix; color reflects how much of the expected fees are in.
-  // Only meaningful for "All Time" — a windowed rate would read as a day's
-  // collections against the full lifetime total owed rather than anything a
-  // team lead could act on.
-  const hasExpected = totalExpected > 0;
-  const rate = hasExpected ? (totalCollected / totalExpected) * 100 : 0;
-  const rateTone = !hasExpected
-    ? t.textMuted
-    : rate >= 80
-      ? "text-emerald-500"
-      : rate >= 40
-        ? dark
-          ? "text-amber-400"
-          : "text-amber-600"
-        : dark
-          ? "text-red-400"
-          : "text-red-500";
+  const totalCollected = teams?.reduce((sum, tm) => sum + tm.collected, 0) ?? 0;
 
   return (
     <div className={`rounded-xl border p-4 md:p-5 ${t.card}`}>
-      <div className="flex items-center justify-between gap-2">
-        <h3 className={`text-sm font-bold ${t.text}`}>Revenue by Team</h3>
-        <div className={`flex items-center rounded-md border overflow-hidden text-[11px] font-semibold shrink-0 ${dark ? "border-neutral-700" : "border-neutral-200"}`}>
-          {(["today", "week", "month", "alltime"] as const).map((mode) => {
-            const active = windowMode === mode;
-            return (
-              <button
-                key={mode}
-                onClick={() => setWindowMode(mode)}
-                aria-pressed={active}
-                className={`px-2.5 py-1 transition-colors ${
-                  active
-                    ? dark
-                      ? "bg-emerald-700 text-white"
-                      : "bg-emerald-600 text-white"
-                    : dark
-                      ? "text-neutral-400 hover:bg-neutral-800"
-                      : "text-neutral-500 hover:bg-neutral-50"
-                }`}
-              >
-                {WINDOW_LABELS[mode]}
-              </button>
-            );
-          })}
-        </div>
-      </div>
+      <h3 className={`text-sm font-bold ${t.text}`}>Revenue by Team</h3>
 
-      {windowError ? (
+      {error ? (
         <div className={`text-[13px] mt-1 ${dark ? "text-red-400" : "text-red-500"}`} role="alert">
-          {windowError}
+          {error}
         </div>
-      ) : windowMode === "alltime" ? (
-        <>
-          <div className={`text-2xl font-extrabold ${t.text} mt-1`}>
-            {fmtFull(totalCollected)}
-          </div>
-          <div className={`text-[13px] font-medium mt-0.5 ${rateTone}`}>
-            {hasExpected
-              ? `${rate.toFixed(1)}% collection rate`
-              : "No fees expected yet"}
-          </div>
-        </>
       ) : (
         <>
-          <div className={`text-2xl font-extrabold ${t.text} mt-1`}>
-            {fmtFull(totalCollected)}
-          </div>
-          <div className={`text-[13px] font-medium mt-0.5 ${t.textMuted}`}>
-            Collected — {WINDOW_LABELS[windowMode]}
-          </div>
+          <div className={`text-2xl font-extrabold ${t.text} mt-1`}>{fmtFull(totalCollected)}</div>
+          <div className={`text-[13px] font-medium mt-0.5 ${t.textMuted}`}>Collected — Month</div>
         </>
       )}
 
-      {!windowError && (
-        <div className="mt-4" aria-busy={windowLoading}>
-          {windowLoading && !teamsData ? (
+      {!error && (
+        <div className="mt-4" aria-busy={loading}>
+          {loading && !teams ? (
             <div className="flex items-center justify-center h-24 text-[13px] text-neutral-400 dark:text-neutral-500">
               Loading…
             </div>
           ) : (
-            <TeamRevenueStats
-              dark={dark}
-              bars={bars}
-              windowedTeams={windowMode === "alltime" ? null : teamsData}
-            />
+            <TeamRevenueStats dark={dark} teams={teams ?? []} />
           )}
         </div>
       )}

--- a/src/components/cases/TeamRevenueStats.tsx
+++ b/src/components/cases/TeamRevenueStats.tsx
@@ -1,36 +1,31 @@
 "use client";
 
 import { fmt } from "@/lib/formatters";
-import { teamCardClasses, teamAccentText, teamLabel, teamFillBg } from "@/lib/team-colors";
+import { teamAccentText, teamLabel, teamFillBg } from "@/lib/team-colors";
 
-export interface TeamRevenueBar {
+export interface TeamRevenueEntry {
   team: string;
-  expected: number;
-  paid: number;
+  collected: number;
 }
 
 interface TeamRevenueStatsProps {
   dark: boolean;
-  /** Pre-aggregated Expected/Collected per team, in display order (see
-   *  RevenuePanel's TEAM_ORDER) — this component doesn't own the team
-   *  taxonomy. */
-  bars: TeamRevenueBar[];
-  /** Collected-in-window totals per team. When set (any window other than
-   *  "All Time"), each row shows only Collected — "Expected" (the total fee
-   *  owed) has no time dimension, so there's nothing to pair it with. */
-  windowedTeams?: { team: string; collected: number }[] | null;
+  teams: TeamRevenueEntry[];
 }
 
-const statLabelClass = "text-[10px] font-medium uppercase tracking-wide text-neutral-500 dark:text-neutral-400";
-const statValueClass = "text-sm font-bold text-neutral-900 dark:text-neutral-100 mt-0.5";
+// Vertical bar chart per team, shared dollar scale — same shape as Reports'
+// own "Fees This Month" team cards, so the two pages read as the same chart.
+export const TeamRevenueStats = ({ dark, teams }: TeamRevenueStatsProps) => {
+  if (teams.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-24 text-[13px] text-neutral-400 dark:text-neutral-500">
+        No fees collected this month yet
+      </div>
+    );
+  }
 
-// Windowed (Today/Week/Month) has only Collected — a plain vertical bar
-// chart per team, shared dollar scale, same shape as Reports' own "Fees
-// This Month" team cards. Comparing raw Collected across teams for the same
-// period is an apples-to-apples read (unlike Expected-vs-Collected below),
-// so a shared scale doesn't carry the "T16 is underperforming" implication.
-const WindowedBars = ({ dark, teams }: { dark: boolean; teams: { team: string; collected: number }[] }) => {
   const maxVal = Math.max(...teams.map((t) => t.collected), 1);
+
   return (
     <div className="flex items-end gap-6 justify-center h-32 px-2">
       {teams.map((t) => (
@@ -47,71 +42,6 @@ const WindowedBars = ({ dark, teams }: { dark: boolean; teams: { team: string; c
           </span>
         </div>
       ))}
-    </div>
-  );
-};
-
-// All Time pairs Expected with Collected, so each team's progress bar is
-// scaled to its OWN Expected (% collected), not a shared dollar axis across
-// teams — a shared axis made T2/CONC's larger dollar totals visually dwarf
-// T16's smaller one, reading as "T16 is underperforming" even when its own
-// collection rate was fine.
-export const TeamRevenueStats = ({ dark, bars, windowedTeams }: TeamRevenueStatsProps) => {
-  if (windowedTeams) {
-    if (windowedTeams.length === 0) {
-      return (
-        <div className="flex items-center justify-center h-24 text-[13px] text-neutral-400 dark:text-neutral-500">
-          No fees collected in this window yet
-        </div>
-      );
-    }
-
-    return <WindowedBars dark={dark} teams={windowedTeams} />;
-  }
-
-  if (bars.length === 0) {
-    return (
-      <div className="flex items-center justify-center h-24 text-[13px] text-neutral-400 dark:text-neutral-500">
-        No team data yet
-      </div>
-    );
-  }
-
-  return (
-    <div className="space-y-2">
-      {bars.map((b) => {
-        const pct = b.expected > 0 ? Math.min(100, (b.paid / b.expected) * 100) : 0;
-        return (
-          <div
-            key={b.team}
-            className={`rounded-lg border p-3 ${teamCardClasses(b.team, dark)}`}
-          >
-            <div className="flex items-center justify-between gap-3">
-              <p className={`text-xs font-bold ${teamAccentText(b.team, dark)}`}>{teamLabel(b.team)}</p>
-              <div className="flex items-center gap-4">
-                <div className="text-right">
-                  <p className={statLabelClass}>Expected</p>
-                  <p className={statValueClass}>{fmt(b.expected)}</p>
-                </div>
-                <div className="text-right">
-                  <p className={statLabelClass}>Collected</p>
-                  <p className={statValueClass}>{fmt(b.paid)}</p>
-                </div>
-              </div>
-            </div>
-            <div
-              className={`mt-2 h-1.5 rounded-full overflow-hidden ${dark ? "bg-neutral-800" : "bg-neutral-200"}`}
-              role="progressbar"
-              aria-valuenow={Math.round(pct)}
-              aria-valuemin={0}
-              aria-valuemax={100}
-              aria-label={`${teamLabel(b.team)} collection progress`}
-            >
-              <div className={`h-full rounded-full ${teamFillBg(b.team)}`} style={{ width: `${pct}%` }} />
-            </div>
-          </div>
-        );
-      })}
     </div>
   );
 };

--- a/src/components/cases/__tests__/RevenuePanel.test.tsx
+++ b/src/components/cases/__tests__/RevenuePanel.test.tsx
@@ -1,13 +1,13 @@
 /** @vitest-environment jsdom */
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
 import { RevenuePanel } from "../RevenuePanel";
 
 vi.mock("next-themes", () => ({
   useTheme: () => ({ resolvedTheme: "light" }),
 }));
 
-describe("RevenuePanel — every window, including All Time, comes from /api/revenue-by-team", () => {
+describe("RevenuePanel — always shows this month's Collected per team as a bar chart", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
   });
@@ -16,140 +16,86 @@ describe("RevenuePanel — every window, including All Time, comes from /api/rev
     vi.unstubAllGlobals();
   });
 
-  it("defaults to All Time: fetches the lifetime Expected/Collected per team (open + closed cases)", async () => {
+  it("fetches window=month on mount and renders the team totals", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
       json: async () => ({
-        window: "alltime",
+        window: "month",
         teams: [
-          { team: "T2", collected: 499_500, expected: 792_636 },
-          { team: "T16", collected: 656, expected: 300_656 },
+          { team: "T2", collected: 414_557 },
+          { team: "T16", collected: 325_569 },
+          { team: "Concurrent", collected: 392_826 },
         ],
       }),
     });
     render(<RevenuePanel />);
 
-    expect(fetch).toHaveBeenCalledWith("/api/revenue-by-team?window=alltime", expect.anything());
+    expect(fetch).toHaveBeenCalledWith("/api/revenue-by-team?window=month", expect.anything());
     await waitFor(() => expect(screen.getByText("T2 Team")).toBeTruthy());
     expect(screen.getByText("T16 Team")).toBeTruthy();
-    expect(screen.getByText(/792,636/)).toBeTruthy();
-  });
-
-  it("fetches the windowed team totals when a narrower preset is clicked", async () => {
-    (fetch as ReturnType<typeof vi.fn>)
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ window: "alltime", teams: [] }) })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          window: "month",
-          teams: [{ team: "T2", collected: 12_400 }, { team: "T16", collected: 3_100 }],
-        }),
-      });
-    render(<RevenuePanel />);
-    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
-
-    fireEvent.click(screen.getByRole("button", { name: "Month" }));
-
-    expect(fetch).toHaveBeenCalledWith("/api/revenue-by-team?window=month", expect.anything());
-    await waitFor(() => expect(screen.getByText(/Collected — Month/)).toBeTruthy());
-    expect(screen.getByText(/15,500/)).toBeTruthy(); // 12,400 + 3,100
+    expect(screen.getByText("Concurrent Team")).toBeTruthy();
+    expect(screen.getByText(/Collected — Month/)).toBeTruthy();
+    // Headline is the sum of all three teams.
+    expect(screen.getByText("$1,132,952.00")).toBeTruthy();
+    // No tab switcher and no Expected figure — removed at Jazz/Lori's request.
+    expect(screen.queryByRole("button", { name: "All Time" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Today" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Week" })).toBeNull();
     expect(screen.queryByText("Expected")).toBeNull();
   });
 
-  it("re-sorts a windowed response into TEAM_ORDER regardless of the API's own row order", async () => {
-    (fetch as ReturnType<typeof vi.fn>)
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ window: "alltime", teams: [] }) })
-      .mockResolvedValueOnce({
-        ok: true,
-        // Deliberately out of order — SQL's GROUP BY gives no ordering guarantee.
-        json: async () => ({
-          window: "month",
-          teams: [
-            { team: "Concurrent", collected: 1 },
-            { team: "T16", collected: 2 },
-            { team: "T2", collected: 3 },
-          ],
-        }),
-      });
+  it("re-sorts the response into a fixed display order regardless of the API's own row order", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      // Deliberately out of order — SQL's GROUP BY gives no ordering guarantee.
+      json: async () => ({
+        window: "month",
+        teams: [
+          { team: "Concurrent", collected: 1 },
+          { team: "T16", collected: 2 },
+          { team: "T2", collected: 3 },
+        ],
+      }),
+    });
     render(<RevenuePanel />);
-    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
-
-    fireEvent.click(screen.getByRole("button", { name: "Month" }));
-    await waitFor(() => expect(screen.getByText(/Collected — Month/)).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("T2 Team")).toBeTruthy());
 
     const labels = screen.getAllByText(/^(T2|T16|Concurrent) Team$/).map((el) => el.textContent);
     expect(labels).toEqual(["T2 Team", "T16 Team", "Concurrent Team"]);
   });
 
-  it("shows an alert when the windowed fetch fails", async () => {
-    (fetch as ReturnType<typeof vi.fn>)
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ window: "alltime", teams: [] }) })
-      .mockResolvedValueOnce({ ok: false, status: 500 });
+  it("shows an alert when the fetch fails, without a redundant empty state underneath", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ok: false, status: 500 });
     render(<RevenuePanel />);
-    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
-
-    fireEvent.click(screen.getByRole("button", { name: "Week" }));
 
     await waitFor(() => expect(screen.getByRole("alert")).toBeTruthy());
     expect(screen.getByRole("alert").textContent).toContain("500");
-    // The error banner replaces the team breakdown entirely — no redundant
-    // "no data" state rendered underneath it.
-    expect(screen.queryByText(/No team data yet/)).toBeNull();
     expect(screen.queryByText(/No fees collected/)).toBeNull();
   });
 
-  it("clears the previous window's figures immediately on switch, instead of showing them under the new label", async () => {
-    let resolveMonth!: (value: unknown) => void;
-    const monthPromise = new Promise((resolve) => {
-      resolveMonth = resolve;
+  it("shows a loading state before the fetch resolves", async () => {
+    let resolveFetch!: (value: unknown) => void;
+    const pending = new Promise((resolve) => {
+      resolveFetch = resolve;
     });
-    (fetch as ReturnType<typeof vi.fn>)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ window: "alltime", teams: [{ team: "T2", collected: 499_500, expected: 792_636 }] }),
-      })
-      .mockReturnValueOnce(monthPromise);
+    (fetch as ReturnType<typeof vi.fn>).mockReturnValueOnce(pending);
     render(<RevenuePanel />);
-    await waitFor(() => expect(screen.getByText(/792,636/)).toBeTruthy());
 
-    fireEvent.click(screen.getByRole("button", { name: "Month" }));
+    expect(screen.getByText(/Loading/)).toBeTruthy();
 
-    // Old All Time figure must be gone before Month's data has even arrived —
-    // otherwise it would sit on screen under the (already-updated) "Month" label.
-    await waitFor(() => expect(screen.getByText(/Loading/)).toBeTruthy());
-    expect(screen.queryByText(/792,636/)).toBeNull();
-
-    resolveMonth({
+    resolveFetch({
       ok: true,
-      json: async () => ({ window: "month", teams: [{ team: "T2", collected: 12_400 }] }),
+      json: async () => ({ window: "month", teams: [{ team: "T2", collected: 900 }] }),
     });
-    // Matches both the headline ($12,400.00) and the bar label ($12,400).
-    await waitFor(() => expect(screen.getAllByText(/12,400/).length).toBeGreaterThan(0));
+    await waitFor(() => expect(screen.getByText("T2 Team")).toBeTruthy());
   });
 
-  it("switching back to All Time re-fetches the lifetime totals", async () => {
-    (fetch as ReturnType<typeof vi.fn>)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ window: "alltime", teams: [{ team: "T2", collected: 499_500, expected: 792_636 }] }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ window: "today", teams: [{ team: "T2", collected: 900 }] }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ window: "alltime", teams: [{ team: "T2", collected: 499_500, expected: 792_636 }] }),
-      });
+  it("shows an empty state when nothing was collected this month", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ window: "month", teams: [] }),
+    });
     render(<RevenuePanel />);
-    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
-
-    fireEvent.click(screen.getByRole("button", { name: "Today" }));
-    await waitFor(() => expect(screen.getByText(/Collected — Today/)).toBeTruthy());
-
-    fireEvent.click(screen.getByRole("button", { name: "All Time" }));
-    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(3));
-    // 499,500 / 792,636 = 63.0%
-    await waitFor(() => expect(screen.getByText(/63\.0%/)).toBeTruthy());
+    await waitFor(() => expect(screen.getByText(/No fees collected this month yet/)).toBeTruthy());
   });
 });

--- a/src/components/cases/__tests__/TeamRevenueStats.test.tsx
+++ b/src/components/cases/__tests__/TeamRevenueStats.test.tsx
@@ -3,93 +3,50 @@ import { describe, it, expect, afterEach } from "vitest";
 import { render, screen, cleanup } from "@testing-library/react";
 import { TeamRevenueStats } from "../TeamRevenueStats";
 
-describe("TeamRevenueStats — All Time (self-scaled progress bars)", () => {
+describe("TeamRevenueStats — Collected-per-team bar chart", () => {
   afterEach(cleanup);
 
-  it("renders Expected/Collected per team as text, with the human-readable team label", () => {
-    render(
+  it("renders a Collected figure and bar per team, with the human-readable team label", () => {
+    const { container } = render(
       <TeamRevenueStats
         dark={false}
-        bars={[
-          { team: "T2", expected: 792_636, paid: 499_500 },
-          { team: "T16", expected: 300_656, paid: 656 },
+        teams={[
+          { team: "T2", collected: 414_557 },
+          { team: "T16", collected: 325_569 },
+          { team: "Concurrent", collected: 392_826 },
         ]}
       />,
     );
     expect(screen.getByText("T2 Team")).toBeTruthy();
     expect(screen.getByText("T16 Team")).toBeTruthy();
-    expect(screen.getByText(/792,636/)).toBeTruthy();
-    expect(screen.getByText(/300,656/)).toBeTruthy();
-  });
-
-  it("scales each team's progress bar to its OWN expected, not a shared dollar axis", () => {
-    render(
-      <TeamRevenueStats
-        dark={false}
-        bars={[
-          { team: "T2", expected: 792_636, paid: 499_500 }, // ~63%
-          { team: "T16", expected: 300_656, paid: 300_656 }, // 100%
-        ]}
-      />,
-    );
-    const bars = screen.getAllByRole("progressbar");
-    expect(bars).toHaveLength(2);
-    expect(bars[0].getAttribute("aria-valuenow")).toBe("63");
-    expect(bars[1].getAttribute("aria-valuenow")).toBe("100");
-  });
-
-  it("caps the progress bar at 100% for an overpaid team", () => {
-    render(
-      <TeamRevenueStats dark={false} bars={[{ team: "T16", expected: 300_656, paid: 400_000 }]} />,
-    );
-    expect(screen.getByRole("progressbar").getAttribute("aria-valuenow")).toBe("100");
-  });
-
-  it("shows an empty state when there are no team bars", () => {
-    render(<TeamRevenueStats dark={false} bars={[]} />);
-    expect(screen.getByText(/No team data yet/)).toBeTruthy();
-  });
-});
-
-describe("TeamRevenueStats — windowed (collected-only bar chart)", () => {
-  afterEach(cleanup);
-
-  it("renders a Collected figure and bar per team, no Expected", () => {
-    const { container } = render(
-      <TeamRevenueStats
-        dark={false}
-        bars={[]}
-        windowedTeams={[
-          { team: "T2", collected: 12_400 },
-          { team: "Concurrent", collected: 3_100 },
-        ]}
-      />,
-    );
-    expect(screen.getByText("T2 Team")).toBeTruthy();
     expect(screen.getByText("Concurrent Team")).toBeTruthy();
-    expect(screen.getByText(/12,400/)).toBeTruthy();
-    expect(screen.queryByText("Expected")).toBeNull();
-    // A real bar per team — height scaled to the shared max Collected value.
+    expect(screen.getByText(/414,557/)).toBeTruthy();
+    expect(screen.getByText(/325,569/)).toBeTruthy();
+    expect(screen.getByText(/392,826/)).toBeTruthy();
+    // A real bar per team, height scaled to the shared max Collected value.
     const heighted = Array.from(container.querySelectorAll<HTMLElement>("[style]")).filter(
       (el) => el.style.height,
     );
-    expect(heighted.length).toBe(2);
+    expect(heighted.length).toBe(3);
   });
 
-  it("shows an empty state when nothing was collected in the window", () => {
-    render(<TeamRevenueStats dark={false} bars={[]} windowedTeams={[]} />);
-    expect(screen.getByText(/No fees collected in this window yet/)).toBeTruthy();
-  });
-
-  it("ignores the bars prop entirely once windowedTeams is set", () => {
-    render(
+  it("scales the tallest bar to the max Collected value among the given teams", () => {
+    const { container } = render(
       <TeamRevenueStats
         dark={false}
-        bars={[{ team: "T16", expected: 999_999, paid: 1 }]}
-        windowedTeams={[{ team: "T2", collected: 500 }]}
+        teams={[
+          { team: "T2", collected: 100 },
+          { team: "T16", collected: 50 },
+        ]}
       />,
     );
-    expect(screen.queryByText("T16 Team")).toBeNull();
-    expect(screen.getByText("T2 Team")).toBeTruthy();
+    const bars = Array.from(container.querySelectorAll<HTMLElement>("[style]")).filter((el) => el.style.height);
+    expect(bars[0].style.height).toBe("100%");
+    expect(bars[1].style.height).toBe("50%");
+  });
+
+  it("shows an empty state when nothing was collected", () => {
+    render(<TeamRevenueStats dark={false} teams={[]} />);
+    expect(screen.getByText(/No fees collected this month yet/)).toBeTruthy();
   });
 });


### PR DESCRIPTION
Closes #428

## Reported by
Ms. Jazz, after #426 shipped the graph + lifetime-total fix:

> It looks good but Lori wanted it to look like a graph like before. We can remove the fees expected numbers

Followed by, after being shown the live Month view:

> This
> Just remove the options for all time, today, and week options

## Changes
- `RevenuePanel`: dropped the Today/Week/All Time toggle entirely — always fetches `/api/revenue-by-team?window=month` on mount, no window-switching state.
- `TeamRevenueStats`: dropped the Expected/Collected self-scaled progress bar (#426's All Time design) — now just the shared-scale bar chart, same shape as Reports' "Fees This Month" team cards.
- `/api/revenue-by-team` is unchanged. `today`/`week`/`alltime` are no longer requested by the UI but the route still supports them — left in place rather than trimmed, given how many times this panel's requirements have changed in the last day.

## Verified
Live in the browser: matches Jazz's screenshot exactly — no tabs, no Expected figure, just the Month bar chart ($414,557 / $325,569 / $392,826 for T2/T16/Concurrent).

## Tests
153/153 passing (both `RevenuePanel`/`TeamRevenueStats` suites rewritten for the simplified contract). Lint/typecheck/build clean.