### PR TITLE
sync: develop → main

### DIFF
--- a/src/components/notifications/AuditLogTab.tsx
+++ b/src/components/notifications/AuditLogTab.tsx
@@ -1,15 +1,14 @@
 "use client";
 
 import { useState, useEffect, useRef, Fragment } from "react";
-import { ChevronLeft, ChevronRight, RefreshCw, ClipboardList, AlertCircle, Check, Table2, MessageSquare, LayoutGrid, type LucideIcon } from "lucide-react";
+import { ChevronLeft, ChevronRight, RefreshCw, ClipboardList, AlertCircle, Check, Table2, MessageSquare, type LucideIcon } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
-import { getMonday, formatWeekLabel, toChatBlock, toTeamsHtml } from "@/lib/formatters";
+import { getMonday, formatWeekLabel, toChatBlock } from "@/lib/formatters";
 
-type CopyFormat = "sheets" | "chat" | "teams";
+type CopyFormat = "sheets" | "chat";
 const COPY_FORMATS: { format: CopyFormat; Icon: LucideIcon; label: string; ariaLabel: string; title: string }[] = [
   { format: "sheets", Icon: Table2, label: "Sheets", ariaLabel: "Copy for Google Sheets", title: "Copy for Google Sheets (tab-separated)" },
   { format: "chat", Icon: MessageSquare, label: "Chat", ariaLabel: "Copy for Google Chat", title: "Copy for Google Chat (monospace code block)" },
-  { format: "teams", Icon: LayoutGrid, label: "Teams", ariaLabel: "Copy for Microsoft Teams", title: "Copy for Microsoft Teams (HTML table)" },
 ];
 
 interface DailyMetricRow {
@@ -105,10 +104,7 @@ export function AuditLogTab({ dark, t }: AuditLogTabProps) {
       if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
       copyTimerRef.current = setTimeout(() => setCopiedTable(null), 1500);
     };
-    if (format === "teams") {
-      const blob = new Blob([toTeamsHtml(title, header, tableRows)], { type: "text/html" });
-      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done).catch(console.warn);
-    } else if (format === "sheets") {
+    if (format === "sheets") {
       const lines = [title, header.join("\t"), ...tableRows.map((r) => r.join("\t"))];
       navigator.clipboard.writeText(lines.join("\n")).then(done);
     } else {

--- a/src/components/notifications/CallsBacklogTab.tsx
+++ b/src/components/notifications/CallsBacklogTab.tsx
@@ -1,16 +1,15 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import { RefreshCw, PhoneMissed, Phone, AlertCircle, ExternalLink, Check, Table2, MessageSquare, LayoutGrid, ChevronLeft, ChevronRight, type LucideIcon } from "lucide-react";
+import { RefreshCw, PhoneMissed, Phone, AlertCircle, ExternalLink, Check, Table2, MessageSquare, ChevronLeft, ChevronRight, type LucideIcon } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
-import { getMonday, formatWeekLabelShort as formatWeekLabel, toChatBlock, toTeamsHtml } from "@/lib/formatters";
+import { getMonday, formatWeekLabelShort as formatWeekLabel, toChatBlock } from "@/lib/formatters";
 import Link from "next/link";
 
-type CopyFormat = "sheets" | "chat" | "teams";
+type CopyFormat = "sheets" | "chat";
 const COPY_FORMATS: { format: CopyFormat; Icon: LucideIcon; label: string; ariaLabel: string; title: string }[] = [
   { format: "sheets", Icon: Table2, label: "Sheets", ariaLabel: "Copy for Google Sheets", title: "Copy for Google Sheets (tab-separated)" },
   { format: "chat", Icon: MessageSquare, label: "Chat", ariaLabel: "Copy for Google Chat", title: "Copy for Google Chat (monospace code block)" },
-  { format: "teams", Icon: LayoutGrid, label: "Teams", ariaLabel: "Copy for Microsoft Teams", title: "Copy for Microsoft Teams (HTML table)" },
 ];
 
 interface DayCallCount {
@@ -155,10 +154,7 @@ export function CallsBacklogTab({ dark, t }: CallsBacklogTabProps) {
       if (countsTimerRef.current) clearTimeout(countsTimerRef.current);
       countsTimerRef.current = setTimeout(() => setCopiedCounts(null), 1500);
     };
-    if (format === "teams") {
-      const blob = new Blob([toTeamsHtml(title, header, countRows)], { type: "text/html" });
-      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done).catch(console.warn);
-    } else if (format === "sheets") {
+    if (format === "sheets") {
       const lines = [title, header.join("\t"), ...countRows.map((r) => r.join("\t"))];
       navigator.clipboard.writeText(lines.join("\n")).then(done);
     } else {
@@ -181,10 +177,7 @@ export function CallsBacklogTab({ dark, t }: CallsBacklogTabProps) {
       if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
       copyTimerRef.current = setTimeout(() => setCopiedTable(null), 1500);
     };
-    if (format === "teams") {
-      const blob = new Blob([toTeamsHtml(title, header, tableRows)], { type: "text/html" });
-      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done).catch(console.warn);
-    } else if (format === "sheets") {
+    if (format === "sheets") {
       const lines = [title, header.join("\t"), ...tableRows.map((r) => r.join("\t"))];
       navigator.clipboard.writeText(lines.join("\n")).then(done);
     } else {

--- a/src/components/notifications/ClosedCasesTab.tsx
+++ b/src/components/notifications/ClosedCasesTab.tsx
@@ -1,15 +1,14 @@
 "use client";
 
 import { useState, useEffect, useRef, Fragment } from "react";
-import { ChevronLeft, ChevronRight, RefreshCw, CheckCircle, AlertCircle, ExternalLink, Check, Table2, MessageSquare, LayoutGrid, type LucideIcon } from "lucide-react";
+import { ChevronLeft, ChevronRight, RefreshCw, CheckCircle, AlertCircle, ExternalLink, Check, Table2, MessageSquare, type LucideIcon } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
-import { getMonday, formatWeekLabelShort as formatWeekLabel, toChatBlock, toTeamsHtml } from "@/lib/formatters";
+import { getMonday, formatWeekLabelShort as formatWeekLabel, toChatBlock } from "@/lib/formatters";
 
-type CopyFormat = "sheets" | "chat" | "teams";
+type CopyFormat = "sheets" | "chat";
 const COPY_FORMATS: { format: CopyFormat; Icon: LucideIcon; label: string; ariaLabel: string; title: string }[] = [
   { format: "sheets", Icon: Table2, label: "Sheets", ariaLabel: "Copy for Google Sheets", title: "Copy for Google Sheets (tab-separated)" },
   { format: "chat", Icon: MessageSquare, label: "Chat", ariaLabel: "Copy for Google Chat", title: "Copy for Google Chat (monospace code block)" },
-  { format: "teams", Icon: LayoutGrid, label: "Teams", ariaLabel: "Copy for Microsoft Teams", title: "Copy for Microsoft Teams (HTML table)" },
 ];
 
 interface DayCount {
@@ -105,6 +104,9 @@ export function ClosedCasesTab({ dark, t }: ClosedCasesTabProps) {
   const barBg = dark ? "bg-sky-500/30" : "bg-sky-200";
   const dateBg = dark ? "bg-neutral-800/60" : "bg-neutral-50";
 
+  // Copies only the daily count summary — not the per-case list rendered
+  // below, which staff paste into Sheets/Chat as a scoreboard-style summary,
+  // not a case export.
   const copyTable = (format: CopyFormat) => {
     const weekLabel = formatWeekLabel(monday);
     const countTitle = `Closed Cases — ${weekLabel}`;
@@ -113,32 +115,16 @@ export function ClosedCasesTab({ dark, t }: ClosedCasesTabProps) {
       ...days.map((d) => [fmtDate(d.date), d.count || 0]),
       ["Week Total", weekTotal],
     ];
-    const listTitle = `Cases Closed — ${weekLabel}`;
-    const listHeader = ["Date", "Case Name", "Assigned To"];
-    const listRows: (string | number)[][] = closureDates.flatMap((date) =>
-      closuresByDate[date].map((c) => [fmtDate(date), c.caseName, c.assignedTo ?? "—"])
-    );
     const done = () => {
       setCopiedTable(format);
       if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
       copyTimerRef.current = setTimeout(() => setCopiedTable(null), 1500);
     };
-    if (format === "teams") {
-      const html = toTeamsHtml(countTitle, countHeader, countRows) +
-        (listRows.length ? toTeamsHtml(listTitle, listHeader, listRows) : "");
-      const blob = new Blob([html], { type: "text/html" });
-      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done).catch(console.warn);
-    } else if (format === "sheets") {
-      const lines = [
-        countTitle, countHeader.join("\t"), ...countRows.map((r) => r.join("\t")),
-        "",
-        ...(listRows.length ? [listTitle, listHeader.join("\t"), ...listRows.map((r) => r.join("\t"))] : []),
-      ];
+    if (format === "sheets") {
+      const lines = [countTitle, countHeader.join("\t"), ...countRows.map((r) => r.join("\t"))];
       navigator.clipboard.writeText(lines.join("\n")).then(done);
     } else {
-      const parts = [toChatBlock(countTitle, countHeader, countRows)];
-      if (listRows.length) parts.push(toChatBlock(listTitle, listHeader, listRows));
-      navigator.clipboard.writeText(parts.join("\n\n")).then(done);
+      navigator.clipboard.writeText(toChatBlock(countTitle, countHeader, countRows)).then(done);
     }
   };
 

--- a/src/components/notifications/FeePetitionApprovedTab.tsx
+++ b/src/components/notifications/FeePetitionApprovedTab.tsx
@@ -1,15 +1,14 @@
 "use client";
 
 import { useState, useEffect, useRef, Fragment } from "react";
-import { ChevronLeft, ChevronRight, RefreshCw, CheckCircle2, AlertCircle, ExternalLink, Check, Table2, MessageSquare, LayoutGrid, type LucideIcon } from "lucide-react";
+import { ChevronLeft, ChevronRight, RefreshCw, CheckCircle2, AlertCircle, ExternalLink, Check, Table2, MessageSquare, type LucideIcon } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
-import { getMonday, formatWeekLabelShort as formatWeekLabel, toChatBlock, toTeamsHtml } from "@/lib/formatters";
+import { getMonday, formatWeekLabelShort as formatWeekLabel, toChatBlock } from "@/lib/formatters";
 
-type CopyFormat = "sheets" | "chat" | "teams";
+type CopyFormat = "sheets" | "chat";
 const COPY_FORMATS: { format: CopyFormat; Icon: LucideIcon; label: string; ariaLabel: string; title: string }[] = [
   { format: "sheets", Icon: Table2, label: "Sheets", ariaLabel: "Copy for Google Sheets", title: "Copy for Google Sheets (tab-separated)" },
   { format: "chat", Icon: MessageSquare, label: "Chat", ariaLabel: "Copy for Google Chat", title: "Copy for Google Chat (monospace code block)" },
-  { format: "teams", Icon: LayoutGrid, label: "Teams", ariaLabel: "Copy for Microsoft Teams", title: "Copy for Microsoft Teams (HTML table)" },
 ];
 
 interface DayCount {
@@ -107,6 +106,9 @@ export function FeePetitionApprovedTab({ dark, t }: FeePetitionApprovedTabProps)
   const barBg = dark ? "bg-emerald-500/30" : "bg-emerald-200";
   const dateBg = dark ? "bg-neutral-800/60" : "bg-neutral-50";
 
+  // Copies only the daily count summary — not the per-case list rendered
+  // below, which staff paste into Sheets/Chat as a scoreboard-style summary,
+  // not a case export.
   const copyTable = (format: CopyFormat) => {
     const weekLabel = formatWeekLabel(monday);
     const countTitle = `Fee Petitions Approved — ${weekLabel}`;
@@ -115,32 +117,16 @@ export function FeePetitionApprovedTab({ dark, t }: FeePetitionApprovedTabProps)
       ...days.map((d) => [fmtDate(d.date), d.count || 0]),
       ["Week Total", weekTotal],
     ];
-    const listTitle = `Approved — ${weekLabel}`;
-    const listHeader = ["Date", "Case Name", "Assigned To"];
-    const listRows: (string | number)[][] = approvalDates.flatMap((date) =>
-      approvalsByDate[date].map((a) => [fmtDate(date), a.caseName, a.assignedTo ?? "—"])
-    );
     const done = () => {
       setCopiedTable(format);
       if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
       copyTimerRef.current = setTimeout(() => setCopiedTable(null), 1500);
     };
-    if (format === "teams") {
-      const html = toTeamsHtml(countTitle, countHeader, countRows) +
-        (listRows.length ? toTeamsHtml(listTitle, listHeader, listRows) : "");
-      const blob = new Blob([html], { type: "text/html" });
-      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done).catch(console.warn);
-    } else if (format === "sheets") {
-      const lines = [
-        countTitle, countHeader.join("\t"), ...countRows.map((r) => r.join("\t")),
-        "",
-        ...(listRows.length ? [listTitle, listHeader.join("\t"), ...listRows.map((r) => r.join("\t"))] : []),
-      ];
+    if (format === "sheets") {
+      const lines = [countTitle, countHeader.join("\t"), ...countRows.map((r) => r.join("\t"))];
       navigator.clipboard.writeText(lines.join("\n")).then(done);
     } else {
-      const parts = [toChatBlock(countTitle, countHeader, countRows)];
-      if (listRows.length) parts.push(toChatBlock(listTitle, listHeader, listRows));
-      navigator.clipboard.writeText(parts.join("\n\n")).then(done);
+      navigator.clipboard.writeText(toChatBlock(countTitle, countHeader, countRows)).then(done);
     }
   };
 

--- a/src/components/notifications/FollowUpsTab.tsx
+++ b/src/components/notifications/FollowUpsTab.tsx
@@ -1,16 +1,15 @@
 "use client";
 
 import { useState, useEffect, useRef, Fragment } from "react";
-import { CalendarClock, ChevronLeft, ChevronRight, RefreshCw, AlertCircle, ExternalLink, Check, Table2, MessageSquare, LayoutGrid, type LucideIcon } from "lucide-react";
+import { CalendarClock, ChevronLeft, ChevronRight, RefreshCw, AlertCircle, ExternalLink, Check, Table2, MessageSquare, type LucideIcon } from "lucide-react";
 import { buildMyCaseUrl } from "@/lib/import/case-link";
 import { themeClasses } from "@/lib/theme-classes";
-import { toChatBlock, toTeamsHtml } from "@/lib/formatters";
+import { toChatBlock } from "@/lib/formatters";
 
-type CopyFormat = "sheets" | "chat" | "teams";
+type CopyFormat = "sheets" | "chat";
 const COPY_FORMATS: { format: CopyFormat; Icon: LucideIcon; label: string; ariaLabel: string }[] = [
   { format: "sheets", Icon: Table2,        label: "Sheets", ariaLabel: "Copy for Google Sheets" },
   { format: "chat",   Icon: MessageSquare, label: "Chat",   ariaLabel: "Copy for Google Chat" },
-  { format: "teams",  Icon: LayoutGrid,    label: "Teams",  ariaLabel: "Copy for Microsoft Teams" },
 ];
 
 interface FollowUpRow {
@@ -157,40 +156,24 @@ export function FollowUpsTab({ dark, t }: FollowUpsTabProps) {
   const barBg     = dark ? "bg-orange-500/30" : "bg-orange-200";
   const agentBg   = dark ? "bg-neutral-800/60" : "bg-neutral-50";
 
+  // Copies only the agent figures — not the case-level detail list rendered
+  // below, which staff paste into Sheets/Chat as a scoreboard-style summary,
+  // not a case export.
   const copyData = (format: CopyFormat) => {
     const label = isToday ? `Today · ${fmtDate(selectedDate)}` : fmtDate(selectedDate);
     const agentTitle  = `Follow-Ups — ${label}`;
     const agentHeader = ["Agent", "Follow-Ups"];
     const agentRows: (string | number)[][] = agentsToday.map((a) => [a.name, a.count]);
-    const listTitle   = `Follow-Up Cases — ${label}`;
-    const listHeader  = ["Agent", "Case Name", "Source"];
-    const listRows: (string | number)[][] = agentNames.flatMap((agent) =>
-      byAgent[agent].map((f) => [
-        agent,
-        f.caseName,
-        f.source === "fee_petition" ? "Fee Petition" : "Master Fees",
-      ])
-    );
     const done = () => {
       setCopied(format);
       if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
       copyTimerRef.current = setTimeout(() => setCopied(null), 1500);
     };
-    if (format === "teams") {
-      const html = toTeamsHtml(agentTitle, agentHeader, agentRows) +
-        (listRows.length ? toTeamsHtml(listTitle, listHeader, listRows) : "");
-      const blob = new Blob([html], { type: "text/html" });
-      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done).catch(console.warn);
-    } else if (format === "sheets") {
-      const lines = [
-        agentTitle, agentHeader.join("\t"), ...agentRows.map((r) => r.join("\t")),
-        ...(listRows.length ? ["", listTitle, listHeader.join("\t"), ...listRows.map((r) => r.join("\t"))] : []),
-      ];
+    if (format === "sheets") {
+      const lines = [agentTitle, agentHeader.join("\t"), ...agentRows.map((r) => r.join("\t"))];
       navigator.clipboard.writeText(lines.join("\n")).then(done);
     } else {
-      const parts = [toChatBlock(agentTitle, agentHeader, agentRows)];
-      if (listRows.length) parts.push(toChatBlock(listTitle, listHeader, listRows));
-      navigator.clipboard.writeText(parts.join("\n\n")).then(done);
+      navigator.clipboard.writeText(toChatBlock(agentTitle, agentHeader, agentRows)).then(done);
     }
   };
 

--- a/src/components/notifications/NewCasesTab.tsx
+++ b/src/components/notifications/NewCasesTab.tsx
@@ -2,15 +2,14 @@
 
 import { useState, useEffect, useRef, Fragment } from "react";
 import Link from "next/link";
-import { ChevronLeft, ChevronRight, RefreshCw, UserPlus, AlertCircle, ExternalLink, Check, Table2, MessageSquare, LayoutGrid, type LucideIcon } from "lucide-react";
+import { ChevronLeft, ChevronRight, RefreshCw, UserPlus, AlertCircle, ExternalLink, Check, Table2, MessageSquare, type LucideIcon } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
-import { getMonday, formatWeekLabelShort as formatWeekLabel, toChatBlock, toTeamsHtml } from "@/lib/formatters";
+import { getMonday, formatWeekLabelShort as formatWeekLabel, toChatBlock } from "@/lib/formatters";
 
-type CopyFormat = "sheets" | "chat" | "teams";
+type CopyFormat = "sheets" | "chat";
 const COPY_FORMATS: { format: CopyFormat; Icon: LucideIcon; label: string; ariaLabel: string; title: string }[] = [
   { format: "sheets", Icon: Table2, label: "Sheets", ariaLabel: "Copy for Google Sheets", title: "Copy for Google Sheets (tab-separated)" },
   { format: "chat", Icon: MessageSquare, label: "Chat", ariaLabel: "Copy for Google Chat", title: "Copy for Google Chat (monospace code block)" },
-  { format: "teams", Icon: LayoutGrid, label: "Teams", ariaLabel: "Copy for Microsoft Teams", title: "Copy for Microsoft Teams (HTML table)" },
 ];
 
 interface DayCount {
@@ -54,7 +53,7 @@ export function NewCasesTab({ dark, t }: NewCasesTabProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
-  const [copiedTable, setCopiedTable] = useState<"sheets" | "chat" | "teams" | null>(null);
+  const [copiedTable, setCopiedTable] = useState<CopyFormat | null>(null);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => () => { if (copyTimerRef.current) clearTimeout(copyTimerRef.current); }, []);
@@ -108,7 +107,10 @@ export function NewCasesTab({ dark, t }: NewCasesTabProps) {
   const barBg = dark ? "bg-indigo-500/30" : "bg-indigo-200";
   const dateBg = dark ? "bg-neutral-800/60" : "bg-neutral-50";
 
-  const copyTable = (format: "sheets" | "chat" | "teams") => {
+  // Copies only the daily count summary — not the per-case list rendered
+  // below, which staff paste into Sheets/Chat as a scoreboard-style summary,
+  // not a case export.
+  const copyTable = (format: "sheets" | "chat") => {
     const weekLabel = formatWeekLabel(monday);
     const countTitle = `New Cases — ${weekLabel}`;
     const countHeader = ["Day", "New Cases"];
@@ -116,11 +118,6 @@ export function NewCasesTab({ dark, t }: NewCasesTabProps) {
       ...days.map((d) => [fmtDate(d.date), d.count || 0]),
       ["Week Total", weekTotal],
     ];
-    const caseTitle = `Cases Added — ${weekLabel}`;
-    const caseHeader = ["Date", "Case Name", "Added"];
-    const caseRows: (string | number)[][] = caseDates.flatMap((date) =>
-      casesByDate[date].map((c) => [fmtDate(date), c.name, fmtTime(c.createdAt)])
-    );
 
     const done = () => {
       setCopiedTable(format);
@@ -128,22 +125,11 @@ export function NewCasesTab({ dark, t }: NewCasesTabProps) {
       copyTimerRef.current = setTimeout(() => setCopiedTable(null), 1500);
     };
 
-    if (format === "teams") {
-      const html = toTeamsHtml(countTitle, countHeader, countRows) +
-        (caseRows.length ? toTeamsHtml(caseTitle, caseHeader, caseRows) : "");
-      const blob = new Blob([html], { type: "text/html" });
-      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done).catch(console.warn);
-    } else if (format === "sheets") {
-      const lines = [
-        countTitle, countHeader.join("\t"), ...countRows.map((r) => r.join("\t")),
-        "",
-        ...(caseRows.length ? [caseTitle, caseHeader.join("\t"), ...caseRows.map((r) => r.join("\t"))] : []),
-      ];
+    if (format === "sheets") {
+      const lines = [countTitle, countHeader.join("\t"), ...countRows.map((r) => r.join("\t"))];
       navigator.clipboard.writeText(lines.join("\n")).then(done);
     } else {
-      const parts = [toChatBlock(countTitle, countHeader, countRows)];
-      if (caseRows.length) parts.push(toChatBlock(caseTitle, caseHeader, caseRows));
-      navigator.clipboard.writeText(parts.join("\n\n")).then(done);
+      navigator.clipboard.writeText(toChatBlock(countTitle, countHeader, countRows)).then(done);
     }
   };
 

--- a/src/components/notifications/PaymentsTab.tsx
+++ b/src/components/notifications/PaymentsTab.tsx
@@ -1,15 +1,14 @@
 "use client";
 
 import { useState, useEffect, useRef, Fragment } from "react";
-import { ChevronLeft, ChevronRight, RefreshCw, DollarSign, AlertCircle, ExternalLink, Check, Table2, MessageSquare, LayoutGrid, type LucideIcon } from "lucide-react";
+import { ChevronLeft, ChevronRight, RefreshCw, DollarSign, AlertCircle, ExternalLink, Check, Table2, MessageSquare, type LucideIcon } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
-import { getMonday, formatWeekLabelShort as formatWeekLabel, fmt, toChatBlock, toTeamsHtml } from "@/lib/formatters";
+import { getMonday, formatWeekLabelShort as formatWeekLabel, fmt, toChatBlock } from "@/lib/formatters";
 
-type CopyFormat = "sheets" | "chat" | "teams";
+type CopyFormat = "sheets" | "chat";
 const COPY_FORMATS: { format: CopyFormat; Icon: LucideIcon; label: string; ariaLabel: string; title: string }[] = [
   { format: "sheets", Icon: Table2, label: "Sheets", ariaLabel: "Copy for Google Sheets", title: "Copy for Google Sheets (tab-separated)" },
   { format: "chat", Icon: MessageSquare, label: "Chat", ariaLabel: "Copy for Google Chat", title: "Copy for Google Chat (monospace code block)" },
-  { format: "teams", Icon: LayoutGrid, label: "Teams", ariaLabel: "Copy for Microsoft Teams", title: "Copy for Microsoft Teams (HTML table)" },
 ];
 
 interface DayTotal {
@@ -112,6 +111,9 @@ export function PaymentsTab({ dark, t }: PaymentsTabProps) {
   const barBg = dark ? "bg-emerald-500/30" : "bg-emerald-200";
   const dateBg = dark ? "bg-neutral-800/60" : "bg-neutral-50";
 
+  // Copies only the daily total summary — not the per-payment list rendered
+  // below, which staff paste into Sheets/Chat as a scoreboard-style summary,
+  // not a case export.
   const copyTable = (format: CopyFormat) => {
     const weekLabel = formatWeekLabel(monday);
     const countTitle = `Payments Received — ${weekLabel}`;
@@ -120,32 +122,16 @@ export function PaymentsTab({ dark, t }: PaymentsTabProps) {
       ...days.map((d) => [fmtDate(d.date), fmt(d.total), d.count]),
       ["Week Total", fmt(weekTotal), weekCount],
     ];
-    const listTitle = `Payments Entered — ${weekLabel}`;
-    const listHeader = ["Date", "Case Name", "Amount", "Type", "Agent"];
-    const listRows: (string | number)[][] = paymentDates.flatMap((date) =>
-      paymentsByDate[date].map((p) => [fmtDate(date), p.caseName, fmt(p.amount), p.feeType, p.assignedTo ?? "—"])
-    );
     const done = () => {
       setCopiedTable(format);
       if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
       copyTimerRef.current = setTimeout(() => setCopiedTable(null), 1500);
     };
-    if (format === "teams") {
-      const html = toTeamsHtml(countTitle, countHeader, countRows) +
-        (listRows.length ? toTeamsHtml(listTitle, listHeader, listRows) : "");
-      const blob = new Blob([html], { type: "text/html" });
-      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done).catch(console.warn);
-    } else if (format === "sheets") {
-      const lines = [
-        countTitle, countHeader.join("\t"), ...countRows.map((r) => r.join("\t")),
-        "",
-        ...(listRows.length ? [listTitle, listHeader.join("\t"), ...listRows.map((r) => r.join("\t"))] : []),
-      ];
+    if (format === "sheets") {
+      const lines = [countTitle, countHeader.join("\t"), ...countRows.map((r) => r.join("\t"))];
       navigator.clipboard.writeText(lines.join("\n")).then(done);
     } else {
-      const parts = [toChatBlock(countTitle, countHeader, countRows)];
-      if (listRows.length) parts.push(toChatBlock(listTitle, listHeader, listRows));
-      navigator.clipboard.writeText(parts.join("\n\n")).then(done);
+      navigator.clipboard.writeText(toChatBlock(countTitle, countHeader, countRows)).then(done);
     }
   };
 

--- a/src/components/notifications/RecentActivityTab.tsx
+++ b/src/components/notifications/RecentActivityTab.tsx
@@ -1,15 +1,14 @@
 "use client";
 
 import { useState, useEffect, useRef, Fragment } from "react";
-import { ChevronLeft, ChevronRight, RefreshCw, Clock, AlertCircle, Check, Table2, MessageSquare, LayoutGrid, type LucideIcon } from "lucide-react";
+import { ChevronLeft, ChevronRight, RefreshCw, Clock, AlertCircle, Check, Table2, MessageSquare, type LucideIcon } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
-import { getMonday, formatWeekLabel, toChatBlock, toTeamsHtml } from "@/lib/formatters";
+import { getMonday, formatWeekLabel, toChatBlock } from "@/lib/formatters";
 
-type CopyFormat = "sheets" | "chat" | "teams";
+type CopyFormat = "sheets" | "chat";
 const COPY_FORMATS: { format: CopyFormat; Icon: LucideIcon; label: string; ariaLabel: string; title: string }[] = [
   { format: "sheets", Icon: Table2, label: "Sheets", ariaLabel: "Copy for Google Sheets", title: "Copy for Google Sheets (tab-separated)" },
   { format: "chat", Icon: MessageSquare, label: "Chat", ariaLabel: "Copy for Google Chat", title: "Copy for Google Chat (monospace code block)" },
-  { format: "teams", Icon: LayoutGrid, label: "Teams", ariaLabel: "Copy for Microsoft Teams", title: "Copy for Microsoft Teams (HTML table)" },
 ];
 
 interface ActivityEntry {
@@ -45,7 +44,7 @@ export function RecentActivityTab({ dark, t }: RecentActivityTabProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
-  const [copiedTable, setCopiedTable] = useState<"sheets" | "chat" | "teams" | null>(null);
+  const [copiedTable, setCopiedTable] = useState<CopyFormat | null>(null);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => () => { if (copyTimerRef.current) clearTimeout(copyTimerRef.current); }, []);
@@ -94,7 +93,7 @@ export function RecentActivityTab({ dark, t }: RecentActivityTabProps) {
   const rowHover  = dark ? "hover:bg-neutral-800/30" : "hover:bg-neutral-50";
   const dateBg    = dark ? "bg-neutral-800/60" : "bg-neutral-50";
 
-  const copyTable = (format: "sheets" | "chat" | "teams") => {
+  const copyTable = (format: CopyFormat) => {
     const title = `Recent Activity — ${formatWeekLabel(monday)}`;
     const header = ["Date", "Time", "Agent", "Case", "Activity"];
     const rows = dates.flatMap((date) =>
@@ -111,10 +110,7 @@ export function RecentActivityTab({ dark, t }: RecentActivityTabProps) {
       if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
       copyTimerRef.current = setTimeout(() => setCopiedTable(null), 1500);
     };
-    if (format === "teams") {
-      const blob = new Blob([toTeamsHtml(title, header, rows)], { type: "text/html" });
-      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done).catch(console.warn);
-    } else if (format === "sheets") {
+    if (format === "sheets") {
       const lines = [title, header.join("\t"), ...rows.map((r) => r.join("\t"))];
       navigator.clipboard.writeText(lines.join("\n")).then(done);
     } else {

--- a/src/components/reports/ScoreboardTracker.tsx
+++ b/src/components/reports/ScoreboardTracker.tsx
@@ -22,12 +22,11 @@ import {
   Clipboard,
   Table2,
   MessageSquare,
-  LayoutGrid,
   type LucideIcon,
 } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { themeClasses } from "@/lib/theme-classes";
-import { fmt, fmtDate, namesMatch, getMonday, formatWeekLabel, toChatBlock, toTeamsHtml } from "@/lib/formatters";
+import { fmt, fmtDate, namesMatch, getMonday, formatWeekLabel, toChatBlock } from "@/lib/formatters";
 import { teamBadgeClasses } from "@/lib/team-colors";
 import { useCapabilities } from "@/hooks/useCapabilities";
 import {
@@ -187,21 +186,18 @@ interface CopyButtonsProps {
   label: string;
   sheetsActive: boolean;
   chatActive: boolean;
-  teamsActive: boolean;
   onSheets: () => void;
   onChat: () => void;
-  onTeams: () => void;
   dark: boolean;
 }
 
-function CopyButtons({ label, sheetsActive, chatActive, teamsActive, onSheets, onChat, onTeams, dark }: CopyButtonsProps) {
+function CopyButtons({ label, sheetsActive, chatActive, onSheets, onChat, dark }: CopyButtonsProps) {
   const base = `flex items-center gap-1 px-2 py-1 rounded-md text-[12px] font-medium border transition-colors`;
   const active = dark ? "border-emerald-700 text-emerald-400" : "border-emerald-300 text-emerald-600";
   const idle = dark ? "border-neutral-700 text-neutral-400 hover:bg-neutral-800" : "border-neutral-200 text-neutral-500 hover:bg-neutral-50";
   const buttons: { Icon: LucideIcon; btnLabel: string; ariaLabel: string; title: string; isActive: boolean; onClick: () => void }[] = [
     { Icon: Table2, btnLabel: "Sheets", ariaLabel: `Copy ${label} for Google Sheets`, title: "Copy for Google Sheets (tab-separated)", isActive: sheetsActive, onClick: onSheets },
     { Icon: MessageSquare, btnLabel: "Chat", ariaLabel: `Copy ${label} for Google Chat`, title: "Copy for Google Chat (monospace code block)", isActive: chatActive, onClick: onChat },
-    { Icon: LayoutGrid, btnLabel: "Teams", ariaLabel: `Copy ${label} for Microsoft Teams`, title: "Copy for Microsoft Teams (HTML table)", isActive: teamsActive, onClick: onTeams },
   ];
   return (
     <div className="flex items-center gap-1">
@@ -244,7 +240,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
   const [metricFocus, setMetricFocus] = useState<MetricFocus>("all");
   const [copiedRow, setCopiedRow] = useState<string | null>(null);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [copiedTable, setCopiedTable] = useState<"noFees-sheets" | "noFees-chat" | "noFees-teams" | "agents-sheets" | "agents-chat" | "agents-teams" | null>(null);
+  const [copiedTable, setCopiedTable] = useState<"noFees-sheets" | "noFees-chat" | "agents-sheets" | "agents-chat" | null>(null);
   const tableCopyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => () => {
@@ -271,7 +267,7 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
     });
   };
 
-  const copyNoFeesTable = (format: "sheets" | "chat" | "teams") => {
+  const copyNoFeesTable = (format: "sheets" | "chat") => {
     const header = format === "sheets"
       ? ["Case Name", "Assigned", "Level", "Claim", "Approval", "Days"]
       : ["Case", "Agent", "Level", "Claim", "Approved", "Days"];
@@ -292,18 +288,13 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
       if (tableCopyTimerRef.current) clearTimeout(tableCopyTimerRef.current);
       tableCopyTimerRef.current = setTimeout(() => setCopiedTable(null), 1500);
     };
-    if (format === "teams") {
-      const blob = new Blob([toTeamsHtml("No Fees Cases", header, rows)], { type: "text/html" });
-      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done).catch(console.warn);
-    } else {
-      const text = format === "sheets"
-        ? [header, ...rows].map((r) => r.join("\t")).join("\n")
-        : toChatBlock("No Fees Cases", header, rows);
-      navigator.clipboard.writeText(text).then(done);
-    }
+    const text = format === "sheets"
+      ? [header, ...rows].map((r) => r.join("\t")).join("\n")
+      : toChatBlock("No Fees Cases", header, rows);
+    navigator.clipboard.writeText(text).then(done);
   };
 
-  const copyAgentTable = (format: "sheets" | "chat" | "teams") => {
+  const copyAgentTable = (format: "sheets" | "chat") => {
     const chat = format === "chat";
     const headers: string[] = ["Agent"];
     if (showCol("cases"))       headers.push("Open");
@@ -349,15 +340,10 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
       if (tableCopyTimerRef.current) clearTimeout(tableCopyTimerRef.current);
       tableCopyTimerRef.current = setTimeout(() => setCopiedTable(null), 1500);
     };
-    if (format === "teams") {
-      const blob = new Blob([toTeamsHtml(`Agent Tracking — ${windowLabel}`, headers, [...dataRows, totalsRow])], { type: "text/html" });
-      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done).catch(console.warn);
-    } else {
-      const text = format === "sheets"
-        ? [headers, ...dataRows, totalsRow].map((r) => r.join("\t")).join("\n")
-        : toChatBlock(`Agent Tracking — ${windowLabel}`, headers, [...dataRows, totalsRow]);
-      navigator.clipboard.writeText(text).then(done);
-    }
+    const text = format === "sheets"
+      ? [headers, ...dataRows, totalsRow].map((r) => r.join("\t")).join("\n")
+      : toChatBlock(`Agent Tracking — ${windowLabel}`, headers, [...dataRows, totalsRow]);
+    navigator.clipboard.writeText(text).then(done);
   };
 
   const [dateMode, setDateMode] = useState<DateMode>("day");
@@ -795,10 +781,8 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                 label="No Fees Cases"
                 sheetsActive={copiedTable === "noFees-sheets"}
                 chatActive={copiedTable === "noFees-chat"}
-                teamsActive={copiedTable === "noFees-teams"}
                 onSheets={() => copyNoFeesTable("sheets")}
                 onChat={() => copyNoFeesTable("chat")}
-                onTeams={() => copyNoFeesTable("teams")}
                 dark={dark}
               />
             </div>
@@ -1102,10 +1086,8 @@ export function ScoreboardTracker({ dark, t }: ScoreboardTrackerProps) {
                   label="Agent Tracking"
                   sheetsActive={copiedTable === "agents-sheets"}
                   chatActive={copiedTable === "agents-chat"}
-                  teamsActive={copiedTable === "agents-teams"}
                   onSheets={() => copyAgentTable("sheets")}
                   onChat={() => copyAgentTable("chat")}
-                  onTeams={() => copyAgentTable("teams")}
                   dark={dark}
                 />
               </div>

--- a/src/components/scoreboard/Scoreboard.tsx
+++ b/src/components/scoreboard/Scoreboard.tsx
@@ -2,20 +2,19 @@
 
 import { useState, useReducer, useEffect, useRef } from "react";
 import { useTheme } from "next-themes";
-import { RefreshCw, ChevronLeft, ChevronRight, Upload, Trophy, Clipboard, Check, Table2, MessageSquare, LayoutGrid, type LucideIcon } from "lucide-react";
+import { RefreshCw, ChevronLeft, ChevronRight, Upload, Trophy, Clipboard, Check, Table2, MessageSquare, type LucideIcon } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
 import CsvImportModal, { type ColumnDef } from "@/components/modals/CsvImportModal";
 import { bulkImportDailyMetrics } from "@/app/(dashboard)/scoreboard/actions";
 import { parseDate, parseNonNegativeInt } from "@/lib/import/csv-parser";
 import { teamHeaderBg } from "@/lib/team-colors";
 import { useCapabilities } from "@/hooks/useCapabilities";
-import { getMonday, toChatBlock, toTeamsHtml } from "@/lib/formatters";
+import { getMonday, toChatBlock } from "@/lib/formatters";
 
-type CopyFormat = "sheets" | "chat" | "teams";
+type CopyFormat = "sheets" | "chat";
 const COPY_FORMATS: { format: CopyFormat; Icon: LucideIcon; label: string; ariaLabel: string; title: string }[] = [
   { format: "sheets", Icon: Table2, label: "Sheets", ariaLabel: "Copy scoreboard for Google Sheets", title: "Copy for Google Sheets (tab-separated)" },
   { format: "chat", Icon: MessageSquare, label: "Chat", ariaLabel: "Copy scoreboard for Google Chat", title: "Copy for Google Chat (monospace code block)" },
-  { format: "teams", Icon: LayoutGrid, label: "Teams", ariaLabel: "Copy scoreboard for Microsoft Teams", title: "Copy for Microsoft Teams (HTML table)" },
 ];
 
 type PeriodMode = "week" | "month";
@@ -136,7 +135,7 @@ export const Scoreboard = () => {
   const [csvImportOpen, setCsvImportOpen] = useState(false);
   const [copiedRow, setCopiedRow] = useState<string | null>(null);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [copiedTable, setCopiedTable] = useState<"sheets" | "chat" | "teams" | null>(null);
+  const [copiedTable, setCopiedTable] = useState<CopyFormat | null>(null);
   const tableCopyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [copiedTeam, setCopiedTeam] = useState<{ key: string; format: CopyFormat } | null>(null);
   const teamCopyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -263,11 +262,7 @@ export const Scoreboard = () => {
       tableCopyTimerRef.current = setTimeout(() => setCopiedTable(null), 1500);
     };
 
-    if (format === "teams") {
-      const html = teamBlocks.map(({ teamLabel, header, rows }) => toTeamsHtml(teamLabel, header, rows)).join("");
-      const blob = new Blob([html], { type: "text/html" });
-      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done).catch(console.warn);
-    } else if (format === "sheets") {
+    if (format === "sheets") {
       const lines: string[] = [];
       for (const { teamLabel, header, rows } of teamBlocks) {
         lines.push(teamLabel);
@@ -296,10 +291,7 @@ export const Scoreboard = () => {
       teamCopyTimerRef.current = setTimeout(() => setCopiedTeam(null), 1500);
     };
 
-    if (format === "teams") {
-      const blob = new Blob([toTeamsHtml(teamLabel, header, dataRows)], { type: "text/html" });
-      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done).catch(console.warn);
-    } else if (format === "sheets") {
+    if (format === "sheets") {
       const lines = [teamLabel, header.join("\t"), ...dataRows.map((r) => r.join("\t"))];
       navigator.clipboard.writeText(lines.join("\n")).then(done);
     } else {

--- a/src/components/scoreboard/ScoreboardSummaryCards.tsx
+++ b/src/components/scoreboard/ScoreboardSummaryCards.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { Check, Table2, MessageSquare, LayoutGrid, RefreshCw } from "lucide-react";
+import { Check, Table2, MessageSquare, RefreshCw } from "lucide-react";
 import { themeClasses } from "@/lib/theme-classes";
-import { fmt, toChatBlock, toTeamsHtml } from "@/lib/formatters";
+import { fmt, toChatBlock } from "@/lib/formatters";
 import { teamCardClasses, teamAccentText, teamLabel } from "@/lib/team-colors";
 
 export interface ScoreboardSummary {
@@ -96,7 +96,7 @@ export function ScoreboardSummaryCards({
   const [t2Days, setT2Days] = useState<60 | 90>(60);
   const [t16Days, setT16Days] = useState<60 | 90>(60);
   const [concDays, setConcDays] = useState<60 | 90>(60);
-  const [byTeamCopied, setByTeamCopied] = useState<"sheets" | "chat" | "teams" | null>(null);
+  const [byTeamCopied, setByTeamCopied] = useState<"sheets" | "chat" | null>(null);
   const byTeamCopyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => () => {
@@ -115,7 +115,7 @@ export function ScoreboardSummaryCards({
       }[windowMode]
     : "Fees";
 
-  const copyByTeam = (format: "sheets" | "chat" | "teams") => {
+  const copyByTeam = (format: "sheets" | "chat") => {
     const feeCol = format === "sheets" ? feesLabel : "Collected";
     const header = format === "sheets"
       ? ["Team", "Agents", feeCol, "SSA Calls", "CL Calls", "Win Sheets", "Cases Closed", "Open Cases"]
@@ -138,15 +138,10 @@ export function ScoreboardSummaryCards({
       if (byTeamCopyTimerRef.current) clearTimeout(byTeamCopyTimerRef.current);
       byTeamCopyTimerRef.current = setTimeout(() => setByTeamCopied(null), 1500);
     };
-    if (format === "teams") {
-      const blob = new Blob([toTeamsHtml(`By Team — ${label}`, header, rows)], { type: "text/html" });
-      navigator.clipboard.write([new ClipboardItem({ "text/html": blob })]).then(done).catch(console.warn);
-    } else {
-      const text = format === "sheets"
-        ? [header, ...rows].map((r) => r.join("\t")).join("\n")
-        : toChatBlock(`By Team — ${label}`, header, rows);
-      navigator.clipboard.writeText(text).then(done);
-    }
+    const text = format === "sheets"
+      ? [header, ...rows].map((r) => r.join("\t")).join("\n")
+      : toChatBlock(`By Team — ${label}`, header, rows);
+    navigator.clipboard.writeText(text).then(done);
   };
 
   // Quiet per-metric accent (border + tint) on the plain cards — not used on
@@ -297,17 +292,6 @@ export function ScoreboardSummaryCards({
                 {byTeamCopied === "chat"
                   ? <><Check aria-hidden="true" className="h-3 w-3" />Copied</>
                   : <><MessageSquare aria-hidden="true" className="h-3 w-3" />Chat</>
-                }
-              </button>
-              <button
-                onClick={() => copyByTeam("teams")}
-                aria-label="Copy By Team for Microsoft Teams"
-                title="Copy for Microsoft Teams (HTML table)"
-                className={`flex items-center gap-1 px-2 py-1 rounded-md text-[12px] font-medium border transition-colors ${byTeamCopied === "teams" ? (dark ? "border-emerald-700 text-emerald-400" : "border-emerald-300 text-emerald-600") : (dark ? "border-neutral-700 text-neutral-400 hover:bg-neutral-800" : "border-neutral-200 text-neutral-500 hover:bg-neutral-50")}`}
-              >
-                {byTeamCopied === "teams"
-                  ? <><Check aria-hidden="true" className="h-3 w-3" />Copied</>
-                  : <><LayoutGrid aria-hidden="true" className="h-3 w-3" />Teams</>
                 }
               </button>
             </div>

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -111,32 +111,6 @@ export const fmtDateLong = (iso: string | null | undefined): string => {
   return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
 };
 
-// MS Teams pastes rich text from clipboard — an HTML table renders with visible borders and alignment.
-export const toTeamsHtml = (
-  title: string,
-  headers: string[],
-  rows: (string | number)[][],
-): string => {
-  const esc = (s: string) =>
-    s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-  const th = `padding:4px 8px;border:1px solid #d0d0d0;background:#f5f5f5;font-weight:600;text-align:left`;
-  const td = `padding:4px 8px;border:1px solid #d0d0d0`;
-  const headRow = headers.map((h) => `<th style="${th}">${esc(h)}</th>`).join("");
-  const bodyRows = rows
-    .map(
-      (r) =>
-        `<tr>${headers.map((_, ci) => `<td style="${td}">${esc(String(r[ci] ?? ""))}</td>`).join("")}</tr>`,
-    )
-    .join("");
-  return (
-    `<p><strong>${esc(title)}</strong></p>` +
-    `<table style="border-collapse:collapse">` +
-    `<thead><tr>${headRow}</tr></thead>` +
-    `<tbody>${bodyRows}</tbody>` +
-    `</table>`
-  );
-};
-
 // Google Chat renders ``` blocks in a fixed-width font — padding aligns columns.
 export const toChatBlock = (
   title: string,


### PR DESCRIPTION
Syncs all changes from develop into main.

## Changes included (since last sync)
- Fix: Notifications copy (Follow-Ups, Closed Cases, Fee Petitions Approved, Payments, New Cases) now only copies the summary figures, not the per-case detail list bundled in alongside it; Microsoft Teams copy format removed everywhere (Notifications, Scoreboard, Reports) since it's no longer in use (#437, closes #436)

Audited: lint clean, 158/158 tests passing, build clean. No schema/migration changes, no new mutations, no PII exposure. Verified live in the browser across all three affected pages.