### PR TITLE
fix: even out Revenue by Team bar spacing and baseline alignment

### DIFF
--- a/src/components/cases/TeamRevenueStats.tsx
+++ b/src/components/cases/TeamRevenueStats.tsx
@@ -27,19 +27,35 @@ export const TeamRevenueStats = ({ dark, teams }: TeamRevenueStatsProps) => {
   const maxVal = Math.max(...teams.map((t) => t.collected), 1);
 
   return (
-    <div className="flex items-end gap-6 justify-center h-32 px-2">
+    // Columns share one fixed width rather than sizing to their own label —
+    // "Concurrent Team" is nearly twice as wide as "T2 Team"/"T16 Team", so
+    // letting each column auto-size made the bar next to the long label sit
+    // visibly further from its neighbor than the other two bars were from
+    // each other, even with equal gap/flex-1 removed. A shared width keeps
+    // every bar-to-bar gap equal; "Concurrent Team" wraps to two lines
+    // rather than widening its column and throwing the spacing off again.
+    <div className="flex items-end justify-center gap-4 h-32 px-2">
       {teams.map((t) => (
-        <div key={t.team} className="flex flex-col items-center gap-1.5 flex-1">
+        <div key={t.team} className="flex flex-col items-center gap-1.5 w-16">
           <span className={`text-[12px] font-semibold ${teamAccentText(t.team, dark)}`}>{fmt(t.collected)}</span>
-          <div className="w-full flex items-end justify-center h-20">
+          <div className="flex items-end justify-center h-20">
             <div
               className={`w-10 rounded-t ${teamFillBg(t.team)}`}
               style={{ height: `${Math.max((t.collected / maxVal) * 100, 2)}%` }}
             />
           </div>
-          <span className={`text-[11px] font-medium ${dark ? "text-neutral-400" : "text-neutral-500"}`}>
-            {teamLabel(t.team)}
-          </span>
+          {/* Fixed-height slot, top-aligned — "Concurrent Team" wraps to two
+              lines while the other labels are one. Without a shared height
+              here, the outer row's items-end bottom-alignment made the
+              taller (wrapped) column push its bar upward relative to the
+              other two, distorting the height comparison between teams. */}
+          <div className="h-8 flex items-start justify-center">
+            <span
+              className={`text-[11px] font-medium text-center leading-tight ${dark ? "text-neutral-400" : "text-neutral-500"}`}
+            >
+              {teamLabel(t.team)}
+            </span>
+          </div>
         </div>
       ))}
     </div>


### PR DESCRIPTION
Closes #431

## Reported by
Kentshin, reviewing #429's Month-only bar chart live — three rounds of feedback as each fix surfaced the next issue:

1. > Ms Jazz wants to keep the distance between the bars minimal maybe we could adjust the width or do you have suggestion
2. > still feels off ... no, visually the T2 bar and T16 bar spacing is smaller than the T16 bar and Concurrent bar spacing
3. > yes, the spacing is now fixed but the concurrent team bar is now higher than the other 2

## Root causes & fixes
1. **Uneven overall spacing** — each column was `flex-1`, stretching to a third of the card's width, so a 40px bar centered in a stretched column read as far more space than the `gap` value alone. Removed the stretch, tightened `gap-6` → `gap-4`.
2. **T2↔T16 gap smaller than T16↔Concurrent gap** — columns still auto-sized to their own label text, and "Concurrent Team" is nearly twice as wide as the other two labels, so that column was wider and pushed its bar further from its neighbor. Gave every column a shared fixed width (`w-16`); "Concurrent Team" now wraps to two lines instead of widening its column.
3. **Concurrent's bar sat higher than the others despite a lower dollar value** — the outer row bottom-aligns columns (`items-end`); once "Concurrent Team" wrapped to two lines, that column became taller than the other two, and bottom-alignment pushed its bar upward relative to them. Gave the label a fixed-height slot (`h-8`, top-aligned) so every column is the same total height regardless of label line count.

## Verified
Live in the browser at each step (zoomed screenshots measuring bar-to-bar gaps and baseline alignment). Final state: T2/T16/Concurrent bar-to-bar gaps are equal, all three `$` labels and bar tops align to the same baseline, and bar heights correctly rank by dollar value (T2 $438,954 tallest, Concurrent $428,712 slightly shorter, T16 $325,569 clearly shortest).

## Tests
153/153 passing. Lint/build clean.